### PR TITLE
Use EnhancedTranscriptionManager for AWS transcription

### DIFF
--- a/BisonNotes AI/BisonNotes AI/BackgroundProcessingManager.swift
+++ b/BisonNotes AI/BisonNotes AI/BackgroundProcessingManager.swift
@@ -668,12 +668,14 @@ class BackgroundProcessingManager: ObservableObject {
             let config = getWhisperConfig()
             let service = WhisperService(config: config, chunkingService: chunkingService)
             return try await service.transcribeAudio(url: chunk.chunkURL, recordingId: recordingId)
-            
+
         case .awsTranscribe:
-            // AWS Transcribe works differently - it's async, so we need to adapt it
-            // For now, throw an error indicating it needs special handling
-            throw BackgroundProcessingError.processingFailed("AWS Transcribe requires async job handling - use EnhancedTranscriptionManager instead")
-            
+            // AWS Transcribe requires asynchronous job handling. Use the
+            // EnhancedTranscriptionManager which manages the lifecycle of AWS
+            // transcription jobs and polling for results.
+            let manager = EnhancedTranscriptionManager()
+            return try await manager.transcribeAudioFile(at: chunk.chunkURL, using: .awsTranscribe)
+
         case .appleIntelligence:
             // Apple Intelligence uses Speech framework which has different limits
             // Use the EnhancedTranscriptionManager for proper handling


### PR DESCRIPTION
## Summary
- route AWS Transcribe requests through EnhancedTranscriptionManager for proper async job handling

## Testing
- `swiftc -typecheck 'BisonNotes AI/BisonNotes AI/BackgroundProcessingManager.swift'` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_688e5cab02dc83319f2358280567bff3