### PR TITLE
Update Additional Settings page subtitle text

### DIFF
--- a/BisonNotes AI/BisonNotes AI/Views/SettingsView.swift
+++ b/BisonNotes AI/BisonNotes AI/Views/SettingsView.swift
@@ -138,7 +138,7 @@ struct SettingsView: View {
             .padding(.top, 20)
             .padding(.horizontal, 24)
             
-            Text("Advanced settings for comprehensive configuration")
+            Text("Additional settings for comprehensive configuration")
                 .font(.subheadline)
                 .foregroundColor(.secondary)
                 .padding(.horizontal, 24)


### PR DESCRIPTION
### Motivation
- Fix a copy issue where the Additional Settings page subtitle incorrectly read "Advanced settings for comprehensive configuration" and should read "Additional settings for comprehensive configuration".

### Description
- Replaced the subtitle string in `BisonNotes AI/BisonNotes AI/Views/SettingsView.swift` so the `Text` now reads `"Additional settings for comprehensive configuration"`.

### Testing
- Verified the change with `rg -n "settings for comprehensive configuration"` and checked repository status with `git status --short`, both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a4d6ffd08331aebdbd21e3d69685)