### PR TITLE
Rename setup page link to "Additional Settings"

### DIFF
--- a/BisonNotes AI/BisonNotes AI/Views/SimpleSettingsView.swift
+++ b/BisonNotes AI/BisonNotes AI/Views/SimpleSettingsView.swift
@@ -193,7 +193,7 @@ struct SimpleSettingsView: View {
                 
                 Spacer()
                 
-                Button("Advanced Options") {
+                Button("Additional Settings") {
                     showingAdvancedSettings = true
                 }
                 .font(.caption)


### PR DESCRIPTION
### Motivation
- The header link labeled `Advanced Options` on the primary setup screen should use the wording `Additional Settings` to match the requested terminology and improve clarity.

### Description
- Updated the label in `BisonNotes AI/BisonNotes AI/Views/SimpleSettingsView.swift` by replacing `Button("Advanced Options")` with `Button("Additional Settings")` while preserving the existing behavior.

### Testing
- No automated tests were run since this is a text-only UI label update; local inspection verified the string change in `SimpleSettingsView.swift`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a43746f08331acc09fcc7d0b1e14)