### PR TITLE
Update UI labels: 'Audio Recordings' → 'Audio Transcripts' in TranscriptViews

### DIFF
--- a/BisonNotes AI/BisonNotes AI/Views/TranscriptViews.swift
+++ b/BisonNotes AI/BisonNotes AI/Views/TranscriptViews.swift
@@ -257,7 +257,7 @@ struct TranscriptsView: View {
         return List {
             // Audio Recordings with Transcripts
             if !filtered.isEmpty {
-                Section(header: Text("Audio Recordings")) {
+                Section(header: Text("Audio Transcripts")) {
                     // Show first 3 items with their section headers
                     ForEach(recentRecordings, id: \.recording.id) { recordingData in
                         recordingRowView(recordingData)
@@ -323,7 +323,7 @@ struct TranscriptsView: View {
                 }
             }
         }
-        .navigationTitle("Audio Recordings")
+        .navigationTitle("Audio Transcripts")
     }
 
     private var importedTranscriptsFullListView: some View {


### PR DESCRIPTION
### Motivation
- Use clearer wording in the transcripts UI so the section refers to transcript content rather than raw audio files.

### Description
- Replace the section header and the full-list navigation title in `BisonNotes AI/BisonNotes AI/Views/TranscriptViews.swift` from `"Audio Recordings"` to `"Audio Transcripts"`.

### Testing
- Verified the change by inspecting the file diff and running `rg -n "Audio Transcripts" "BisonNotes AI/BisonNotes AI/Views/TranscriptViews.swift"`, which returned the two updated locations and confirmed only the intended UI strings were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a315a44c8331bc609289ca40c26e)