### PR TITLE
Fix chunk overlap default

### DIFF
--- a/Audio Journal/Audio Journal/EnhancedTranscriptionManager.swift
+++ b/Audio Journal/Audio Journal/EnhancedTranscriptionManager.swift
@@ -82,7 +82,7 @@ class EnhancedTranscriptionManager: NSObject, ObservableObject {
     }
     
     private var chunkOverlap: TimeInterval {
-        UserDefaults.standard.double(forKey: "chunkOverlap").nonZero ?? 30.0 // 30 second overlap between chunks
+        UserDefaults.standard.double(forKey: "chunkOverlap").nonZero ?? 2.0 // 2 second overlap between chunks
     }
     
     private var enableAWSTranscribe: Bool {


### PR DESCRIPTION
## Summary
- default chunk overlap to 2 seconds in EnhancedTranscriptionManager

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6886cbb67fb88331b00dd023b338b166