### PR TITLE
Clear app icon badge on activation to fix persistent notification bubble

### DIFF
--- a/BisonNotes AI/BisonNotes AI/AppDelegate.swift
+++ b/BisonNotes AI/BisonNotes AI/AppDelegate.swift
@@ -24,6 +24,22 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         return true
     }
 
+
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        // Ensure stale badge counts are cleared whenever the app becomes active.
+        Task {
+            let center = UNUserNotificationCenter.current()
+            do {
+                try await center.setBadgeCount(0)
+                application.applicationIconBadgeNumber = 0
+                center.removeAllDeliveredNotifications()
+                NSLog("✅ Cleared app icon badge and delivered notifications on app activation")
+            } catch {
+                NSLog("⚠️ Failed to clear app icon badge on activation: \(error)")
+            }
+        }
+    }
+
     // NOTE: application(_:open:url:options:) is intentionally NOT implemented.
     // In scene-based SwiftUI apps, iOS delivers file URLs through the scene delegate,
     // which SwiftUI translates to .onOpenURL on the WindowGroup. Implementing the

--- a/BisonNotes AI/BisonNotes AI/AppDelegate.swift
+++ b/BisonNotes AI/BisonNotes AI/AppDelegate.swift
@@ -26,16 +26,20 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
 
 
     func applicationDidBecomeActive(_ application: UIApplication) {
-        // Ensure stale badge counts are cleared whenever the app becomes active.
+        // Always clear the local badge immediately — this is unconditional so it
+        // succeeds even when notification authorization is denied and setBadgeCount throws.
+        application.applicationIconBadgeNumber = 0
+
+        // Best-effort async clear via the UNUserNotificationCenter API.
+        // Do NOT call removeAllDeliveredNotifications() here: actionable notifications
+        // such as RESUME_RECORDING may still be waiting for a user response, and
+        // clearing them would prevent the action from being delivered.
         Task {
-            let center = UNUserNotificationCenter.current()
             do {
-                try await center.setBadgeCount(0)
-                application.applicationIconBadgeNumber = 0
-                center.removeAllDeliveredNotifications()
-                NSLog("✅ Cleared app icon badge and delivered notifications on app activation")
+                try await UNUserNotificationCenter.current().setBadgeCount(0)
+                NSLog("✅ Cleared app icon badge on app activation")
             } catch {
-                NSLog("⚠️ Failed to clear app icon badge on activation: \(error)")
+                NSLog("⚠️ setBadgeCount failed on activation (badge already cleared via applicationIconBadgeNumber): \(error)")
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Stale app icon badges and delivered notifications can linger across lifecycle transitions, so the app should aggressively reset badge state when it becomes active to avoid a stuck red bubble.

### Description
- Added `applicationDidBecomeActive(_:)` to `AppDelegate.swift` which calls `UNUserNotificationCenter.current().setBadgeCount(0)`, sets `application.applicationIconBadgeNumber = 0`, and calls `removeAllDeliveredNotifications()` to clear lingering badge and delivered notifications.

### Testing
- Attempted to run project discovery with `xcodebuild -project 'BisonNotes AI/BisonNotes AI.xcodeproj' -list`, but the command failed because `xcodebuild` is not available in the execution environment (no further automated tests were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c52205a2288331a711467cac5eff9d)