### PR TITLE
Show “Preparing logs…” overlay while exporting diagnostic logs

### DIFF
--- a/BisonNotes AI/BisonNotes AI/LogExporter.swift
+++ b/BisonNotes AI/BisonNotes AI/LogExporter.swift
@@ -122,11 +122,18 @@ class LogEmailPresenter: NSObject, MFMailComposeViewControllerDelegate {
     static let shared = LogEmailPresenter()
 
     private var onDismiss: (() -> Void)?
+    private var onPresented: (() -> Void)?
 
-    func presentLogEmail(logFileURL: URL, onDismiss: @escaping () -> Void) {
+    func presentLogEmail(
+        logFileURL: URL,
+        onPresented: @escaping () -> Void = {},
+        onDismiss: @escaping () -> Void
+    ) {
+        self.onPresented = onPresented
         self.onDismiss = onDismiss
 
         guard let rootVC = Self.topViewController() else {
+            onPresented()
             onDismiss()
             return
         }
@@ -147,14 +154,20 @@ class LogEmailPresenter: NSObject, MFMailComposeViewControllerDelegate {
                 mail.addAttachmentData(data, mimeType: "text/plain", fileName: logFileURL.lastPathComponent)
             }
 
-            rootVC.present(mail, animated: true)
+            rootVC.present(mail, animated: true) { [weak self] in
+                self?.onPresented?()
+                self?.onPresented = nil
+            }
         } else {
             // Mail not configured — fall back to share sheet
             let activityVC = UIActivityViewController(activityItems: [logFileURL], applicationActivities: nil)
             activityVC.completionWithItemsHandler = { _, _, _, _ in
                 onDismiss()
             }
-            rootVC.present(activityVC, animated: true)
+            rootVC.present(activityVC, animated: true) { [weak self] in
+                self?.onPresented?()
+                self?.onPresented = nil
+            }
         }
     }
 
@@ -162,6 +175,7 @@ class LogEmailPresenter: NSObject, MFMailComposeViewControllerDelegate {
         controller.dismiss(animated: true) {
             self.onDismiss?()
             self.onDismiss = nil
+            self.onPresented = nil
         }
     }
 

--- a/BisonNotes AI/BisonNotes AI/LogExporter.swift
+++ b/BisonNotes AI/BisonNotes AI/LogExporter.swift
@@ -22,14 +22,17 @@ struct LogExporter {
     /// 1. Current session OSLog entries
     /// 2. Persistent error buffer (survives crashes)
     /// 3. MetricKit crash/hang diagnostics (if any)
-    static func exportLogs() throws -> URL {
+    static func exportLogs() async throws -> URL {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
 
         var sections = [String]()
 
         // ── Header ──
-        let device = UIDevice.current
+        // Capture UIDevice info on the main thread (UIKit is main-thread-only)
+        let (deviceModel, systemVersion) = await MainActor.run {
+            (UIDevice.current.model, UIDevice.current.systemVersion)
+        }
         let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
         let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"
         let previousCrash = AppLog.shared.previousSessionCrashed
@@ -37,7 +40,7 @@ struct LogExporter {
         let header = """
         BisonNotes AI Diagnostic Log
         App Version: \(appVersion) (\(buildNumber))
-        Device: \(device.model), iOS \(device.systemVersion)
+        Device: \(deviceModel), iOS \(systemVersion)
         Exported: \(formatter.string(from: Date()))
         Previous session crashed: \(previousCrash ? "YES" : "No")
         """
@@ -133,7 +136,8 @@ class LogEmailPresenter: NSObject, MFMailComposeViewControllerDelegate {
         self.onDismiss = onDismiss
 
         guard let rootVC = Self.topViewController() else {
-            onPresented()
+            // No root VC — signal failure via onDismiss only so the call site
+            // can distinguish "presented" from "failed to find a window".
             onDismiss()
             return
         }

--- a/BisonNotes AI/BisonNotes AI/Views/SettingsView.swift
+++ b/BisonNotes AI/BisonNotes AI/Views/SettingsView.swift
@@ -901,27 +901,28 @@ struct SettingsView: View {
                         Spacer()
                         Button(action: {
                             logExportError = nil
-                            isPreparingLogs = true
+                            withAnimation(.easeInOut(duration: 0.2)) { isPreparingLogs = true }
 
                             Task {
                                 do {
                                     let url = try await Task.detached(priority: .userInitiated) {
-                                        try LogExporter.exportLogs()
+                                        try await LogExporter.exportLogs()
                                     }.value
 
                                     await MainActor.run {
                                         LogEmailPresenter.shared.presentLogEmail(
                                             logFileURL: url,
                                             onPresented: {
-                                                isPreparingLogs = false
+                                                withAnimation(.easeInOut(duration: 0.2)) { isPreparingLogs = false }
                                             }
                                         ) {
-                                            // no-op
+                                            // Overlay is already gone; called on mail-sheet dismiss
+                                            withAnimation(.easeInOut(duration: 0.2)) { isPreparingLogs = false }
                                         }
                                     }
                                 } catch {
                                     await MainActor.run {
-                                        isPreparingLogs = false
+                                        withAnimation(.easeInOut(duration: 0.2)) { isPreparingLogs = false }
                                         logExportError = error.localizedDescription
                                     }
                                 }
@@ -940,6 +941,8 @@ struct SettingsView: View {
                                     .fill(Color.blue.opacity(0.1))
                             )
                         }
+                        .disabled(isPreparingLogs)
+                        .opacity(isPreparingLogs ? 0.5 : 1.0)
                     }
                     if let logExportError {
                         Text("Error: \(logExportError)")

--- a/BisonNotes AI/BisonNotes AI/Views/SettingsView.swift
+++ b/BisonNotes AI/BisonNotes AI/Views/SettingsView.swift
@@ -25,6 +25,7 @@ struct SettingsView: View {
     @State private var showingAcknowledgements = false
     @State private var showingTroubleshootingWarning = false
     @State private var logExportError: String?
+    @State private var isPreparingLogs = false
 
     @AppStorage("selectedTranscriptionEngine") private var selectedTranscriptionEngine: String = "On Device"
     @AppStorage("SelectedAIEngine") private var selectedAIEngine: String = "On-Device AI"
@@ -109,6 +110,30 @@ struct SettingsView: View {
         }
         .sheet(isPresented: $showingAcknowledgements) {
             AcknowledgementsView()
+        }
+        .overlay {
+            if isPreparingLogs {
+                ZStack {
+                    Color.black.opacity(0.25)
+                        .ignoresSafeArea()
+
+                    VStack(spacing: 12) {
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                        Text("Preparing logs…")
+                            .font(.headline)
+                            .foregroundColor(.primary)
+                    }
+                    .padding(.horizontal, 28)
+                    .padding(.vertical, 20)
+                    .background(
+                        RoundedRectangle(cornerRadius: 14)
+                            .fill(Color(.systemBackground))
+                            .shadow(color: Color.black.opacity(0.15), radius: 10, x: 0, y: 2)
+                    )
+                }
+                .transition(.opacity)
+            }
         }
     }
     
@@ -876,11 +901,30 @@ struct SettingsView: View {
                         Spacer()
                         Button(action: {
                             logExportError = nil
-                            do {
-                                let url = try LogExporter.exportLogs()
-                                LogEmailPresenter.shared.presentLogEmail(logFileURL: url) {}
-                            } catch {
-                                logExportError = error.localizedDescription
+                            isPreparingLogs = true
+
+                            Task {
+                                do {
+                                    let url = try await Task.detached(priority: .userInitiated) {
+                                        try LogExporter.exportLogs()
+                                    }.value
+
+                                    await MainActor.run {
+                                        LogEmailPresenter.shared.presentLogEmail(
+                                            logFileURL: url,
+                                            onPresented: {
+                                                isPreparingLogs = false
+                                            }
+                                        ) {
+                                            // no-op
+                                        }
+                                    }
+                                } catch {
+                                    await MainActor.run {
+                                        isPreparingLogs = false
+                                        logExportError = error.localizedDescription
+                                    }
+                                }
                             }
                         }) {
                             HStack {


### PR DESCRIPTION
### Motivation
- Users experienced a delay after tapping **Send Logs** with no feedback while the app generated log files, so an immediate visual indicator is needed.

### Description
- Add `@State private var isPreparingLogs` and a modal overlay in `SettingsView` that displays `Preparing logs…` with a `ProgressView` while logs are generated.
- Move log export off the main thread by calling `LogExporter.exportLogs()` inside `Task.detached` to avoid blocking the UI so the overlay can appear immediately.
- Extend `LogEmailPresenter.presentLogEmail` with an optional `onPresented` callback and invoke it from the UIKit `present(..., completion:)` so the preparing overlay is dismissed when the mail/share sheet is actually shown.
- Wire the `onPresented` callback from `SettingsView` to set `isPreparingLogs = false`, and surface export errors to the existing `logExportError` UI when export fails.

### Testing
- Attempted to run `xcodebuild -project 'BisonNotes AI/BisonNotes AI.xcodeproj' -list`, which failed in this environment because `xcodebuild` is not available.
- Inspected the updated sources `SettingsView.swift` and `LogExporter.swift` to verify the `isPreparingLogs` overlay, background export `Task.detached`, and the new `onPresented` callback are wired correctly.
- No automated unit or UI test suite was executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d70ce284788331ba0a53c27da9bf8f)