### PR TITLE
Add FluidAudio (Parakeet) as optional on-device transcription engine

### DIFF
--- a/BisonNotes AI/BisonNotes AI.xcodeproj/project.pbxproj
+++ b/BisonNotes AI/BisonNotes AI.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		1435735C2F2E92A500E93954 /* BisonNotes Share.appex in Embed Controls Extension */ = {isa = PBXBuildFile; fileRef = 143573522F2E92A500E93954 /* BisonNotes Share.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		14748E1C2F145C0D0016C521 /* WhisperKit in Frameworks */ = {isa = PBXBuildFile; productRef = 14748E1B2F145C0D0016C521 /* WhisperKit */; };
 		14748E1E2F145C0D0016C521 /* whisperkit-cli in Frameworks */ = {isa = PBXBuildFile; productRef = 14748E1D2F145C0D0016C521 /* whisperkit-cli */; };
+		14FA00012F30000000BBD2FA /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = 14FA00022F30000000BBD2FA /* FluidAudio */; };
 		1485FEC52E526FB30044121F /* BisonNotes AI Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 1485FEA52E526FB10044121F /* BisonNotes AI Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		1485FED52E5271970044121F /* WatchConnectivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1485FED42E5271970044121F /* WatchConnectivity.framework */; };
 		1485FED72E5271AF0044121F /* WatchConnectivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1485FED62E5271AF0044121F /* WatchConnectivity.framework */; };
@@ -265,6 +266,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				14FDF9102E3F8D5600BBD2FA /* AWSTranscribeStreaming in Frameworks */,
+				14FA00012F30000000BBD2FA /* FluidAudio in Frameworks */,
 				14748E1E2F145C0D0016C521 /* whisperkit-cli in Frameworks */,
 				14FDF90C2E3F8D5600BBD2FA /* AWSS3 in Frameworks */,
 				14748E1C2F145C0D0016C521 /* WhisperKit in Frameworks */,
@@ -484,6 +486,7 @@
 				14748E1B2F145C0D0016C521 /* WhisperKit */,
 				14748E1D2F145C0D0016C521 /* whisperkit-cli */,
 				1435711C2F2137E1000BFF00 /* Textual */,
+				14FA00022F30000000BBD2FA /* FluidAudio */,
 			);
 			productName = "BisonNotes AI";
 			productReference = 14DBC83D2E34F7B500DAD442 /* BisonNotes AI.app */;
@@ -610,6 +613,7 @@
 				14FDF9062E3F8D5600BBD2FA /* XCRemoteSwiftPackageReference "aws-sdk-swift" */,
 				14748E1A2F145C0D0016C521 /* XCRemoteSwiftPackageReference "WhisperKit" */,
 				1435711B2F2137E1000BFF00 /* XCRemoteSwiftPackageReference "textual" */,
+				14FA00032F30000000BBD2FA /* XCRemoteSwiftPackageReference "FluidAudio" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 14DBC83E2E34F7B500DAD442 /* Products */;
@@ -1466,6 +1470,14 @@
 				minimumVersion = 1.5.12;
 			};
 		};
+		14FA00032F30000000BBD2FA /* XCRemoteSwiftPackageReference "FluidAudio" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/FluidInference/FluidAudio";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.7.8;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1513,6 +1525,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 14FDF9062E3F8D5600BBD2FA /* XCRemoteSwiftPackageReference "aws-sdk-swift" */;
 			productName = AWSBedrockRuntime;
+		};
+		14FA00022F30000000BBD2FA /* FluidAudio */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 14FA00032F30000000BBD2FA /* XCRemoteSwiftPackageReference "FluidAudio" */;
+			productName = FluidAudio;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/BisonNotes AI/BisonNotes AI/BackgroundProcessingManager.swift
+++ b/BisonNotes AI/BisonNotes AI/BackgroundProcessingManager.swift
@@ -851,6 +851,11 @@ class BackgroundProcessingManager: ObservableObject {
                 }
                 result = try await whisperKitManager.transcribe(audioURL: chunk.chunkURL)
 
+            case .fluidAudio:
+                print("🤖 Using FluidAudio (Parakeet) for transcription")
+                let fluidAudioManager = FluidAudioManager.shared
+                result = try await fluidAudioManager.transcribe(audioURL: chunk.chunkURL)
+
             case .mistralAI:
                 print("🤖 Using Mistral AI for transcription")
                 let config = getMistralTranscribeConfig()

--- a/BisonNotes AI/BisonNotes AI/BackgroundProcessingManager.swift
+++ b/BisonNotes AI/BisonNotes AI/BackgroundProcessingManager.swift
@@ -854,6 +854,9 @@ class BackgroundProcessingManager: ObservableObject {
             case .fluidAudio:
                 print("🤖 Using FluidAudio (Parakeet) for transcription")
                 let fluidAudioManager = FluidAudioManager.shared
+                guard fluidAudioManager.isAvailableInCurrentBuild else {
+                    throw BackgroundProcessingError.processingFailed("FluidAudio SDK is not available in this build.")
+                }
                 result = try await fluidAudioManager.transcribe(audioURL: chunk.chunkURL)
 
             case .mistralAI:

--- a/BisonNotes AI/BisonNotes AI/BackgroundProcessingManager.swift
+++ b/BisonNotes AI/BisonNotes AI/BackgroundProcessingManager.swift
@@ -857,6 +857,9 @@ class BackgroundProcessingManager: ObservableObject {
                 guard fluidAudioManager.isAvailableInCurrentBuild else {
                     throw BackgroundProcessingError.processingFailed("FluidAudio SDK is not available in this build.")
                 }
+                guard fluidAudioManager.isModelReady else {
+                    throw BackgroundProcessingError.processingFailed("Parakeet model not downloaded. Please download the model in Settings > Transcription > On Device (Parakeet).")
+                }
                 result = try await fluidAudioManager.transcribe(audioURL: chunk.chunkURL)
 
             case .mistralAI:

--- a/BisonNotes AI/BisonNotes AI/EnhancedTranscriptionManager.swift
+++ b/BisonNotes AI/BisonNotes AI/EnhancedTranscriptionManager.swift
@@ -460,6 +460,10 @@ if durationMinutes > 120 { // 2 hours max
             switchToWhisperKitTranscription()
             return try await transcribeWithWhisperKit(url: url)
 
+        case .fluidAudio:
+            switchToFluidAudioTranscription()
+            return try await transcribeWithFluidAudio(url: url)
+
         case .awsTranscribe:
             switchToAWSTranscription()
             
@@ -1548,6 +1552,41 @@ return result
         }
     }
 
+    // MARK: - FluidAudio (Parakeet) Transcription
+
+    private func transcribeWithFluidAudio(url: URL) async throws -> TranscriptionResult {
+        beginBackgroundTask()
+        defer { endBackgroundTask() }
+
+        let manager = FluidAudioManager.shared
+
+        guard manager.isAvailableInCurrentBuild else {
+            throw TranscriptionError.fluidAudioNotAvailable
+        }
+
+        await MainActor.run {
+            isTranscribing = true
+            currentStatus = "Preparing Parakeet transcription..."
+        }
+
+        do {
+            let result = try await manager.transcribe(audioURL: url)
+
+            await MainActor.run {
+                isTranscribing = false
+                currentStatus = "Transcription complete"
+            }
+
+            return result
+        } catch {
+            await MainActor.run {
+                isTranscribing = false
+                currentStatus = "Parakeet transcription failed"
+            }
+            throw TranscriptionError.fluidAudioTranscriptionFailed(error)
+        }
+    }
+
     // MARK: - OpenAI Transcription
 
 private func transcribeWithOpenAI(url: URL, config: OpenAITranscribeConfig) async throws -> TranscriptionResult {
@@ -1888,6 +1927,19 @@ func switchToWhisperTranscription() {
         }
     }
 
+    func switchToFluidAudioTranscription() {
+        stopBackgroundChecking()
+
+        let pendingCount = getPendingJobNames().count
+        if pendingCount > 0 {
+            clearAllPendingJobs()
+        }
+
+        if PerformanceOptimizer.shouldLogEngineInitialization() {
+            AppLogger.shared.verbose("FluidAudio (Parakeet) transcription selected", category: "EnhancedTranscriptionManager")
+        }
+    }
+
     /// Public method to update transcription engine and manage background processes
     func updateTranscriptionEngine(_ engine: TranscriptionEngine) {
         // Only log if verbose logging is enabled
@@ -1901,6 +1953,8 @@ func switchToWhisperTranscription() {
             switchToNativeSpeechTranscription()
         case .whisperKit:
             switchToWhisperKitTranscription()
+        case .fluidAudio:
+            switchToFluidAudioTranscription()
         case .awsTranscribe:
             switchToAWSTranscription()
         case .whisper:
@@ -2051,6 +2105,9 @@ enum TranscriptionError: LocalizedError {
     case openAITranscriptionFailed(Error)
     case whisperKitNotReady
     case whisperKitTranscriptionFailed(Error)
+    case fluidAudioNotAvailable
+    case fluidAudioNotReady
+    case fluidAudioTranscriptionFailed(Error)
     case engineNotConfigured
     case mistralTranscriptionFailed(Error)
 
@@ -2086,6 +2143,12 @@ enum TranscriptionError: LocalizedError {
             return "WhisperKit model is not downloaded. Please download the model in Settings > Transcription > WhisperKit."
         case .whisperKitTranscriptionFailed(let error):
             return "WhisperKit transcription failed: \(error.localizedDescription)"
+        case .fluidAudioNotAvailable:
+            return "FluidAudio is not available in this build. Add the FluidAudio Swift package and rebuild."
+        case .fluidAudioNotReady:
+            return "FluidAudio model is not ready. Download and initialize the Parakeet model in Settings > Transcription > On Device (Parakeet)."
+        case .fluidAudioTranscriptionFailed(let error):
+            return "Parakeet transcription failed: \(error.localizedDescription)"
         case .fileTooLarge(let duration, let maxDuration):
             return "File too large for processing (\(Int(duration/60)) minutes, max \(Int(maxDuration/60)) minutes)"
         case .engineNotConfigured:

--- a/BisonNotes AI/BisonNotes AI/EnhancedTranscriptionManager.swift
+++ b/BisonNotes AI/BisonNotes AI/EnhancedTranscriptionManager.swift
@@ -1564,6 +1564,11 @@ return result
             throw TranscriptionError.fluidAudioNotAvailable
         }
 
+        // Check if model is ready
+        guard manager.isModelReady else {
+            throw TranscriptionError.fluidAudioNotReady
+        }
+
         await MainActor.run {
             isTranscribing = true
             currentStatus = "Preparing Parakeet transcription..."

--- a/BisonNotes AI/BisonNotes AI/FluidAudio/FluidAudioManager.swift
+++ b/BisonNotes AI/BisonNotes AI/FluidAudio/FluidAudioManager.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Combine
+
+#if canImport(FluidAudio)
+import FluidAudio
+#endif
+
+@MainActor
+final class FluidAudioManager: ObservableObject {
+    static let shared = FluidAudioManager()
+
+    @Published var isModelReady = false
+    @Published var isDownloading = false
+    @Published var currentStatus = ""
+
+    #if canImport(FluidAudio)
+    private var asrManager: AsrManager?
+    #endif
+
+    private init() {
+        isModelReady = UserDefaults.standard.bool(forKey: FluidAudioModelInfo.SettingsKeys.modelDownloaded)
+    }
+
+    var isAvailableInCurrentBuild: Bool {
+        #if canImport(FluidAudio)
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    func downloadAndPrepareModel() async throws {
+        guard !isDownloading else { return }
+
+        #if canImport(FluidAudio)
+        isDownloading = true
+        currentStatus = "Downloading Parakeet model..."
+        defer { isDownloading = false }
+
+        let models: AsrModels
+        switch FluidAudioModelInfo.selectedModelVersion {
+        case .v2:
+            models = try await AsrModels.downloadAndLoad(version: .v2)
+        case .v3:
+            models = try await AsrModels.downloadAndLoad(version: .v3)
+        }
+
+        let manager = AsrManager(config: .default)
+        try await manager.initialize(models: models)
+
+        asrManager = manager
+        isModelReady = true
+        currentStatus = "Parakeet model ready"
+        UserDefaults.standard.set(true, forKey: FluidAudioModelInfo.SettingsKeys.modelDownloaded)
+        #else
+        throw TranscriptionError.fluidAudioNotAvailable
+        #endif
+    }
+
+    func transcribe(audioURL: URL) async throws -> TranscriptionResult {
+        #if canImport(FluidAudio)
+        if asrManager == nil {
+            try await downloadAndPrepareModel()
+        }
+
+        guard let asrManager else {
+            throw TranscriptionError.fluidAudioNotReady
+        }
+
+        currentStatus = "Transcribing with Parakeet..."
+        let start = Date()
+        let result = try await asrManager.transcribe(audioURL, source: .system)
+
+        let segment = TranscriptSegment(
+            speaker: "Speaker 1",
+            text: result.text,
+            startTime: 0,
+            endTime: 0
+        )
+
+        return TranscriptionResult(
+            fullText: result.text,
+            segments: [segment],
+            processingTime: Date().timeIntervalSince(start),
+            chunkCount: 1,
+            success: !result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+            error: nil
+        )
+        #else
+        throw TranscriptionError.fluidAudioNotAvailable
+        #endif
+    }
+}

--- a/BisonNotes AI/BisonNotes AI/FluidAudio/FluidAudioManager.swift
+++ b/BisonNotes AI/BisonNotes AI/FluidAudio/FluidAudioManager.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Combine
 import AVFoundation
+import Network
 
 #if canImport(FluidAudio)
 import FluidAudio
@@ -12,9 +12,12 @@ final class FluidAudioManager: ObservableObject {
 
     @Published var isModelReady = false
     @Published var isDownloading = false
+    @Published var downloadProgress: Float = 0
     @Published var currentStatus = ""
 
     private var loadedModelVersion: FluidAudioModelInfo.ModelVersion?
+    private var downloadTask: Task<Void, Error>?
+    private var networkMonitor: NWPathMonitor?
 
     #if canImport(FluidAudio)
     private var asrManager: AsrManager?
@@ -40,6 +43,8 @@ final class FluidAudioManager: ObservableObject {
             // Legacy install without version tracking: trust the downloaded flag
             isModelReady = true
         }
+
+        startNetworkMonitoring()
     }
 
     var isAvailableInCurrentBuild: Bool {
@@ -49,6 +54,24 @@ final class FluidAudioManager: ObservableObject {
         return false
         #endif
     }
+
+    // MARK: - Network Monitoring
+
+    private func startNetworkMonitoring() {
+        networkMonitor = NWPathMonitor()
+        networkMonitor?.pathUpdateHandler = { [weak self] path in
+            Task { @MainActor [weak self] in
+                if path.status == .unsatisfied && self?.isDownloading == true {
+                    self?.currentStatus = "Network connection lost."
+                    self?.cancelDownload()
+                }
+            }
+        }
+        let queue = DispatchQueue(label: "FluidAudioNetworkMonitor")
+        networkMonitor?.start(queue: queue)
+    }
+
+    // MARK: - Model Version Management
 
     /// Resets the loaded model state when the user selects a different model version.
     /// Must be called from `FluidAudioSettingsView` when the version picker changes.
@@ -63,22 +86,72 @@ final class FluidAudioManager: ObservableObject {
         UserDefaults.standard.removeObject(forKey: FluidAudioModelInfo.SettingsKeys.downloadedModelVersion)
     }
 
+    // MARK: - Download & Prepare
+
     func downloadAndPrepareModel() async throws {
         guard !isDownloading else { return }
 
+        // Check network availability before starting download
+        if networkMonitor?.currentPath.status == .unsatisfied {
+            currentStatus = "No network connection. Please check your internet and try again."
+            throw TranscriptionError.fluidAudioNotAvailable
+        }
+
         #if canImport(FluidAudio)
         isDownloading = true
+        downloadProgress = 0
         currentStatus = "Downloading Parakeet model..."
-        defer { isDownloading = false }
+        defer {
+            isDownloading = false
+        }
 
         let selectedVersion = FluidAudioModelInfo.selectedModelVersion
-        let models: AsrModels
-        switch selectedVersion {
-        case .v2:
-            models = try await AsrModels.downloadAndLoad(version: .v2)
-        case .v3:
-            models = try await AsrModels.downloadAndLoad(version: .v3)
+
+        // Wrap in a Task so we can support cancellation
+        let task = Task {
+            let models: AsrModels
+            switch selectedVersion {
+            case .v2:
+                models = try await AsrModels.downloadAndLoad(version: .v2)
+            case .v3:
+                models = try await AsrModels.downloadAndLoad(version: .v3)
+            }
+            try Task.checkCancellation()
+            return models
         }
+        downloadTask = task
+
+        // Update progress while downloading (poll-based since FluidAudio SDK doesn't expose progress callbacks)
+        let progressTask = Task {
+            var tick: Float = 0
+            while !Task.isCancelled {
+                try await Task.sleep(nanoseconds: 500_000_000) // 0.5s
+                tick += 1
+                // Indeterminate progress: pulse between 0 and 0.9 until done
+                let pulse = min(0.9, tick * 0.02)
+                await MainActor.run {
+                    if self.isDownloading {
+                        self.downloadProgress = pulse
+                        self.currentStatus = "Downloading Parakeet model... (\(Int(pulse * 100))%)"
+                    }
+                }
+            }
+        }
+
+        let models: AsrModels
+        do {
+            models = try await task.value
+            progressTask.cancel()
+        } catch {
+            progressTask.cancel()
+            downloadTask = nil
+            downloadProgress = 0
+            throw error
+        }
+
+        downloadTask = nil
+        downloadProgress = 0.95
+        currentStatus = "Initializing model..."
 
         let manager = AsrManager(config: .default)
         try await manager.initialize(models: models)
@@ -86,6 +159,7 @@ final class FluidAudioManager: ObservableObject {
         asrManager = manager
         loadedModelVersion = selectedVersion
         isModelReady = true
+        downloadProgress = 1.0
         currentStatus = "Parakeet model ready"
         UserDefaults.standard.set(true, forKey: FluidAudioModelInfo.SettingsKeys.modelDownloaded)
         UserDefaults.standard.set(selectedVersion.rawValue, forKey: FluidAudioModelInfo.SettingsKeys.downloadedModelVersion)
@@ -94,11 +168,59 @@ final class FluidAudioManager: ObservableObject {
         #endif
     }
 
+    /// Cancel the current download
+    func cancelDownload() {
+        downloadTask?.cancel()
+        downloadTask = nil
+        isDownloading = false
+        downloadProgress = 0
+        currentStatus = "Download cancelled"
+    }
+
+    // MARK: - Model Management
+
+    /// Delete the downloaded model and free storage
+    func deleteModel() {
+        #if canImport(FluidAudio)
+        asrManager = nil
+        // Clear cached model files if FluidAudio stores them in a known location
+        if let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first {
+            let fluidAudioCache = cacheDir.appendingPathComponent("FluidAudio")
+            try? FileManager.default.removeItem(at: fluidAudioCache)
+        }
+        #endif
+        loadedModelVersion = nil
+        isModelReady = false
+        downloadProgress = 0
+        currentStatus = "Model deleted"
+        UserDefaults.standard.set(false, forKey: FluidAudioModelInfo.SettingsKeys.modelDownloaded)
+        UserDefaults.standard.removeObject(forKey: FluidAudioModelInfo.SettingsKeys.downloadedModelVersion)
+    }
+
+    /// Unload the model from memory without deleting files on disk
+    func unloadModel() {
+        #if canImport(FluidAudio)
+        asrManager = nil
+        #endif
+        loadedModelVersion = nil
+        print("[FluidAudio] Model unloaded from memory")
+    }
+
+    // MARK: - Transcription
+
     func transcribe(audioURL: URL) async throws -> TranscriptionResult {
         #if canImport(FluidAudio)
         // Require explicit model download before transcription can proceed
         guard isModelReady else {
             throw TranscriptionError.fluidAudioNotReady
+        }
+
+        // Validate audio file exists
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            throw TranscriptionError.fluidAudioTranscriptionFailed(
+                NSError(domain: "FluidAudioManager", code: -1,
+                        userInfo: [NSLocalizedDescriptionKey: "Audio file not found at \(audioURL.path)"])
+            )
         }
 
         // Guard against a version switch that wasn't flushed via invalidateForVersionChange()
@@ -130,7 +252,8 @@ final class FluidAudioManager: ObservableObject {
 
         // Determine audio duration for accurate segment end time
         let asset = AVURLAsset(url: audioURL)
-        let durationSeconds = CMTimeGetSeconds(asset.duration)
+        let duration = try await asset.load(.duration)
+        let durationSeconds = CMTimeGetSeconds(duration)
 
         let segment = TranscriptSegment(
             speaker: "Speaker 1",

--- a/BisonNotes AI/BisonNotes AI/FluidAudio/FluidAudioManager.swift
+++ b/BisonNotes AI/BisonNotes AI/FluidAudio/FluidAudioManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import AVFoundation
 
 #if canImport(FluidAudio)
 import FluidAudio
@@ -13,12 +14,32 @@ final class FluidAudioManager: ObservableObject {
     @Published var isDownloading = false
     @Published var currentStatus = ""
 
+    private var loadedModelVersion: FluidAudioModelInfo.ModelVersion?
+
     #if canImport(FluidAudio)
     private var asrManager: AsrManager?
     #endif
 
     private init() {
-        isModelReady = UserDefaults.standard.bool(forKey: FluidAudioModelInfo.SettingsKeys.modelDownloaded)
+        let downloaded = UserDefaults.standard.bool(forKey: FluidAudioModelInfo.SettingsKeys.modelDownloaded)
+        guard downloaded else { return }
+
+        let downloadedVersion = UserDefaults.standard.string(forKey: FluidAudioModelInfo.SettingsKeys.downloadedModelVersion)
+        let selectedVersion = FluidAudioModelInfo.selectedModelVersion.rawValue
+
+        if let dv = downloadedVersion {
+            // Version tracking present: only mark ready if versions match
+            if dv == selectedVersion {
+                isModelReady = true
+            } else {
+                // Selected version changed since last download — clear stale state
+                UserDefaults.standard.set(false, forKey: FluidAudioModelInfo.SettingsKeys.modelDownloaded)
+                UserDefaults.standard.removeObject(forKey: FluidAudioModelInfo.SettingsKeys.downloadedModelVersion)
+            }
+        } else {
+            // Legacy install without version tracking: trust the downloaded flag
+            isModelReady = true
+        }
     }
 
     var isAvailableInCurrentBuild: Bool {
@@ -29,6 +50,19 @@ final class FluidAudioManager: ObservableObject {
         #endif
     }
 
+    /// Resets the loaded model state when the user selects a different model version.
+    /// Must be called from `FluidAudioSettingsView` when the version picker changes.
+    func invalidateForVersionChange() {
+        #if canImport(FluidAudio)
+        asrManager = nil
+        #endif
+        loadedModelVersion = nil
+        isModelReady = false
+        currentStatus = "Model version changed. Please re-download."
+        UserDefaults.standard.set(false, forKey: FluidAudioModelInfo.SettingsKeys.modelDownloaded)
+        UserDefaults.standard.removeObject(forKey: FluidAudioModelInfo.SettingsKeys.downloadedModelVersion)
+    }
+
     func downloadAndPrepareModel() async throws {
         guard !isDownloading else { return }
 
@@ -37,8 +71,9 @@ final class FluidAudioManager: ObservableObject {
         currentStatus = "Downloading Parakeet model..."
         defer { isDownloading = false }
 
+        let selectedVersion = FluidAudioModelInfo.selectedModelVersion
         let models: AsrModels
-        switch FluidAudioModelInfo.selectedModelVersion {
+        switch selectedVersion {
         case .v2:
             models = try await AsrModels.downloadAndLoad(version: .v2)
         case .v3:
@@ -49,9 +84,11 @@ final class FluidAudioManager: ObservableObject {
         try await manager.initialize(models: models)
 
         asrManager = manager
+        loadedModelVersion = selectedVersion
         isModelReady = true
         currentStatus = "Parakeet model ready"
         UserDefaults.standard.set(true, forKey: FluidAudioModelInfo.SettingsKeys.modelDownloaded)
+        UserDefaults.standard.set(selectedVersion.rawValue, forKey: FluidAudioModelInfo.SettingsKeys.downloadedModelVersion)
         #else
         throw TranscriptionError.fluidAudioNotAvailable
         #endif
@@ -59,8 +96,28 @@ final class FluidAudioManager: ObservableObject {
 
     func transcribe(audioURL: URL) async throws -> TranscriptionResult {
         #if canImport(FluidAudio)
+        // Require explicit model download before transcription can proceed
+        guard isModelReady else {
+            throw TranscriptionError.fluidAudioNotReady
+        }
+
+        // Guard against a version switch that wasn't flushed via invalidateForVersionChange()
+        if let loaded = loadedModelVersion, loaded != FluidAudioModelInfo.selectedModelVersion {
+            invalidateForVersionChange()
+            throw TranscriptionError.fluidAudioNotReady
+        }
+
+        // Re-initialize from cached model on fresh app launch (asrManager is nil until first use)
         if asrManager == nil {
-            try await downloadAndPrepareModel()
+            do {
+                try await downloadAndPrepareModel()
+            } catch {
+                // Cached model files are gone; clear stale state so the UI reflects this
+                isModelReady = false
+                UserDefaults.standard.set(false, forKey: FluidAudioModelInfo.SettingsKeys.modelDownloaded)
+                UserDefaults.standard.removeObject(forKey: FluidAudioModelInfo.SettingsKeys.downloadedModelVersion)
+                throw TranscriptionError.fluidAudioNotReady
+            }
         }
 
         guard let asrManager else {
@@ -71,11 +128,15 @@ final class FluidAudioManager: ObservableObject {
         let start = Date()
         let result = try await asrManager.transcribe(audioURL, source: .system)
 
+        // Determine audio duration for accurate segment end time
+        let asset = AVURLAsset(url: audioURL)
+        let durationSeconds = CMTimeGetSeconds(asset.duration)
+
         let segment = TranscriptSegment(
             speaker: "Speaker 1",
             text: result.text,
             startTime: 0,
-            endTime: 0
+            endTime: durationSeconds > 0 ? durationSeconds : 0
         )
 
         return TranscriptionResult(
@@ -83,7 +144,7 @@ final class FluidAudioManager: ObservableObject {
             segments: [segment],
             processingTime: Date().timeIntervalSince(start),
             chunkCount: 1,
-            success: !result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+            success: true,  // success reflects engine completion without error, not output length
             error: nil
         )
         #else

--- a/BisonNotes AI/BisonNotes AI/FluidAudio/FluidAudioModelInfo.swift
+++ b/BisonNotes AI/BisonNotes AI/FluidAudio/FluidAudioModelInfo.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+struct FluidAudioModelInfo {
+    enum ModelVersion: String, CaseIterable {
+        case v2
+        case v3
+
+        var displayName: String {
+            switch self {
+            case .v2:
+                return "Parakeet v2 (English)"
+            case .v3:
+                return "Parakeet v3 (Multilingual)"
+            }
+        }
+
+        var description: String {
+            switch self {
+            case .v2:
+                return "English-only model with stronger long-form English recall"
+            case .v3:
+                return "Multilingual model for 25 European languages"
+            }
+        }
+    }
+
+    enum SettingsKeys {
+        static let enableFluidAudio = "enableFluidAudio"
+        static let selectedModelVersion = "fluidAudioSelectedModelVersion"
+        static let modelDownloaded = "fluidAudioModelDownloaded"
+    }
+
+    static var selectedModelVersion: ModelVersion {
+        let raw = UserDefaults.standard.string(forKey: SettingsKeys.selectedModelVersion) ?? ModelVersion.v3.rawValue
+        return ModelVersion(rawValue: raw) ?? .v3
+    }
+}

--- a/BisonNotes AI/BisonNotes AI/FluidAudio/FluidAudioModelInfo.swift
+++ b/BisonNotes AI/BisonNotes AI/FluidAudio/FluidAudioModelInfo.swift
@@ -28,6 +28,7 @@ struct FluidAudioModelInfo {
         static let enableFluidAudio = "enableFluidAudio"
         static let selectedModelVersion = "fluidAudioSelectedModelVersion"
         static let modelDownloaded = "fluidAudioModelDownloaded"
+        static let downloadedModelVersion = "fluidAudioDownloadedModelVersion"
     }
 
     static var selectedModelVersion: ModelVersion {

--- a/BisonNotes AI/BisonNotes AI/FluidAudio/FluidAudioSettingsView.swift
+++ b/BisonNotes AI/BisonNotes AI/FluidAudio/FluidAudioSettingsView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+struct FluidAudioSettingsView: View {
+    @AppStorage(FluidAudioModelInfo.SettingsKeys.enableFluidAudio) private var enableFluidAudio = false
+    @AppStorage(FluidAudioModelInfo.SettingsKeys.selectedModelVersion) private var selectedModelVersion = FluidAudioModelInfo.ModelVersion.v3.rawValue
+
+    @StateObject private var manager = FluidAudioManager.shared
+
+    var body: some View {
+        Form {
+            Section("Engine") {
+                Toggle("Enable FluidAudio (Parakeet)", isOn: $enableFluidAudio)
+
+                Picker("Model", selection: $selectedModelVersion) {
+                    ForEach(FluidAudioModelInfo.ModelVersion.allCases, id: \.self) { version in
+                        VStack(alignment: .leading) {
+                            Text(version.displayName)
+                            Text(version.description)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        .tag(version.rawValue)
+                    }
+                }
+            }
+
+            Section("Model Status") {
+                HStack {
+                    Text("Status")
+                    Spacer()
+                    Text(manager.isModelReady ? "Ready" : "Not Downloaded")
+                        .foregroundColor(manager.isModelReady ? .green : .secondary)
+                }
+
+                if !manager.currentStatus.isEmpty {
+                    Text(manager.currentStatus)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Button(manager.isDownloading ? "Downloading..." : "Download / Prepare Model") {
+                    Task {
+                        do {
+                            try await manager.downloadAndPrepareModel()
+                        } catch {
+                            manager.currentStatus = "Failed: \(error.localizedDescription)"
+                        }
+                    }
+                }
+                .disabled(manager.isDownloading)
+            }
+
+            Section {
+                Text("FluidAudio runs NVIDIA Parakeet models fully on-device using CoreML/ANE acceleration. This option keeps audio local and does not remove your existing transcription engines.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .navigationTitle("Parakeet Settings")
+    }
+}

--- a/BisonNotes AI/BisonNotes AI/FluidAudio/FluidAudioSettingsView.swift
+++ b/BisonNotes AI/BisonNotes AI/FluidAudio/FluidAudioSettingsView.swift
@@ -22,7 +22,7 @@ struct FluidAudioSettingsView: View {
                         .tag(version.rawValue)
                     }
                 }
-                .onChange(of: selectedModelVersion) { _ in
+                .onChange(of: selectedModelVersion) { _, _ in
                     manager.invalidateForVersionChange()
                 }
             }
@@ -36,22 +36,38 @@ struct FluidAudioSettingsView: View {
                             .foregroundColor(manager.isModelReady ? .green : .secondary)
                     }
 
+                    if manager.isDownloading {
+                        ProgressView(value: manager.downloadProgress)
+                            .progressViewStyle(.linear)
+                    }
+
                     if !manager.currentStatus.isEmpty {
                         Text(manager.currentStatus)
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
 
-                    Button(manager.isDownloading ? "Downloading..." : "Download / Prepare Model") {
-                        Task {
-                            do {
-                                try await manager.downloadAndPrepareModel()
-                            } catch {
-                                manager.currentStatus = "Failed: \(error.localizedDescription)"
+                    if manager.isDownloading {
+                        Button("Cancel Download", role: .destructive) {
+                            manager.cancelDownload()
+                        }
+                    } else {
+                        Button("Download / Prepare Model") {
+                            Task {
+                                do {
+                                    try await manager.downloadAndPrepareModel()
+                                } catch {
+                                    manager.currentStatus = "Failed: \(error.localizedDescription)"
+                                }
                             }
                         }
                     }
-                    .disabled(manager.isDownloading)
+
+                    if manager.isModelReady {
+                        Button("Delete Model", role: .destructive) {
+                            manager.deleteModel()
+                        }
+                    }
                 }
             }
 

--- a/BisonNotes AI/BisonNotes AI/FluidAudio/FluidAudioSettingsView.swift
+++ b/BisonNotes AI/BisonNotes AI/FluidAudio/FluidAudioSettingsView.swift
@@ -4,7 +4,7 @@ struct FluidAudioSettingsView: View {
     @AppStorage(FluidAudioModelInfo.SettingsKeys.enableFluidAudio) private var enableFluidAudio = false
     @AppStorage(FluidAudioModelInfo.SettingsKeys.selectedModelVersion) private var selectedModelVersion = FluidAudioModelInfo.ModelVersion.v3.rawValue
 
-    @StateObject private var manager = FluidAudioManager.shared
+    @ObservedObject private var manager = FluidAudioManager.shared
 
     var body: some View {
         Form {
@@ -22,32 +22,37 @@ struct FluidAudioSettingsView: View {
                         .tag(version.rawValue)
                     }
                 }
+                .onChange(of: selectedModelVersion) { _ in
+                    manager.invalidateForVersionChange()
+                }
             }
 
-            Section("Model Status") {
-                HStack {
-                    Text("Status")
-                    Spacer()
-                    Text(manager.isModelReady ? "Ready" : "Not Downloaded")
-                        .foregroundColor(manager.isModelReady ? .green : .secondary)
-                }
+            if enableFluidAudio {
+                Section("Model Status") {
+                    HStack {
+                        Text("Status")
+                        Spacer()
+                        Text(manager.isModelReady ? "Ready" : "Not Downloaded")
+                            .foregroundColor(manager.isModelReady ? .green : .secondary)
+                    }
 
-                if !manager.currentStatus.isEmpty {
-                    Text(manager.currentStatus)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
+                    if !manager.currentStatus.isEmpty {
+                        Text(manager.currentStatus)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
 
-                Button(manager.isDownloading ? "Downloading..." : "Download / Prepare Model") {
-                    Task {
-                        do {
-                            try await manager.downloadAndPrepareModel()
-                        } catch {
-                            manager.currentStatus = "Failed: \(error.localizedDescription)"
+                    Button(manager.isDownloading ? "Downloading..." : "Download / Prepare Model") {
+                        Task {
+                            do {
+                                try await manager.downloadAndPrepareModel()
+                            } catch {
+                                manager.currentStatus = "Failed: \(error.localizedDescription)"
+                            }
                         }
                     }
+                    .disabled(manager.isDownloading)
                 }
-                .disabled(manager.isDownloading)
             }
 
             Section {

--- a/BisonNotes AI/BisonNotes AI/Models/AudioChunkingModels.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/AudioChunkingModels.swift
@@ -109,6 +109,8 @@ struct ChunkingConfig {
             return ChunkingConfig(strategy: .aws)
         case .whisperKit:
             return ChunkingConfig(strategy: .whisper) // WhisperKit uses similar limits to Whisper
+        case .fluidAudio:
+            return ChunkingConfig(strategy: .onDeviceAI)
         case .mistralAI:
             return ChunkingConfig(strategy: .mistralAI)
         case .openAIAPICompatible:

--- a/BisonNotes AI/BisonNotes AI/Models/AudioModels.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/AudioModels.swift
@@ -94,9 +94,9 @@ public enum TranscriptionEngine: String, CaseIterable, Codable {
     case mistralAI = "Mistral AI"
     case openAIAPICompatible = "OpenAI API Compatible"
 
-    /// Returns all available engine types based on device capabilities
+    /// Returns only engine types that are available on the current device and build.
     static var availableCases: [TranscriptionEngine] {
-        return allCases
+        return allCases.filter { $0.isAvailable }
     }
 
     var description: String {
@@ -128,7 +128,7 @@ public enum TranscriptionEngine: String, CaseIterable, Codable {
             // Only show WhisperKit if device is compatible
             return DeviceCompatibility.isWhisperKitSupported
         case .fluidAudio:
-            return DeviceCompatibility.isFluidAudioSupported
+            return DeviceCompatibility.isFluidAudioSupported && FluidAudioManager.shared.isAvailableInCurrentBuild
         case .awsTranscribe, .whisper, .openAI, .mistralAI:
             return true
         case .openAIAPICompatible:

--- a/BisonNotes AI/BisonNotes AI/Models/AudioModels.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/AudioModels.swift
@@ -87,6 +87,7 @@ public enum WhisperProtocol: String, CaseIterable, Codable {
 public enum TranscriptionEngine: String, CaseIterable, Codable {
     case notConfigured = "Not Configured"
     case whisperKit = "On Device"
+    case fluidAudio = "On Device (Parakeet)"
     case awsTranscribe = "AWS Transcribe"
     case whisper = "Whisper (Local Server)"
     case openAI = "OpenAI"
@@ -104,6 +105,8 @@ public enum TranscriptionEngine: String, CaseIterable, Codable {
             return "No transcription engine has been configured yet"
         case .whisperKit:
             return "High-quality on-device transcription. Your audio never leaves your device, ensuring complete privacy."
+        case .fluidAudio:
+            return "On-device transcription powered by FluidAudio + NVIDIA Parakeet CoreML models."
         case .awsTranscribe:
             return "Cloud-based transcription service with support for long audio files"
         case .whisper:
@@ -124,6 +127,8 @@ public enum TranscriptionEngine: String, CaseIterable, Codable {
         case .whisperKit:
             // Only show WhisperKit if device is compatible
             return DeviceCompatibility.isWhisperKitSupported
+        case .fluidAudio:
+            return DeviceCompatibility.isFluidAudioSupported
         case .awsTranscribe, .whisper, .openAI, .mistralAI:
             return true
         case .openAIAPICompatible:
@@ -135,7 +140,7 @@ public enum TranscriptionEngine: String, CaseIterable, Codable {
         switch self {
         case .notConfigured:
             return true
-        case .whisperKit:
+        case .whisperKit, .fluidAudio:
             return true  // Requires model download
         case .awsTranscribe, .whisper, .openAI, .openAIAPICompatible, .mistralAI:
             return true
@@ -144,7 +149,7 @@ public enum TranscriptionEngine: String, CaseIterable, Codable {
 
     var usesWyomingProtocol: Bool {
         switch self {
-        case .notConfigured, .whisperKit:
+        case .notConfigured, .whisperKit, .fluidAudio:
             return false
         case .whisper:
             // For unified Whisper, check the user's protocol preference

--- a/BisonNotes AI/BisonNotes AI/Models/DeviceCompatibility.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/DeviceCompatibility.swift
@@ -92,6 +92,16 @@ struct DeviceCompatibility {
     static var isOnDeviceAISupported: Bool {
         return DeviceCapabilities.supportsOnDeviceLLM
     }
+
+    // MARK: - FluidAudio Support
+
+    /// FluidAudio requires iOS 17+ for CoreML model runtime in this app
+    static var isFluidAudioSupported: Bool {
+        if #available(iOS 17.0, *) {
+            return true
+        }
+        return false
+    }
 }
 
 public extension UIDevice {

--- a/BisonNotes AI/BisonNotes AI/Models/DeviceCompatibility.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/DeviceCompatibility.swift
@@ -95,12 +95,41 @@ struct DeviceCompatibility {
 
     // MARK: - FluidAudio Support
 
-    /// FluidAudio requires iOS 17+ for CoreML model runtime in this app
+    /// Cached result for FluidAudio support check
+    private static var _cachedFluidAudioSupport: Bool?
+    private static var _hasLoggedFluidAudioSupport = false
+
+    /// FluidAudio requires iOS 17+ and 4GB+ RAM for CoreML/ANE model inference
     static var isFluidAudioSupported: Bool {
-        if #available(iOS 17.0, *) {
-            return true
+        if let cached = _cachedFluidAudioSupport {
+            return cached
         }
-        return false
+
+        guard #available(iOS 17.0, *) else {
+            if !_hasLoggedFluidAudioSupport {
+                print("❌ DeviceCompatibility: iOS 17+ required for FluidAudio")
+                _hasLoggedFluidAudioSupport = true
+            }
+            _cachedFluidAudioSupport = false
+            return false
+        }
+
+        // Check RAM (4GB minimum for CoreML ANE inference)
+        let totalMemory = ProcessInfo.processInfo.physicalMemory
+        let totalMemoryGB = Double(totalMemory) / 1_073_741_824.0
+        let hasEnoughRAM = totalMemoryGB >= 4.0
+
+        if !_hasLoggedFluidAudioSupport {
+            if hasEnoughRAM {
+                print("✅ DeviceCompatibility: FluidAudio supported (RAM: \(String(format: "%.1f", totalMemoryGB))GB)")
+            } else {
+                print("❌ DeviceCompatibility: FluidAudio requires 4GB+ RAM (Device has \(String(format: "%.1f", totalMemoryGB))GB)")
+            }
+            _hasLoggedFluidAudioSupport = true
+        }
+
+        _cachedFluidAudioSupport = hasEnoughRAM
+        return hasEnoughRAM
     }
 }
 

--- a/BisonNotes AI/BisonNotes AI/TranscriptionSettingsView.swift
+++ b/BisonNotes AI/BisonNotes AI/TranscriptionSettingsView.swift
@@ -98,7 +98,7 @@ struct TranscriptionSettingsView: View {
                     .fontWeight(.medium)
                 
                 Picker("Transcription Engine", selection: $selectedTranscriptionEngine) {
-                    ForEach(TranscriptionEngine.availableCases.filter { $0.isAvailable }, id: \.self) { engine in
+                    ForEach(TranscriptionEngine.availableCases, id: \.self) { engine in
                         VStack(alignment: .leading) {
                             Text(engine.rawValue)
                                 .font(.body)

--- a/BisonNotes AI/BisonNotes AI/TranscriptionSettingsView.swift
+++ b/BisonNotes AI/BisonNotes AI/TranscriptionSettingsView.swift
@@ -18,6 +18,7 @@ struct TranscriptionSettingsView: View {
     @State private var showingAWSSettings = false
     @State private var showingWhisperSettings = false
     @State private var showingWhisperKitSettings = false
+    @State private var showingFluidAudioSettings = false
     @State private var showingOpenAISettings = false
     @State private var showingMistralTranscribeSettings = false
     @Environment(\.dismiss) private var dismiss
@@ -51,6 +52,11 @@ struct TranscriptionSettingsView: View {
                     WhisperKitSettingsView()
                 }
             }
+            .sheet(isPresented: $showingFluidAudioSettings) {
+                NavigationStack {
+                    FluidAudioSettingsView()
+                }
+            }
             .sheet(isPresented: $showingOpenAISettings) {
                 OpenAISettingsView()
             }
@@ -73,6 +79,13 @@ struct TranscriptionSettingsView: View {
             // If model not downloaded, prompt user to download
             if !whisperKitManager.isModelReady {
                 showingWhisperKitSettings = true
+            }
+        }
+
+        if engine == .fluidAudio {
+            UserDefaults.standard.set(true, forKey: FluidAudioModelInfo.SettingsKeys.enableFluidAudio)
+            if !FluidAudioManager.shared.isModelReady {
+                showingFluidAudioSettings = true
             }
         }
     }
@@ -138,6 +151,8 @@ struct TranscriptionSettingsView: View {
                                     break
                                 case .whisperKit:
                                     showingWhisperKitSettings = true
+                                case .fluidAudio:
+                                    showingFluidAudioSettings = true
                                 case .awsTranscribe:
                                     showingAWSSettings = true
                                 case .whisper:
@@ -180,6 +195,8 @@ struct TranscriptionSettingsView: View {
             return .gray
         case .whisperKit:
             return .indigo
+        case .fluidAudio:
+            return .mint
         case .awsTranscribe:
             return .orange
         case .whisper:
@@ -220,7 +237,7 @@ struct TranscriptionSettingsView: View {
                     .fontWeight(.medium)
             }
             
-            if engine == .whisperKit {
+            if engine == .whisperKit || engine == .fluidAudio {
                 HStack {
                     Text("Privacy:")
                         .font(.body)
@@ -246,6 +263,8 @@ struct TranscriptionSettingsView: View {
         case .notConfigured:
             return "Not Configured"
         case .whisperKit:
+            return "On-Device AI"
+        case .fluidAudio:
             return "On-Device AI"
         case .awsTranscribe:
             return "Cloud-based"


### PR DESCRIPTION
### Motivation
- Provide an additional on-device transcription option that runs NVIDIA Parakeet via the FluidAudio SDK so users can opt into a privacy-preserving, ANE-accelerated ASR without removing existing engines.

### Description
- Added a new `TranscriptionEngine` case `fluidAudio` (`"On Device (Parakeet)"`) and engine metadata/availability checks, including `DeviceCompatibility.isFluidAudioSupported` and UI labels for on-device privacy.  Files: `Models/AudioModels.swift`, `Models/DeviceCompatibility.swift`.
- Implemented `FluidAudioManager` (guarded by `#if canImport(FluidAudio)`) to download/initialize Parakeet models and perform transcription via FluidAudio's `AsrManager`, plus model metadata in `FluidAudioModelInfo`.  Files: `FluidAudio/FluidAudioManager.swift`, `FluidAudio/FluidAudioModelInfo.swift`.
- Added `FluidAudioSettingsView` to let users enable the engine and pick Parakeet model variants (v2/v3) and added it to the `TranscriptionSettingsView` flow and engine configuration sheet.  File: `FluidAudio/FluidAudioSettingsView.swift`, updates in `TranscriptionSettingsView.swift`.
- Wired runtime usage: `EnhancedTranscriptionManager` now routes to `transcribeWithFluidAudio` and includes error cases (`.fluidAudioNotAvailable`, `.fluidAudioNotReady`, `.fluidAudioTranscriptionFailed`). `BackgroundProcessingManager` supports chunked background transcription via `FluidAudioManager`. File updates: `EnhancedTranscriptionManager.swift`, `BackgroundProcessingManager.swift`.
- Mapped chunking strategy for `fluidAudio` to on-device limits in `AudioChunkingModels.swift` and kept the integration additive and feature-gated so builds without the FluidAudio package remain functional.
- Added the `FluidAudio` Swift package product (`https://github.com/FluidInference/FluidAudio`) into the Xcode project references so Xcode can include the package when available; code paths are guarded by `#if canImport(FluidAudio)` to avoid build-time failures when the package is not resolved. File: `BisonNotes AI.xcodeproj/project.pbxproj`.

### Testing
- Ran `swift --version` to validate the local Swift toolchain and it succeeded.
- Performed static checks: `git diff --check` (no whitespace/git-diff issues) and repository diff inspection; these checks passed.
- Attempted `xcodebuild -showBuildSettings` for the iOS scheme but `xcodebuild` is not available in this environment, so a full Xcode build could not be executed here.  The FluidAudio integration is guarded with `#if canImport(FluidAudio)` so non-Xcode builds remain unaffected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aad9969eb48331b39608b7e1ef4946)