### PR TITLE
Implement batch iCloud sync and CloudKit deletion

### DIFF
--- a/BisonNotes AI/BisonNotes AI/Models/AppDataCoordinator.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/AppDataCoordinator.swift
@@ -127,9 +127,8 @@ class AppDataCoordinator: ObservableObject {
 
     func deleteSummary(id: UUID) async throws {
         try coreDataManager.deleteSummary(id: id)
-        do {
-            try await SummaryManager.shared.getiCloudManager().deleteSummaryFromiCloud(id)
-        } catch {
+        try await SummaryManager.shared.getiCloudManager().deleteSummaryFromiCloud(id)
+    }
             print("⚠️ Failed to delete summary from iCloud: \(error)")
         }
     }

--- a/BisonNotes AI/BisonNotes AI/Models/AppDataCoordinator.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/AppDataCoordinator.swift
@@ -124,7 +124,16 @@ class AppDataCoordinator: ObservableObject {
     func deleteRecording(id: UUID) {
         coreDataManager.deleteRecording(id: id)
     }
-    
+
+    func deleteSummary(id: UUID) async throws {
+        try coreDataManager.deleteSummary(id: id)
+        do {
+            try await SummaryManager.shared.getiCloudManager().deleteSummaryFromiCloud(id)
+        } catch {
+            print("⚠️ Failed to delete summary from iCloud: \(error)")
+        }
+    }
+
     func updateRecordingName(recordingId: UUID, newName: String) {
         workflowManager.updateRecordingName(recordingId: recordingId, newName: newName)
     }

--- a/BisonNotes AI/BisonNotes AI/Models/AppDataCoordinator.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/AppDataCoordinator.swift
@@ -127,9 +127,12 @@ class AppDataCoordinator: ObservableObject {
 
     func deleteSummary(id: UUID) async throws {
         try coreDataManager.deleteSummary(id: id)
-        try await SummaryManager.shared.getiCloudManager().deleteSummaryFromiCloud(id)
-    }
+        do {
+            try await SummaryManager.shared.getiCloudManager().deleteSummaryFromiCloud(id)
+        } catch {
             print("⚠️ Failed to delete summary from iCloud: \(error)")
+            // Re-throw the error so caller can handle the partial failure
+            throw error
         }
     }
 

--- a/BisonNotes AI/BisonNotes AI/SummariesView.swift
+++ b/BisonNotes AI/BisonNotes AI/SummariesView.swift
@@ -503,9 +503,7 @@ struct SummariesView: View {
     
     private func syncAllSummaries() async {
         do {
-            // TODO: Implement iCloud sync with new Core Data system
-            let allSummaries: [EnhancedSummaryData] = [] // Placeholder
-            try await iCloudManager.performBidirectionalSync(localSummaries: allSummaries)
+            try await iCloudManager.syncAllSummaries()
         } catch {
             print("❌ Sync error: \(error)")
             await MainActor.run {

--- a/BisonNotes AI/BisonNotes AI/SummaryRegenerationManager.swift
+++ b/BisonNotes AI/BisonNotes AI/SummaryRegenerationManager.swift
@@ -78,8 +78,8 @@ class SummaryRegenerationManager: ObservableObject {
                     recordingDate: summary.recordingDate
                 )
                 
-                // Delete the old summary from Core Data
-                try appCoordinator.coreDataManager.deleteSummary(id: summary.id)
+                // Delete the old summary from Core Data and iCloud
+                try await appCoordinator.deleteSummary(id: summary.id)
                 
                 // Debug: Show what names we're comparing (bulk regeneration)
                 print("🔍 Bulk regeneration name check for '\(summary.recordingName)':")
@@ -165,8 +165,8 @@ class SummaryRegenerationManager: ObservableObject {
                 recordingDate: summary.recordingDate
             )
             
-            // Delete the old summary from Core Data
-            try appCoordinator.coreDataManager.deleteSummary(id: summary.id)
+            // Delete the old summary from Core Data and iCloud
+            try await appCoordinator.deleteSummary(id: summary.id)
             print("🗑️ Deleted old summary with ID: \(summary.id)")
             
             // Debug: Show what names we're comparing

--- a/BisonNotes AI/BisonNotes AI/Views/DataMigrationView.swift
+++ b/BisonNotes AI/BisonNotes AI/Views/DataMigrationView.swift
@@ -778,7 +778,7 @@ struct DataMigrationView: View {
                 
                 // Delete the orphaned summary
                 do {
-                    try appCoordinator.coreDataManager.deleteSummary(id: summary.id)
+                    try await appCoordinator.deleteSummary(id: summary.id)
                     orphanedSummaries += 1
                 } catch {
                     print("❌ Failed to delete orphaned summary: \(error)")

--- a/BisonNotes AI/BisonNotes AI/Views/SettingsView.swift
+++ b/BisonNotes AI/BisonNotes AI/Views/SettingsView.swift
@@ -753,9 +753,7 @@ struct SettingsView: View {
     
     private func syncAllSummaries() async {
         do {
-            // TODO: Implement iCloud sync with new Core Data system
-            let allSummaries: [EnhancedSummaryData] = [] // Placeholder
-            try await iCloudManager.performBidirectionalSync(localSummaries: allSummaries)
+            try await iCloudManager.syncAllSummaries()
         } catch {
             print("❌ Sync error: \(error)")
             await MainActor.run {

--- a/BisonNotes AI/BisonNotes AI/iCloudStorageManager.swift
+++ b/BisonNotes AI/BisonNotes AI/iCloudStorageManager.swift
@@ -414,10 +414,12 @@ class iCloudStorageManager: ObservableObject {
 
     /// Convenience wrapper that loads all locally stored summaries and syncs them
     func syncAllSummaries() async throws {
+    /// Convenience wrapper that loads all locally stored summaries and syncs them
+    func syncAllSummaries() async throws {
         // Load summaries from the local store
-        let summaryManager = SummaryManager()
-        let allSummaries = summaryManager.enhancedSummaries
+        let allSummaries = SummaryManager.shared.enhancedSummaries
         try await syncAllSummaries(allSummaries)
+    }
     }
     
     func deleteSummaryFromiCloud(_ summaryId: UUID) async throws {

--- a/BisonNotes AI/BisonNotes AI/iCloudStorageManager.swift
+++ b/BisonNotes AI/BisonNotes AI/iCloudStorageManager.swift
@@ -414,12 +414,9 @@ class iCloudStorageManager: ObservableObject {
 
     /// Convenience wrapper that loads all locally stored summaries and syncs them
     func syncAllSummaries() async throws {
-    /// Convenience wrapper that loads all locally stored summaries and syncs them
-    func syncAllSummaries() async throws {
         // Load summaries from the local store
         let allSummaries = SummaryManager.shared.enhancedSummaries
         try await syncAllSummaries(allSummaries)
-    }
     }
     
     func deleteSummaryFromiCloud(_ summaryId: UUID) async throws {

--- a/BisonNotes AI/BisonNotes AI/iCloudStorageManager.swift
+++ b/BisonNotes AI/BisonNotes AI/iCloudStorageManager.swift
@@ -374,17 +374,17 @@ class iCloudStorageManager: ObservableObject {
             print("⚠️ iCloud sync is disabled, skipping batch sync")
             return
         }
-        
+
         await updateSyncStatus(.syncing)
         await MainActor.run {
             self.pendingSyncCount = summaries.count
         }
-        
+
         print("🔄 Starting batch sync of \(summaries.count) summaries...")
-        
+
         var syncedCount = 0
         var failedCount = 0
-        
+
         for summary in summaries {
             do {
                 try await syncSummary(summary)
@@ -393,12 +393,12 @@ class iCloudStorageManager: ObservableObject {
                 print("❌ Failed to sync summary \(summary.recordingName): \(error)")
                 failedCount += 1
             }
-            
+
             await MainActor.run {
                 self.pendingSyncCount = summaries.count - syncedCount - failedCount
             }
         }
-        
+
         if failedCount == 0 {
             await updateSyncStatus(.completed)
             print("✅ Successfully synced all \(syncedCount) summaries")
@@ -406,10 +406,18 @@ class iCloudStorageManager: ObservableObject {
             await updateSyncStatus(.failed("Synced \(syncedCount), failed \(failedCount)"))
             print("⚠️ Batch sync completed with errors: \(syncedCount) synced, \(failedCount) failed")
         }
-        
+
         await MainActor.run {
             self.pendingSyncCount = 0
         }
+    }
+
+    /// Convenience wrapper that loads all locally stored summaries and syncs them
+    func syncAllSummaries() async throws {
+        // Load summaries from the local store
+        let summaryManager = SummaryManager()
+        let allSummaries = summaryManager.enhancedSummaries
+        try await syncAllSummaries(allSummaries)
     }
     
     func deleteSummaryFromiCloud(_ summaryId: UUID) async throws {
@@ -771,7 +779,7 @@ class iCloudStorageManager: ObservableObject {
             try await syncSummariesInBatches(batchSize: batchSize)
         } else {
             // Use standard sync
-            try await syncAllSummaries([]) // Pass empty array for now
+            try await syncAllSummaries()
         }
     }
     
@@ -781,7 +789,7 @@ class iCloudStorageManager: ObservableObject {
         
         // This would implement batch processing for network efficiency
         // For now, just call the standard sync
-        try await syncAllSummaries([]) // Pass empty array for now
+        try await syncAllSummaries()
     }
     
 


### PR DESCRIPTION
## Summary
- add `syncAllSummaries()` wrapper in iCloudStorageManager to load and sync existing summaries
- route battery and batch sync paths through new summary loader
- call new sync method from SummariesView and SettingsView
- remove summaries from CloudKit when deleted locally to keep stores consistent

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_689e854950808331a2f0b7b5119e77e2