### PR TITLE
feat: add small circular watch complication

### DIFF
--- a/BisonNotes AI/BisonNotes AI Watch App/BisonNotes_AI_Watch_AppApp.swift
+++ b/BisonNotes AI/BisonNotes AI Watch App/BisonNotes_AI_Watch_AppApp.swift
@@ -13,8 +13,9 @@ struct BisonNotes_AI_Watch_App_Watch_AppApp: App {
         WindowGroup {
             ContentView()
                 .onOpenURL { _ in
-                    // Handles launch from complication
+                .onOpenURL { url in
+                    // Handle the URL, e.g., log the event
+                    print("Launched from complication with URL: \(url.absoluteString)")
                 }
-        }
     }
 }

--- a/BisonNotes AI/BisonNotes AI Watch App/BisonNotes_AI_Watch_AppApp.swift
+++ b/BisonNotes AI/BisonNotes AI Watch App/BisonNotes_AI_Watch_AppApp.swift
@@ -12,6 +12,9 @@ struct BisonNotes_AI_Watch_App_Watch_AppApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .onOpenURL { _ in
+                    // Handles launch from complication
+                }
         }
     }
 }

--- a/BisonNotes AI/BisonNotes AI Watch Complication/BisonNotesComplication.swift
+++ b/BisonNotes AI/BisonNotes AI Watch Complication/BisonNotesComplication.swift
@@ -1,0 +1,46 @@
+import WidgetKit
+import SwiftUI
+
+struct BisonNotesComplicationEntry: TimelineEntry {
+    let date: Date
+}
+
+struct BisonNotesComplicationProvider: TimelineProvider {
+    func placeholder(in context: Context) -> BisonNotesComplicationEntry {
+        BisonNotesComplicationEntry(date: Date())
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (BisonNotesComplicationEntry) -> Void) {
+        let entry = BisonNotesComplicationEntry(date: Date())
+        completion(entry)
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<BisonNotesComplicationEntry>) -> Void) {
+        let entry = BisonNotesComplicationEntry(date: Date())
+        let timeline = Timeline(entries: [entry], policy: .never)
+        completion(timeline)
+    }
+}
+
+struct BisonNotesComplicationEntryView: View {
+    var entry: BisonNotesComplicationProvider.Entry
+
+    var body: some View {
+        Image(systemName: "pencil")
+            .widgetURL(URL(string: "bisonnotes://complication"))
+    }
+}
+
+@main
+struct BisonNotesComplication: Widget {
+    let kind: String = "BisonNotesComplication"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: BisonNotesComplicationProvider()) { entry in
+            BisonNotesComplicationEntryView(entry: entry)
+        }
+        .configurationDisplayName("BisonNotes")
+        .description("Open BisonNotes quickly from your watch.")
+        .supportedFamilies([.accessoryCircular])
+    }
+}

--- a/BisonNotes AI/BisonNotes AI Watch Complication/BisonNotesComplication.swift
+++ b/BisonNotes AI/BisonNotes AI Watch Complication/BisonNotesComplication.swift
@@ -31,8 +31,14 @@ struct BisonNotesComplicationEntryView: View {
     }
 }
 
-@main
-struct BisonNotesComplication: Widget {
+    private enum Constants {
+        static let complicationURL = "bisonnotes://complication"
+    }
+
+    var body: some View {
+        Image(systemName: "pencil")
+            .widgetURL(URL(string: Constants.complicationURL))
+    }
     let kind: String = "BisonNotesComplication"
 
     var body: some WidgetConfiguration {


### PR DESCRIPTION
## Summary
- add WidgetKit complication that launches the watch app
- handle complication URL in watch app

## Testing
- `xcodebuild test -project "BisonNotes AI/BisonNotes AI.xcodeproj" -scheme "BisonNotes AI" -destination 'platform=iOS Simulator,name=iPhone 15'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b8988e308331881f6315d5862509