### PR TITLE
fix: update app shortcuts registration

### DIFF
--- a/BisonNotes AI/BisonNotes AI/BisonNotesAIApp.swift
+++ b/BisonNotes AI/BisonNotes AI/BisonNotesAIApp.swift
@@ -150,7 +150,9 @@ struct BisonNotesAIApp: App {
     
     private func setupAppShortcuts() {
         // Update app shortcuts to include our recording intent
-        AppShortcutsProvider.updateAppShortcutParameters()
+        Task {
+            await AppShortcuts.updateAppShortcutParameters()
+        }
         print("📱 App shortcuts configured for Action Button support")
     }
 }


### PR DESCRIPTION
## Summary
- call AppShortcuts.updateAppShortcutParameters() from setupAppShortcuts()
- wrap the update call in Task to satisfy the async API contract

## Testing
- xcodebuild -project "BisonNotes AI/BisonNotes AI.xcodeproj" -scheme "BisonNotes AI" -configuration Debug build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cef7ee61d08331b501eedec08200ab