### PR TITLE
fix: update location permission alert wording

### DIFF
--- a/BisonNotes AI/BisonNotes AI/ContentView.swift
+++ b/BisonNotes AI/BisonNotes AI/ContentView.swift
@@ -67,14 +67,11 @@ struct ContentView: View {
                         .tag(3)
                 }
                 .alert("Enable Location Services", isPresented: $showingLocationPermission) {
-                    Button("Enable") {
+                    Button("Continue") {
                         recorderVM.locationManager.requestLocationPermission()
                     }
-                    Button("Skip") {
-                        // Do nothing, just dismiss
-                    }
                 } message: {
-                    Text("Location services help add context to your recordings by capturing where they were made. This can be useful for organizing and remembering your audio notes.")
+                    Text("We use your location to log where each recording happens, helping you organize and revisit your audio notes with helpful context.")
                 }
             }
         } else {


### PR DESCRIPTION
## Summary
- update the location permission alert to use a Continue action and remove the skip option per App Store guidance
- clarify the pre-permission message so users understand the request supports logging locations with recordings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd68d9957483319cef6a65c1e74a3c