### PR TITLE
Use Ollama for meta summary and respect context limits

### DIFF
--- a/Audio Journal/Audio Journal/EnhancedAppleIntelligenceEngine.swift
+++ b/Audio Journal/Audio Journal/EnhancedAppleIntelligenceEngine.swift
@@ -242,6 +242,10 @@ class EnhancedAppleIntelligenceEngine: SummarizationEngine {
     
     private func processChunkedText(_ text: String) async throws -> (summary: String, tasks: [TaskItem], reminders: [ReminderItem], titles: [TitleItem], contentType: ContentType) {
         let startTime = Date()
+
+        // Initialize Ollama service for meta-summary generation
+        let ollamaService = OllamaService()
+        _ = await ollamaService.testConnection()
         
         // Split text into chunks
         let chunks = TokenManager.chunkText(text)
@@ -282,8 +286,12 @@ class EnhancedAppleIntelligenceEngine: SummarizationEngine {
             }
         }
         
-        // Combine results
-        let combinedSummary = TokenManager.combineSummaries(allSummaries, contentType: contentType)
+        // Combine results using AI-generated meta-summary
+        let combinedSummary = try await TokenManager.combineSummaries(
+            allSummaries,
+            contentType: contentType,
+            service: ollamaService
+        )
         
         // Deduplicate tasks, reminders, and titles
         let uniqueTasks = deduplicateTasks(allTasks)

--- a/Audio Journal/Audio Journal/FutureAIEngines.swift
+++ b/Audio Journal/Audio Journal/FutureAIEngines.swift
@@ -486,8 +486,12 @@ class LocalLLMEngine: SummarizationEngine, ConnectionTestable {
             }
         }
         
-        // Combine results
-        let combinedSummary = TokenManager.combineSummaries(allSummaries, contentType: contentType)
+        // Combine results using AI-generated meta-summary
+        let combinedSummary = try await TokenManager.combineSummaries(
+            allSummaries,
+            contentType: contentType,
+            service: service
+        )
         
         // Deduplicate tasks, reminders, and titles
         let uniqueTasks = deduplicateTasks(allTasks)

--- a/Audio Journal/Audio Journal/OllamaService.swift
+++ b/Audio Journal/Audio Journal/OllamaService.swift
@@ -82,10 +82,13 @@ struct OllamaGenerateResponse: Codable {
 class OllamaService: ObservableObject {
     private let config: OllamaConfig
     private let session: URLSession
-    
+
     @Published var isConnected: Bool = false
     @Published var availableModels: [OllamaModel] = []
     @Published var connectionError: String?
+
+    /// Maximum context tokens supported by the configured model
+    var maxContextTokens: Int { config.maxContextTokens }
     
     init(config: OllamaConfig = .default) {
         self.config = config

--- a/Audio Journal/Audio Journal/OpenAISummarizationEngine.swift
+++ b/Audio Journal/Audio Journal/OpenAISummarizationEngine.swift
@@ -224,6 +224,10 @@ class OpenAISummarizationEngine: SummarizationEngine, ConnectionTestable {
     
     private func processChunkedText(_ text: String, service: OpenAISummarizationService) async throws -> (summary: String, tasks: [TaskItem], reminders: [ReminderItem], titles: [TitleItem], contentType: ContentType) {
         let startTime = Date()
+
+        // Initialize Ollama service for meta-summary generation
+        let ollamaService = OllamaService()
+        _ = await ollamaService.testConnection()
         
         // Split text into chunks
         let chunks = TokenManager.chunkText(text)
@@ -257,8 +261,12 @@ class OpenAISummarizationEngine: SummarizationEngine, ConnectionTestable {
             }
         }
         
-        // Combine results
-        let combinedSummary = TokenManager.combineSummaries(allSummaries, contentType: contentType)
+        // Combine results using AI-generated meta-summary
+        let combinedSummary = try await TokenManager.combineSummaries(
+            allSummaries,
+            contentType: contentType,
+            service: ollamaService
+        )
         
         // Deduplicate tasks, reminders, and titles
         let uniqueTasks = deduplicateTasks(allTasks)

--- a/Audio Journal/Audio Journal/PerformanceOptimizer.swift
+++ b/Audio Journal/Audio Journal/PerformanceOptimizer.swift
@@ -453,12 +453,16 @@ class PerformanceOptimizer: ObservableObject, Sendable {
         let chunks = text.chunked(into: optimalChunkSize)
         
         logger.info("Split transcript into \(chunks.count) chunks of ~\(optimalChunkSize) bytes each")
-        
+
         var summaryParts: [String] = []
         var allTasks: [TaskItem] = []
         var allReminders: [ReminderItem] = []
         var allTitles: [TitleItem] = []
         var contentTypes: [ContentType] = []
+
+        // Initialize Ollama service for meta-summary generation
+        let ollamaService = OllamaService()
+        _ = await ollamaService.testConnection()
         
         for (index, chunk) in chunks.enumerated() {
             processingProgress = Double(index) / Double(chunks.count) * 0.8 // 80% for chunk processing
@@ -490,8 +494,12 @@ class PerformanceOptimizer: ObservableObject, Sendable {
         
         processingProgress = 0.9 // 90% - consolidating results
         
-        // Consolidate results using TokenManager
-        let finalSummary = TokenManager.combineSummaries(summaryParts, contentType: determinePrimaryContentType(contentTypes))
+        // Consolidate results using TokenManager with AI-generated meta-summary
+        let finalSummary = try await TokenManager.combineSummaries(
+            summaryParts,
+            contentType: determinePrimaryContentType(contentTypes),
+            service: ollamaService
+        )
         let finalTasks = deduplicateAndLimitTasks(allTasks, limit: 15)
         let finalReminders = deduplicateAndLimitReminders(allReminders, limit: 15)
         let finalContentType = determinePrimaryContentType(contentTypes)
@@ -598,6 +606,10 @@ class PerformanceOptimizer: ObservableObject, Sendable {
         var allTitles: [TitleItem] = []
         var summaryParts: [String] = []
         var contentTypes: [ContentType] = []
+
+        // Initialize Ollama service for meta-summary generation
+        let ollamaService = OllamaService()
+        _ = await ollamaService.testConnection()
         
         for (index, chunk) in chunks.enumerated() {
             processingProgress = Double(index) / Double(chunks.count) * 0.8 // 80% for chunk processing
@@ -624,8 +636,12 @@ class PerformanceOptimizer: ObservableObject, Sendable {
         
         processingProgress = 0.9 // 90% - consolidating results
         
-        // Consolidate results using TokenManager
-        let finalSummary = TokenManager.combineSummaries(summaryParts, contentType: determinePrimaryContentType(contentTypes))
+        // Consolidate results using TokenManager with AI-generated meta-summary
+        let finalSummary = try await TokenManager.combineSummaries(
+            summaryParts,
+            contentType: determinePrimaryContentType(contentTypes),
+            service: ollamaService
+        )
         let finalTasks = deduplicateAndLimitTasks(allTasks, limit: 15)
         let finalReminders = deduplicateAndLimitReminders(allReminders, limit: 15)
         let finalContentType = determinePrimaryContentType(contentTypes)


### PR DESCRIPTION
## Summary
- Replace simple concatenation with Ollama-powered meta-summary in `TokenManager.combineSummaries`
- Expose `maxContextTokens` in `OllamaService` and chunk combined summaries when necessary
- Update chunked processing paths to generate AI meta-summaries and keep tasks, reminders, and titles deduplicated

## Testing
- `xcodebuild -project "Audio Journal.xcodeproj" -scheme "Audio Journal" -sdk iphonesimulator -configuration Debug build` *(command not found)*
- `swift build` *(no Package.swift present)*

------
https://chatgpt.com/codex/tasks/task_e_688e234204a083319d404ac07c32e5c6