### PR TITLE
Fix AI engine retrieval key

### DIFF
--- a/Audio Journal/Audio Journal/EnhancedSummaryDetailView.swift
+++ b/Audio Journal/Audio Journal/EnhancedSummaryDetailView.swift
@@ -329,7 +329,8 @@ struct EnhancedSummaryDetailView: View {
             }
             
             // Set the current AI engine
-            summaryManager.setEngine(UserDefaults.standard.string(forKey: "selectedAIEngine") ?? "OpenAI")
+            // Use the same key used when saving the selected AI engine
+            summaryManager.setEngine(UserDefaults.standard.string(forKey: "SelectedAIEngine") ?? "OpenAI")
             
             // Generate new enhanced summary
             _ = try await summaryManager.generateEnhancedSummary(

--- a/Audio Journal/Audio Journal/SummaryDetailView.swift
+++ b/Audio Journal/Audio Journal/SummaryDetailView.swift
@@ -314,7 +314,8 @@ struct SummaryDetailView: View {
             }
             
             // Set the current AI engine
-            summaryManager.setEngine(UserDefaults.standard.string(forKey: "selectedAIEngine") ?? "OpenAI")
+            // Use the correct key when retrieving the selected AI engine
+            summaryManager.setEngine(UserDefaults.standard.string(forKey: "SelectedAIEngine") ?? "OpenAI")
             
             // Generate new enhanced summary
             _ = try await summaryManager.generateEnhancedSummary(


### PR DESCRIPTION
## Summary
- fetch selected AI engine from the correct `UserDefaults` key in the summary views

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6886c74633b4833196641ac5b47fa809