### PR TITLE
Fix stale on-device jobs stuck in Processing state

### DIFF
--- a/BisonNotes AI/BisonNotes AI/BackgroundProcessingManager.swift
+++ b/BisonNotes AI/BisonNotes AI/BackgroundProcessingManager.swift
@@ -26,11 +26,33 @@ struct ProcessingJob: Identifiable, Codable {
     let progress: Double
     let startTime: Date
     /// When the job actually began processing (transitioned from queued to processing).
-    /// Not persisted to Core Data — only valid for the current app session.
+    /// Not persisted — only valid for the current app session.
     let processingStartTime: Date?
     let completionTime: Date?
     let chunks: [AudioChunk]?
     let error: String?
+
+    // Exclude processingStartTime from Codable to avoid forward-compatibility issues
+    private enum CodingKeys: String, CodingKey {
+        case id, type, recordingPath, recordingName, modelName, status, progress,
+             startTime, completionTime, chunks, error
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        type = try container.decode(JobType.self, forKey: .type)
+        recordingPath = try container.decode(String.self, forKey: .recordingPath)
+        recordingName = try container.decode(String.self, forKey: .recordingName)
+        modelName = try container.decodeIfPresent(String.self, forKey: .modelName)
+        status = try container.decode(JobProcessingStatus.self, forKey: .status)
+        progress = try container.decode(Double.self, forKey: .progress)
+        startTime = try container.decode(Date.self, forKey: .startTime)
+        processingStartTime = nil
+        completionTime = try container.decodeIfPresent(Date.self, forKey: .completionTime)
+        chunks = try container.decodeIfPresent([AudioChunk].self, forKey: .chunks)
+        error = try container.decodeIfPresent(String.self, forKey: .error)
+    }
 
     // Computed property to get absolute URL when needed
     var recordingURL: URL {
@@ -67,7 +89,7 @@ struct ProcessingJob: Identifiable, Codable {
             status: status,
             progress: self.progress,
             startTime: self.startTime,
-            processingStartTime: status == .processing ? (self.processingStartTime ?? Date()) : self.processingStartTime,
+            processingStartTime: status == .processing ? Date() : nil,
             completionTime: status == .completed || status.isCancelled || status.isError ? Date() : self.completionTime,
             chunks: self.chunks,
             error: status.errorMessage
@@ -692,24 +714,34 @@ class BackgroundProcessingManager: ObservableObject {
                 }
 
             } catch {
-                let failedJob = processingJob.withStatus(.failed(error.localizedDescription))
-                await updateJob(failedJob)
+                // Clear any stale cancellation reason so it doesn't leak to the next job.
+                cancellationReason = nil
 
-                print("❌ Job failed: \(nextJob.type.displayName) for \(nextJob.recordingName)")
-                print("   - Error: \(error)")
-                print("   - Localized description: \(error.localizedDescription)")
+                // If the job was already moved to a terminal state (e.g., timed out by the
+                // stale job monitor), don't overwrite it or attempt recovery.
+                let currentStatus = activeJobs.first(where: { $0.id == nextJob.id })?.status
+                if let currentStatus, currentStatus.isTerminal {
+                    print("⏭️ Job already terminal (\(currentStatus.displayName)): \(nextJob.type.displayName) for \(nextJob.recordingName) (error was: \(error.localizedDescription))")
+                } else {
+                    let failedJob = processingJob.withStatus(.failed(error.localizedDescription))
+                    await updateJob(failedJob)
 
-                // Save detailed error log
-                await saveErrorLog(for: processingJob, error: error)
+                    print("❌ Job failed: \(nextJob.type.displayName) for \(nextJob.recordingName)")
+                    print("   - Error: \(error)")
+                    print("   - Localized description: \(error.localizedDescription)")
 
-                // Error recovery
-                await handleJobFailure(processingJob, error: error)
+                    // Save detailed error log
+                    await saveErrorLog(for: processingJob, error: error)
 
-                // Send failure notification
-                await sendNotification(
-                    title: "Processing Failed",
-                    body: "Failed to process \(nextJob.recordingName): \(error.localizedDescription)"
-                )
+                    // Error recovery
+                    await handleJobFailure(processingJob, error: error)
+
+                    // Send failure notification
+                    await sendNotification(
+                        title: "Processing Failed",
+                        body: "Failed to process \(nextJob.recordingName): \(error.localizedDescription)"
+                    )
+                }
             }
 
             // Clear current job and task handle
@@ -2493,37 +2525,26 @@ class BackgroundProcessingManager: ObservableObject {
         if let index = activeJobs.firstIndex(where: { $0.id == updatedJob.id }) {
             activeJobs[index] = updatedJob
         }
-        
-        // Update in Core Data
+
+        // Keep currentJob in sync so the UI reflects the update immediately
+        if updatedJob.id == currentJob?.id {
+            currentJob = updatedJob
+            processingStatus = updatedJob.status
+        }
+
+        // Update in Core Data — use displayName for status (title-case) to match
+        // convertToProcessingJob's expected format, and store error separately.
         if let jobEntry = coreDataManager.getProcessingJob(id: updatedJob.id) {
-            jobEntry.status = statusToString(updatedJob.status)
+            jobEntry.status = updatedJob.status.displayName
             jobEntry.error = updatedJob.error
             jobEntry.completionTime = updatedJob.completionTime
             jobEntry.progress = updatedJob.progress
-            
+
             do {
                 try coreDataManager.saveContext()
             } catch {
                 print("❌ Failed to update job in Core Data: \(error)")
             }
-        }
-    }
-    
-    /// Convert JobProcessingStatus to string for Core Data storage
-    private func statusToString(_ status: JobProcessingStatus) -> String {
-        switch status {
-        case .queued:
-            return "queued"
-        case .processing:
-            return "processing"
-        case .completed:
-            return "completed"
-        case .failed(let message):
-            return "failed:\(message)"
-        case .cancelled:
-            return "cancelled"
-        case .interrupted(let reason):
-            return "interrupted:\(reason)"
         }
     }
     

--- a/BisonNotes AI/BisonNotes AI/BackgroundProcessingManager.swift
+++ b/BisonNotes AI/BisonNotes AI/BackgroundProcessingManager.swift
@@ -25,6 +25,9 @@ struct ProcessingJob: Identifiable, Codable {
     let status: JobProcessingStatus
     let progress: Double
     let startTime: Date
+    /// When the job actually began processing (transitioned from queued to processing).
+    /// Not persisted to Core Data — only valid for the current app session.
+    let processingStartTime: Date?
     let completionTime: Date?
     let chunks: [AudioChunk]?
     let error: String?
@@ -48,6 +51,7 @@ struct ProcessingJob: Identifiable, Codable {
         self.status = .queued
         self.progress = 0.0
         self.startTime = Date()
+        self.processingStartTime = nil
         self.completionTime = nil
         self.chunks = chunks
         self.error = nil
@@ -63,6 +67,7 @@ struct ProcessingJob: Identifiable, Codable {
             status: status,
             progress: self.progress,
             startTime: self.startTime,
+            processingStartTime: status == .processing ? (self.processingStartTime ?? Date()) : self.processingStartTime,
             completionTime: status == .completed || status.isCancelled || status.isError ? Date() : self.completionTime,
             chunks: self.chunks,
             error: status.errorMessage
@@ -79,13 +84,14 @@ struct ProcessingJob: Identifiable, Codable {
             status: self.status,
             progress: progress,
             startTime: self.startTime,
+            processingStartTime: self.processingStartTime,
             completionTime: self.completionTime,
             chunks: self.chunks,
             error: self.error
         )
     }
 
-    init(id: UUID, type: JobType, recordingPath: String, recordingName: String, modelName: String? = nil, status: JobProcessingStatus, progress: Double, startTime: Date, completionTime: Date?, chunks: [AudioChunk]?, error: String?) {
+    init(id: UUID, type: JobType, recordingPath: String, recordingName: String, modelName: String? = nil, status: JobProcessingStatus, progress: Double, startTime: Date, processingStartTime: Date? = nil, completionTime: Date?, chunks: [AudioChunk]?, error: String?) {
         self.id = id
         self.type = type
         self.recordingPath = recordingPath
@@ -94,6 +100,7 @@ struct ProcessingJob: Identifiable, Codable {
         self.status = status
         self.progress = progress
         self.startTime = startTime
+        self.processingStartTime = processingStartTime
         self.completionTime = completionTime
         self.chunks = chunks
         self.error = error
@@ -2430,12 +2437,15 @@ class BackgroundProcessingManager: ObservableObject {
         var reconciledCount = 0
 
         for job in activeJobs where job.status == .processing {
-            let timeSinceStart = now.timeIntervalSince(job.startTime)
+            // Use processingStartTime (when the job actually began processing) for timeout,
+            // falling back to startTime for jobs rehydrated from Core Data where it's unavailable.
+            let effectiveStart = job.processingStartTime ?? job.startTime
+            let timeSinceProcessingBegan = now.timeIntervalSince(effectiveStart)
             let isCurrentInProcess = currentJob?.id == job.id
             let hasExternalTask = externalTaskHandles[job.id] != nil
 
-            if timeSinceStart > processingTimeoutThreshold {
-                let timeoutMessage = "Job timed out after \(Int(timeSinceStart/60)) minutes"
+            if timeSinceProcessingBegan > processingTimeoutThreshold {
+                let timeoutMessage = "Job timed out after \(Int(timeSinceProcessingBegan/60)) minutes"
 
                 // Write the failure status first, before cancelling the task.
                 let failedJob = job.withStatus(.failed(timeoutMessage))
@@ -2458,7 +2468,7 @@ class BackgroundProcessingManager: ObservableObject {
             }
 
             // If no task is actively associated with this processing job, reconcile it out of active state.
-            if !isCurrentInProcess && !hasExternalTask && timeSinceStart > orphanedProcessingThreshold {
+            if !isCurrentInProcess && !hasExternalTask && timeSinceProcessingBegan > orphanedProcessingThreshold {
                 let interruptedJob = job.withStatus(.interrupted("Processing stopped unexpectedly"))
                 await updateJobInMemoryAndCoreData(interruptedJob)
                 reconciledCount += 1

--- a/BisonNotes AI/BisonNotes AI/BackgroundProcessingManager.swift
+++ b/BisonNotes AI/BisonNotes AI/BackgroundProcessingManager.swift
@@ -265,6 +265,7 @@ class BackgroundProcessingManager: ObservableObject {
     private var backgroundTaskID: UIBackgroundTaskIdentifier = .invalid
     private var backgroundTaskStartTime: Date?
     private var backgroundTimeMonitor: Task<Void, Never>?
+    private var staleJobMonitor: Task<Void, Never>?
     private let chunkingService = AudioFileChunkingService()
     private let performanceOptimizer = PerformanceOptimizer.shared
     private let enhancedFileManager = EnhancedFileManager.shared
@@ -281,6 +282,7 @@ class BackgroundProcessingManager: ObservableObject {
         setupNotifications()
         setupAppLifecycleObservers()
         setupPerformanceOptimization()
+        startStaleJobMonitoring()
         
         // Resume interrupted jobs and start processing queued jobs on initialization
         Task {
@@ -293,10 +295,23 @@ class BackgroundProcessingManager: ObservableObject {
     
     deinit {
         NotificationCenter.default.removeObserver(self)
+        staleJobMonitor?.cancel()
     }
     
     // MARK: - Performance Optimization Setup
     
+    private func startStaleJobMonitoring() {
+        staleJobMonitor?.cancel()
+        staleJobMonitor = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 60_000_000_000) // 60 seconds
+                if !Task.isCancelled {
+                    await cleanupStaleJobs()
+                }
+            }
+        }
+    }
+
     private func setupPerformanceOptimization() {
         // Start periodic optimization
         Task {
@@ -2027,7 +2042,9 @@ class BackgroundProcessingManager: ObservableObject {
         case "Queued":
             processingStatus = .queued
         case "Processing":
-            processingStatus = .processing
+            // A persisted "Processing" job means the previous app session ended before status was finalized.
+            // Mark as interrupted so it can be resumed instead of appearing permanently active.
+            processingStatus = .interrupted(jobEntry.error ?? "Recovered after app restart")
         case "Completed":
             processingStatus = .completed
         case "Failed":
@@ -2393,29 +2410,41 @@ class BackgroundProcessingManager: ObservableObject {
     
     // MARK: - Stale Job Cleanup
     
-    /// Cleans up jobs that have been stuck in processing state for too long
+    /// Reconciles jobs that are stuck in `processing` without a live task, or exceed timeout.
     func cleanupStaleJobs() async {
-        let staleThreshold: TimeInterval = 3600 // 1 hour
+        let processingTimeoutThreshold: TimeInterval = 3600 // 1 hour hard timeout
+        let orphanedProcessingThreshold: TimeInterval = 120 // 2 minute grace period
         let now = Date()
-        var cleanedCount = 0
-        
-        for job in activeJobs {
+        var reconciledCount = 0
+
+        for job in activeJobs where job.status == .processing {
             let timeSinceStart = now.timeIntervalSince(job.startTime)
-            
-            // Check if job is stuck in processing state for too long
-            if job.status == .processing && timeSinceStart > staleThreshold {
-                // Cleanup stale job silently
-                
+            let isCurrentInProcess = currentJob?.id == job.id
+            let hasExternalTask = externalTaskHandles[job.id] != nil
+
+            if timeSinceStart > processingTimeoutThreshold {
                 let failedJob = job.withStatus(.failed("Job timed out after \(Int(timeSinceStart/60)) minutes"))
                 await updateJobInMemoryAndCoreData(failedJob)
-                cleanedCount += 1
+                reconciledCount += 1
+                continue
+            }
+
+            // If no task is actively associated with this processing job, reconcile it out of active state.
+            if !isCurrentInProcess && !hasExternalTask && timeSinceStart > orphanedProcessingThreshold {
+                let interruptedJob = job.withStatus(.interrupted("Processing stopped unexpectedly"))
+                await updateJobInMemoryAndCoreData(interruptedJob)
+                reconciledCount += 1
             }
         }
-        
-        if cleanedCount > 0 {
-            // Update UI on main thread
-            await MainActor.run {
-                self.objectWillChange.send()
+
+        if reconciledCount > 0 {
+            print("🧹 Reconciled \(reconciledCount) stale/orphaned processing job(s)")
+            objectWillChange.send()
+
+            // Re-queue interrupted jobs after reconciliation and continue processing.
+            await resumeInterruptedJobs()
+            if currentJob == nil && activeJobs.contains(where: { $0.status == .queued }) {
+                await processNextJob()
             }
         }
     }

--- a/BisonNotes AI/BisonNotes AI/BackgroundProcessingManager.swift
+++ b/BisonNotes AI/BisonNotes AI/BackgroundProcessingManager.swift
@@ -266,6 +266,7 @@ class BackgroundProcessingManager: ObservableObject {
     private var backgroundTaskStartTime: Date?
     private var backgroundTimeMonitor: Task<Void, Never>?
     private var staleJobMonitor: Task<Void, Never>?
+    private var isCleaningUpStaleJobs = false
     private let chunkingService = AudioFileChunkingService()
     private let performanceOptimizer = PerformanceOptimizer.shared
     private let enhancedFileManager = EnhancedFileManager.shared
@@ -295,11 +296,13 @@ class BackgroundProcessingManager: ObservableObject {
     
     deinit {
         NotificationCenter.default.removeObserver(self)
-        staleJobMonitor?.cancel()
+        staleJobMonitor?.cancel() // Defensive: class is a singleton so deinit rarely fires
     }
     
     // MARK: - Performance Optimization Setup
     
+    /// Starts a periodic monitor that reconciles stale/orphaned processing jobs every 60s.
+    /// The initial 60s sleep is intentional — `init` already handles the first pass via `resumeInterruptedJobs()`.
     private func startStaleJobMonitoring() {
         staleJobMonitor?.cancel()
         staleJobMonitor = Task {
@@ -1805,7 +1808,7 @@ class BackgroundProcessingManager: ObservableObject {
     }
     
     /// Resume jobs that were interrupted due to background limitations
-    private func resumeInterruptedJobs() async {
+    private func resumeInterruptedJobs(notify: Bool = true) async {
         // Find interrupted jobs (using the new .interrupted status)
         let interruptedJobs = activeJobs.filter { $0.status.isInterrupted }
 
@@ -1870,13 +1873,13 @@ class BackgroundProcessingManager: ObservableObject {
             }
         }
 
-        if resumedCount > 0 {
+        if notify && resumedCount > 0 {
             await sendNotification(
                 title: "Jobs Resumed",
                 body: "Resumed \(resumedCount) interrupted job\(resumedCount == 1 ? "" : "s")."
             )
         }
-        if waitingCount > 0 {
+        if notify && waitingCount > 0 {
             await sendNotification(
                 title: "Jobs Waiting",
                 body: "\(waitingCount) job\(waitingCount == 1 ? "" : "s") waiting for engine availability."
@@ -2412,6 +2415,10 @@ class BackgroundProcessingManager: ObservableObject {
     
     /// Reconciles jobs that are stuck in `processing` without a live task, or exceed timeout.
     func cleanupStaleJobs() async {
+        guard !isCleaningUpStaleJobs else { return }
+        isCleaningUpStaleJobs = true
+        defer { isCleaningUpStaleJobs = false }
+
         let processingTimeoutThreshold: TimeInterval = 3600 // 1 hour hard timeout
         let orphanedProcessingThreshold: TimeInterval = 120 // 2 minute grace period
         let now = Date()
@@ -2423,6 +2430,16 @@ class BackgroundProcessingManager: ObservableObject {
             let hasExternalTask = externalTaskHandles[job.id] != nil
 
             if timeSinceStart > processingTimeoutThreshold {
+                // Cancel any live task handles before marking the job as failed,
+                // so the underlying work actually stops and can't overwrite state later.
+                if isCurrentInProcess {
+                    currentTaskHandle?.cancel()
+                    currentTaskHandle = nil
+                    currentJob = nil
+                }
+                if let externalTask = externalTaskHandles.removeValue(forKey: job.id) {
+                    externalTask.cancel()
+                }
                 let failedJob = job.withStatus(.failed("Job timed out after \(Int(timeSinceStart/60)) minutes"))
                 await updateJobInMemoryAndCoreData(failedJob)
                 reconciledCount += 1
@@ -2441,8 +2458,8 @@ class BackgroundProcessingManager: ObservableObject {
             print("🧹 Reconciled \(reconciledCount) stale/orphaned processing job(s)")
             objectWillChange.send()
 
-            // Re-queue interrupted jobs after reconciliation and continue processing.
-            await resumeInterruptedJobs()
+            // Re-queue interrupted jobs after reconciliation (suppress notifications from periodic monitor).
+            await resumeInterruptedJobs(notify: false)
             if currentJob == nil && activeJobs.contains(where: { $0.status == .queued }) {
                 await processNextJob()
             }

--- a/BisonNotes AI/BisonNotes AI/BackgroundProcessingManager.swift
+++ b/BisonNotes AI/BisonNotes AI/BackgroundProcessingManager.swift
@@ -656,8 +656,13 @@ class BackgroundProcessingManager: ObservableObject {
                 await updateFileMetadata(for: processingJob)
 
             } catch is CancellationError {
-                // Check if this was an interruption (background/termination) or user cancel
-                if let reason = cancellationReason {
+                // If the job was already moved to a terminal state (e.g., timed out by the
+                // stale job monitor), don't overwrite it — just clear the cancellation reason.
+                let currentStatus = activeJobs.first(where: { $0.id == nextJob.id })?.status
+                if let currentStatus, currentStatus.isTerminal {
+                    print("⏭️ Job already terminal (\(currentStatus.displayName)): \(nextJob.type.displayName) for \(nextJob.recordingName)")
+                    cancellationReason = nil
+                } else if let reason = cancellationReason {
                     let interruptedJob = processingJob.withStatus(.interrupted(reason))
                     await updateJob(interruptedJob)
                     print("⏸️ Job interrupted (\(reason)): \(nextJob.type.displayName) for \(nextJob.recordingName)")
@@ -2430,19 +2435,25 @@ class BackgroundProcessingManager: ObservableObject {
             let hasExternalTask = externalTaskHandles[job.id] != nil
 
             if timeSinceStart > processingTimeoutThreshold {
-                // Cancel any live task handles before marking the job as failed,
-                // so the underlying work actually stops and can't overwrite state later.
+                let timeoutMessage = "Job timed out after \(Int(timeSinceStart/60)) minutes"
+
+                // Write the failure status first, before cancelling the task.
+                let failedJob = job.withStatus(.failed(timeoutMessage))
+                await updateJobInMemoryAndCoreData(failedJob)
+                reconciledCount += 1
+
+                // Cancel live task handles. Set cancellationReason so the task's
+                // CancellationError catch block doesn't overwrite .failed with .cancelled.
+                // Keep currentJob/currentTaskHandle bound — the task's natural exit path
+                // (after the do/catch) will clear them and schedule the next queued job,
+                // preventing overlapping execution if cancellation takes time to propagate.
                 if isCurrentInProcess {
+                    cancellationReason = timeoutMessage
                     currentTaskHandle?.cancel()
-                    currentTaskHandle = nil
-                    currentJob = nil
                 }
                 if let externalTask = externalTaskHandles.removeValue(forKey: job.id) {
                     externalTask.cancel()
                 }
-                let failedJob = job.withStatus(.failed("Job timed out after \(Int(timeSinceStart/60)) minutes"))
-                await updateJobInMemoryAndCoreData(failedJob)
-                reconciledCount += 1
                 continue
             }
 


### PR DESCRIPTION
### Motivation
- On-device jobs could remain marked `Processing` indefinitely when the app/session ended or the processing task desynced, causing ghost "running" jobs in the UI. 
- We need periodic reconciliation so jobs are correctly marked finished/cancelled/failed/interrupted and can be resumed or cleaned up. 
- Preventing persisted `Processing` state from being treated as actively running after a restart avoids user confusion and stuck UI indicators. 

### Description
- Added a periodic stale-job monitor via a new `staleJobMonitor` and `startStaleJobMonitoring()` that runs every 60s and calls `cleanupStaleJobs()`, and cancel it in `deinit`. 
- Updated Core Data rehydration in `convertToProcessingJob(from:)` so persisted `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b358fe1064833199eee5e8c69f57af)