### PR TITLE
Add Apple Native summarization engine using Foundation Models

### DIFF
--- a/BisonNotes AI/BisonNotes AI/AISettingsView.swift
+++ b/BisonNotes AI/BisonNotes AI/AISettingsView.swift
@@ -143,7 +143,7 @@ final class AISettingsViewModel: ObservableObject {
             let selectedModel = OnDeviceLLMModelInfo.selectedModel
             return isEnabled && selectedModel.isDownloaded
         case .appleNative:
-            return AppleNativeEngine().isAvailable
+            return AppleNativeEngine.modelAvailable
         }
     }
 }
@@ -250,7 +250,7 @@ struct AISettingsView: View {
             let isModelReady = OnDeviceLLMDownloadManager.shared.isModelReady
             return isEnabled && isModelReady
         case .appleNative:
-            return AppleNativeEngine().isAvailable
+            return AppleNativeEngine.modelAvailable
         }
     }
 

--- a/BisonNotes AI/BisonNotes AI/AISettingsView.swift
+++ b/BisonNotes AI/BisonNotes AI/AISettingsView.swift
@@ -94,6 +94,8 @@ final class AISettingsViewModel: ObservableObject {
         case .onDeviceLLM:
             UserDefaults.standard.set(true, forKey: OnDeviceLLMModelInfo.SettingsKeys.enableOnDeviceLLM)
             print("🔧 Auto-enabled On-Device AI engine")
+        case .appleNative:
+            print("🔧 Selected Apple Native engine")
         }
 
         // Sync UserDefaults immediately
@@ -140,6 +142,8 @@ final class AISettingsViewModel: ObservableObject {
             let isEnabled = UserDefaults.standard.bool(forKey: OnDeviceLLMModelInfo.SettingsKeys.enableOnDeviceLLM)
             let selectedModel = OnDeviceLLMModelInfo.selectedModel
             return isEnabled && selectedModel.isDownloaded
+        case .appleNative:
+            return AppleNativeEngine().isAvailable
         }
     }
 }
@@ -245,6 +249,8 @@ struct AISettingsView: View {
             let isEnabled = UserDefaults.standard.bool(forKey: OnDeviceLLMModelInfo.SettingsKeys.enableOnDeviceLLM)
             let isModelReady = OnDeviceLLMDownloadManager.shared.isModelReady
             return isEnabled && isModelReady
+        case .appleNative:
+            return AppleNativeEngine().isAvailable
         }
     }
 
@@ -273,6 +279,8 @@ struct AISettingsView: View {
             return "Claude 4.5 Haiku"
         case .onDeviceLLM:
             return OnDeviceLLMModelInfo.selectedModel.displayName
+        case .appleNative:
+            return "Foundation Models"
         }
     }
     
@@ -544,8 +552,33 @@ private extension AISettingsView {
                     } else {
                         EmptyView()
                     }
+                case .appleNative:
+                    appleNativeConfigurationSection
                 }
             }
+        }
+    }
+
+    var appleNativeConfigurationSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Apple Native Configuration")
+                .font(.headline)
+                .padding(.horizontal, 24)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("This engine uses Apple's Foundation Models framework directly on-device.")
+                    .font(.body)
+                Text("No API key is required. Availability depends on OS version and Apple Intelligence support on the current device.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 16)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.blue.opacity(0.08))
+            )
+            .padding(.horizontal, 24)
         }
     }
 

--- a/BisonNotes AI/BisonNotes AI/AppleNativeEngine.swift
+++ b/BisonNotes AI/BisonNotes AI/AppleNativeEngine.swift
@@ -13,16 +13,22 @@ final class AppleNativeEngine: SummarizationEngine {
 
     var metadataName: String { "Apple Foundation Model" }
 
-    var isAvailable: Bool {
+    /// Static availability check so callers (e.g. AISettingsView) don't need to
+    /// instantiate the engine just to ask whether the device supports it.
+    static var modelAvailable: Bool {
         #if canImport(FoundationModels)
         if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
-            return true
+            return SystemLanguageModel.default.availability == .available
         }
         return false
         #else
         return false
         #endif
     }
+
+    var isAvailable: Bool { AppleNativeEngine.modelAvailable }
+
+    // MARK: - SummarizationEngine
 
     func generateSummary(from text: String, contentType: ContentType) async throws -> String {
         let prompt = """
@@ -32,18 +38,43 @@ final class AppleNativeEngine: SummarizationEngine {
     }
 
     func extractTasks(from text: String) async throws -> [TaskItem] {
-        let result = try await processComplete(text: text)
-        return result.tasks
+        let prompt = """
+        Extract personal and actionable tasks from the following text. \
+        Focus only on tasks that require action by the speaker. \
+        Return each task on its own line starting with a bullet (- or •). \
+        Avoid tasks about news, public figures, or world events.
+
+        Text:
+        \(text)
+        """
+        let response = try await askModel(prompt)
+        return parseTasksFromResponse(response)
     }
 
     func extractReminders(from text: String) async throws -> [ReminderItem] {
-        let result = try await processComplete(text: text)
-        return result.reminders
+        let prompt = """
+        Extract personal time-sensitive reminders from the following text. \
+        Focus on appointments, deadlines, or commitments that affect the speaker. \
+        Return each reminder on its own line starting with a bullet (- or •). \
+        Avoid reminders about news, public events, or world happenings.
+
+        Text:
+        \(text)
+        """
+        let response = try await askModel(prompt)
+        return parseRemindersFromResponse(response)
     }
 
     func extractTitles(from text: String) async throws -> [TitleItem] {
-        let result = try await processComplete(text: text)
-        return result.titles
+        let prompt = """
+        Suggest 3 short, descriptive titles for the following content. \
+        Return each title on its own line starting with a bullet (- or •).
+
+        Content:
+        \(text)
+        """
+        let response = try await askModel(prompt)
+        return parseTitlesFromResponse(response)
     }
 
     func classifyContent(_ text: String) async throws -> ContentType {
@@ -51,24 +82,29 @@ final class AppleNativeEngine: SummarizationEngine {
         if lowered.contains("meeting") || lowered.contains("agenda") {
             return .meeting
         }
-        if lowered.contains("task") || lowered.contains("todo") {
-            return .technical
+        if lowered.contains("journal") || lowered.contains("diary") {
+            return .personalJournal
         }
         return .general
     }
 
     func processComplete(text: String) async throws -> (summary: String, tasks: [TaskItem], reminders: [ReminderItem], titles: [TitleItem], contentType: ContentType) {
-        let summary = try await generateSummary(from: text, contentType: .general)
-        let contentType = try await classifyContent(text)
+        // Run all extractions concurrently to minimise total latency.
+        async let summaryResult = generateSummary(from: text, contentType: .general)
+        async let tasksResult = extractTasks(from: text)
+        async let remindersResult = extractReminders(from: text)
+        async let contentTypeResult = classifyContent(text)
 
-        return (
-            summary: summary,
-            tasks: [],
-            reminders: [],
-            titles: [TitleItem(text: summaryTitle(from: summary), confidence: 0.7, category: .general)],
-            contentType: contentType
-        )
+        let summary = try await summaryResult
+        let tasks = try await tasksResult
+        let reminders = try await remindersResult
+        let contentType = try await contentTypeResult
+
+        let titles = [TitleItem(text: summaryTitle(from: summary), confidence: 0.7, category: .general)]
+        return (summary: summary, tasks: tasks, reminders: reminders, titles: titles, contentType: contentType)
     }
+
+    // MARK: - Private helpers
 
     private func summaryTitle(from summary: String) -> String {
         let cleaned = summary
@@ -85,6 +121,9 @@ final class AppleNativeEngine: SummarizationEngine {
     private func askModel(_ prompt: String) async throws -> String {
         #if canImport(FoundationModels)
         if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
+            guard SystemLanguageModel.default.availability == .available else {
+                throw SummarizationError.aiServiceUnavailable(service: "Apple Foundation Models are not available on this device")
+            }
             let session = LanguageModelSession()
             let response = try await session.respond(to: prompt)
             let output = response.content.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -98,5 +137,39 @@ final class AppleNativeEngine: SummarizationEngine {
         #else
         throw SummarizationError.aiServiceUnavailable(service: "FoundationModels framework unavailable in this build")
         #endif
+    }
+
+    private func parseTasksFromResponse(_ response: String) -> [TaskItem] {
+        response.components(separatedBy: .newlines).compactMap { line in
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty,
+                  trimmed.hasPrefix("•") || trimmed.hasPrefix("-") || trimmed.hasPrefix("*") else { return nil }
+            let taskText = String(trimmed.dropFirst()).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !taskText.isEmpty else { return nil }
+            return TaskItem(text: taskText, priority: .medium, confidence: 0.8)
+        }
+    }
+
+    private func parseRemindersFromResponse(_ response: String) -> [ReminderItem] {
+        response.components(separatedBy: .newlines).compactMap { line in
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty,
+                  trimmed.hasPrefix("•") || trimmed.hasPrefix("-") || trimmed.hasPrefix("*") else { return nil }
+            let reminderText = String(trimmed.dropFirst()).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !reminderText.isEmpty else { return nil }
+            let timeRef = ReminderItem.TimeReference.fromReminderText(reminderText)
+            return ReminderItem(text: reminderText, timeReference: timeRef, urgency: .later, confidence: 0.8)
+        }
+    }
+
+    private func parseTitlesFromResponse(_ response: String) -> [TitleItem] {
+        response.components(separatedBy: .newlines).compactMap { line in
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty,
+                  trimmed.hasPrefix("•") || trimmed.hasPrefix("-") || trimmed.hasPrefix("*") else { return nil }
+            let titleText = String(trimmed.dropFirst()).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !titleText.isEmpty else { return nil }
+            return TitleItem(text: titleText, confidence: 0.8, category: .general)
+        }
     }
 }

--- a/BisonNotes AI/BisonNotes AI/AppleNativeEngine.swift
+++ b/BisonNotes AI/BisonNotes AI/AppleNativeEngine.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+/// Summarization engine that uses Apple's on-device Foundation Models runtime.
+final class AppleNativeEngine: SummarizationEngine {
+    let name: String = "Apple Native"
+    let engineType: String = "Apple Native"
+    let description: String = "On-device summaries powered by Apple's native Foundation Models framework."
+    let version: String = "1.0"
+
+    var metadataName: String { "Apple Foundation Model" }
+
+    var isAvailable: Bool {
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
+            return true
+        }
+        return false
+        #else
+        return false
+        #endif
+    }
+
+    func generateSummary(from text: String, contentType: ContentType) async throws -> String {
+        let prompt = """
+        Summarize the following transcript in 4-7 concise bullet points. Keep factual details, decisions, action owners, and deadlines if present. Transcript:\n\n\(text)
+        """
+        return try await askModel(prompt)
+    }
+
+    func extractTasks(from text: String) async throws -> [TaskItem] {
+        let result = try await processComplete(text: text)
+        return result.tasks
+    }
+
+    func extractReminders(from text: String) async throws -> [ReminderItem] {
+        let result = try await processComplete(text: text)
+        return result.reminders
+    }
+
+    func extractTitles(from text: String) async throws -> [TitleItem] {
+        let result = try await processComplete(text: text)
+        return result.titles
+    }
+
+    func classifyContent(_ text: String) async throws -> ContentType {
+        let lowered = text.lowercased()
+        if lowered.contains("meeting") || lowered.contains("agenda") {
+            return .meeting
+        }
+        if lowered.contains("task") || lowered.contains("todo") {
+            return .technical
+        }
+        return .general
+    }
+
+    func processComplete(text: String) async throws -> (summary: String, tasks: [TaskItem], reminders: [ReminderItem], titles: [TitleItem], contentType: ContentType) {
+        let summary = try await generateSummary(from: text, contentType: .general)
+        let contentType = try await classifyContent(text)
+
+        return (
+            summary: summary,
+            tasks: [],
+            reminders: [],
+            titles: [TitleItem(text: summaryTitle(from: summary), confidence: 0.7, category: .general)],
+            contentType: contentType
+        )
+    }
+
+    private func summaryTitle(from summary: String) -> String {
+        let cleaned = summary
+            .replacingOccurrences(of: "•", with: "")
+            .replacingOccurrences(of: "-", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if let firstLine = cleaned.components(separatedBy: .newlines).first, !firstLine.isEmpty {
+            return String(firstLine.prefix(80))
+        }
+        return "Summary"
+    }
+
+    private func askModel(_ prompt: String) async throws -> String {
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
+            let session = LanguageModelSession()
+            let response = try await session.respond(to: prompt)
+            let output = response.content.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            guard !output.isEmpty else {
+                throw SummarizationError.emptyResponse
+            }
+            return output
+        }
+        throw SummarizationError.aiServiceUnavailable(service: "Apple Native requires iOS/macOS/visionOS 26 or newer")
+        #else
+        throw SummarizationError.aiServiceUnavailable(service: "FoundationModels framework unavailable in this build")
+        #endif
+    }
+}

--- a/BisonNotes AI/BisonNotes AI/BackgroundProcessingManager.swift
+++ b/BisonNotes AI/BisonNotes AI/BackgroundProcessingManager.swift
@@ -1962,7 +1962,8 @@ class BackgroundProcessingManager: ObservableObject {
         let lowerEngine = engine.lowercased()
 
         // On-device engines
-        if lowerEngine.contains("on-device") || lowerEngine.contains("apple intelligence") {
+        if lowerEngine.contains("on-device") || lowerEngine.contains("apple intelligence") ||
+           lowerEngine.contains("apple native") || lowerEngine.contains("foundation") {
             return (true, nil)
         }
 

--- a/BisonNotes AI/BisonNotes AI/FutureAIEngines.swift
+++ b/BisonNotes AI/BisonNotes AI/FutureAIEngines.swift
@@ -1745,6 +1745,8 @@ class AIEngineFactory {
             return GoogleAIStudioEngine()
         case .onDeviceLLM:
             return OnDeviceLLMEngine()
+        case .appleNative:
+            return AppleNativeEngine()
         }
     }
     
@@ -1768,6 +1770,7 @@ enum AIEngineType: String, CaseIterable {
     case localLLM = "Ollama"
     case googleAIStudio = "Google AI Studio"
     case onDeviceLLM = "On-Device AI"
+    case appleNative = "Apple Native"
 
     /// Returns all available engine types based on device capabilities
     static var availableCases: [AIEngineType] {
@@ -1796,12 +1799,14 @@ enum AIEngineType: String, CaseIterable {
             return "Advanced AI-powered summaries using Google's Gemini models"
         case .onDeviceLLM:
             return "Privacy-focused on-device AI processing using local AI models"
+        case .appleNative:
+            return "Uses Apple's on-device Foundation Models runtime for private summaries"
         }
     }
 
     var isComingSoon: Bool {
         switch self {
-        case .localLLM, .openAI, .openAICompatible, .googleAIStudio, .mistralAI, .awsBedrock, .onDeviceLLM:
+        case .localLLM, .openAI, .openAICompatible, .googleAIStudio, .mistralAI, .awsBedrock, .onDeviceLLM, .appleNative:
             return false
         }
     }
@@ -1822,6 +1827,8 @@ enum AIEngineType: String, CaseIterable {
             return ["Google AI Studio API Key", "Internet Connection", "Usage Credits"]
         case .onDeviceLLM:
             return ["Downloaded LLM Model (~2 GB)", "No Internet Required", "A16+ Chip Recommended"]
+        case .appleNative:
+            return ["Apple Intelligence-supported device", "iOS/iPadOS/macOS/visionOS 26+", "No Internet Required"]
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Provide an on-device AI summarization option that uses Apple’s Foundation Models runtime to keep audio/text processing private and use native OS model capabilities.
- Expose the native engine as a selectable AI engine in settings so users can opt into Apple-backed summaries when the device/OS supports it.

### Description
- Added a new `AppleNativeEngine` that implements the `SummarizationEngine` protocol and generates summaries using `LanguageModelSession` + `respond(to:)`, with the model call and code guarded by `#if canImport(FoundationModels)` and runtime availability checks for iOS/macOS/visionOS 26+.
- Registered the engine by adding `AIEngineType.appleNative` and wiring `AppleNativeEngine()` into `AIEngineFactory` so it appears alongside other engines.
- Updated `AISettingsView` to support selecting Apple Native, to evaluate availability with `AppleNativeEngine().isAvailable`, to surface a version label (`"Foundation Models"`), and to render an `appleNativeConfigurationSection` describing availability and requirements.
- Implemented a simple prompt for summaries and lightweight `classifyContent`/`processComplete` behavior in the engine to produce a summary and title metadata; errors gracefully return `SummarizationError` when the framework or OS support is missing.

### Testing
- Attempted to run an Xcode build with `xcodebuild -project "BisonNotes AI.xcodeproj" -scheme "BisonNotes AI" -destination 'generic/platform=iOS' -quiet build`, but the command failed because `xcodebuild` is not available in this environment (`xcodebuild: command not found`).
- No other automated tests were executed in this environment; the implementation is guarded so it will compile and run only when built against an SDK that provides the `FoundationModels` framework and on devices/OS versions that meet the availability checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c49545bfc483318dd735cc6db4f958)