### PR TITLE
Show summarization jobs in background panel

### DIFF
--- a/BisonNotes AI/BisonNotes AI/BackgroundProcessingManager.swift
+++ b/BisonNotes AI/BisonNotes AI/BackgroundProcessingManager.swift
@@ -323,7 +323,17 @@ class BackgroundProcessingManager: ObservableObject {
             job.status == .completed || job.status.isError
         }
     }
-    
+
+    // MARK: - External Job Tracking
+
+    func trackExternalJob(_ job: ProcessingJob) async {
+        await addJob(job)
+    }
+
+    func updateExternalJob(_ job: ProcessingJob) async {
+        await updateJob(job)
+    }
+
     // MARK: - Helper Methods
     
     private func getEngineString(from jobType: JobType) -> String {


### PR DESCRIPTION
## Summary
- track external jobs in `BackgroundProcessingManager` to allow manual job reporting
- register and update summarization tasks as background jobs in `SummariesView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688e5a2716c4833183fb70ee540b964d