### PR TITLE
Improve Processing Method section outline visibility

### DIFF
--- a/BisonNotes AI/BisonNotes AI/Views/SimpleSettingsView.swift
+++ b/BisonNotes AI/BisonNotes AI/Views/SimpleSettingsView.swift
@@ -287,7 +287,7 @@ struct SimpleSettingsView: View {
                 .shadow(color: Color.black.opacity(0.05), radius: 2, x: 0, y: 1)
                 .overlay(
                     RoundedRectangle(cornerRadius: 12)
-                        .stroke(Color(.systemGray4), lineWidth: 0.5)
+                        .stroke(Color.blue, lineWidth: 1)
                 )
         )
     }


### PR DESCRIPTION
### Motivation
- The "Processing Method" card used a faint gray border that can blend into dark backgrounds, so it should match the stronger visual outlines used by the other setup sections for better contrast.

### Description
- Updated the Processing Method container in `SimpleSettingsView.swift` to use `.stroke(Color.blue, lineWidth: 1)` instead of `.stroke(Color(.systemGray4), lineWidth: 0.5)` to increase outline visibility.

### Testing
- Verified the change via `git diff` and confirmed the file was staged/committed with `git status --short`; both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a3cc82488331b61f3c14a2bba9d8)