### PR TITLE
Remove duplicate top labels from audio player sheet

### DIFF
--- a/BisonNotes AI/BisonNotes AI/Views/RecordingsListView.swift
+++ b/BisonNotes AI/BisonNotes AI/Views/RecordingsListView.swift
@@ -150,15 +150,8 @@ struct RecordingsListView: View {
                 LocationDetailView(locationData: locationData)
             }
             .sheet(item: $selectedRecordingForPlayer) { recording in
-                VStack {
-                    Text("Audio Player Test")
-                        .font(.title)
-                        .padding()
-                    Text("Recording: \(recording.name)")
-                        .padding()
-                    AudioPlayerView(recording: recording)
-                        .environmentObject(recorderVM)
-                }
+                AudioPlayerView(recording: recording)
+                    .environmentObject(recorderVM)
             }
             .sheet(isPresented: $showingCombineView) {
                 if let recordings = recordingsToCombine {


### PR DESCRIPTION
### Motivation
- Remove the temporary header text that displayed “Audio Player Test” and the duplicate “Recording:” line above the actual player so the audio player appears centered as intended.

### Description
- Replace the wrapper `VStack` in `RecordingsListView`'s sheet for `selectedRecordingForPlayer` with a direct presentation of `AudioPlayerView(recording:)` while retaining the `recorderVM` environment object, in `BisonNotes AI/BisonNotes AI/Views/RecordingsListView.swift`.

### Testing
- Ran automated static checks by searching the codebase (`rg`) to confirm the header lines were removed and validated that the sheet now presents only `AudioPlayerView`, with no automated unit/UI tests executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5863c37e88331b483b83a9d821b40)