### PR TITLE
Enable editing recording title from Audio Player and Transcript editor

### DIFF
--- a/BisonNotes AI/BisonNotes AI/Views/AudioPlayerView.swift
+++ b/BisonNotes AI/BisonNotes AI/Views/AudioPlayerView.swift
@@ -37,32 +37,12 @@ struct AudioPlayerView: View {
                 .fontWeight(.bold)
                 .foregroundColor(.primary)
 
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Recording Title")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-
-                HStack(spacing: 8) {
-                    TextField("Enter title", text: $editableTitle)
-                        .textFieldStyle(.roundedBorder)
-                        .disabled(isUpdatingTitle)
-                        .onSubmit {
-                            updateRecordingTitle()
-                        }
-
-                    Button(action: updateRecordingTitle) {
-                        if isUpdatingTitle {
-                            ProgressView()
-                                .scaleEffect(0.8)
-                        } else {
-                            Text("Save")
-                                .fontWeight(.semibold)
-                        }
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(isUpdatingTitle || editableTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || editableTitle.trimmingCharacters(in: .whitespacesAndNewlines) == currentSavedTitle)
-                }
-            }
+            RecordingTitleEditorView(
+                title: $editableTitle,
+                savedTitle: currentSavedTitle,
+                isSaving: isUpdatingTitle,
+                onSave: updateRecordingTitle
+            )
             .frame(maxWidth: .infinity)
 
             Text("Date: \(recording.dateString)")
@@ -214,7 +194,7 @@ struct AudioPlayerView: View {
         let trimmedName = editableTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !isUpdatingTitle,
               !trimmedName.isEmpty,
-              trimmedName != recording.name else {
+              trimmedName != currentSavedTitle else {
             return
         }
 
@@ -228,6 +208,8 @@ struct AudioPlayerView: View {
 
         Task {
             do {
+                // Updates the display name only (recordingName field in Core Data).
+                // Physical audio file renaming is not performed here, consistent with SummaryDetailView.
                 try appCoordinator.coreDataManager.updateRecordingName(for: recordingId, newName: trimmedName)
 
                 await MainActor.run {
@@ -246,6 +228,45 @@ struct AudioPlayerView: View {
                     isUpdatingTitle = false
                     titleUpdateError = error.localizedDescription
                 }
+            }
+        }
+    }
+}
+
+/// Reusable title-editing row shared by AudioPlayerView and EditableTranscriptView.
+struct RecordingTitleEditorView: View {
+    @Binding var title: String
+    let savedTitle: String
+    let isSaving: Bool
+    let onSave: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Recording Title")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            HStack(spacing: 8) {
+                TextField("Enter title", text: $title)
+                    .textFieldStyle(.roundedBorder)
+                    .disabled(isSaving)
+                    .onSubmit { onSave() }
+
+                Button(action: onSave) {
+                    if isSaving {
+                        ProgressView()
+                            .scaleEffect(0.8)
+                    } else {
+                        Text("Save")
+                            .fontWeight(.semibold)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(
+                    isSaving ||
+                    title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+                    title.trimmingCharacters(in: .whitespacesAndNewlines) == savedTitle
+                )
             }
         }
     }

--- a/BisonNotes AI/BisonNotes AI/Views/AudioPlayerView.swift
+++ b/BisonNotes AI/BisonNotes AI/Views/AudioPlayerView.swift
@@ -11,9 +11,14 @@ import AVFoundation
 struct AudioPlayerView: View {
     let recording: AudioRecordingFile
     @EnvironmentObject var recorderVM: AudioRecorderViewModel
+    @EnvironmentObject var appCoordinator: AppDataCoordinator
     @Environment(\.dismiss) private var dismiss
     @State private var duration: TimeInterval = 0
     @State private var showingShareSheet = false
+    @State private var editableTitle: String = ""
+    @State private var currentSavedTitle: String = ""
+    @State private var isUpdatingTitle = false
+    @State private var titleUpdateError: String?
 
     var body: some View {
         VStack(spacing: 20) {
@@ -32,9 +37,33 @@ struct AudioPlayerView: View {
                 .fontWeight(.bold)
                 .foregroundColor(.primary)
 
-            Text("Recording: \(recording.name)")
-                .font(.title2)
-                .multilineTextAlignment(.center)
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Recording Title")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                HStack(spacing: 8) {
+                    TextField("Enter title", text: $editableTitle)
+                        .textFieldStyle(.roundedBorder)
+                        .disabled(isUpdatingTitle)
+                        .onSubmit {
+                            updateRecordingTitle()
+                        }
+
+                    Button(action: updateRecordingTitle) {
+                        if isUpdatingTitle {
+                            ProgressView()
+                                .scaleEffect(0.8)
+                        } else {
+                            Text("Save")
+                                .fontWeight(.semibold)
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(isUpdatingTitle || editableTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || editableTitle.trimmingCharacters(in: .whitespacesAndNewlines) == currentSavedTitle)
+                }
+            }
+            .frame(maxWidth: .infinity)
 
             Text("Date: \(recording.dateString)")
                 .font(.subheadline)
@@ -117,7 +146,19 @@ struct AudioPlayerView: View {
         }
         .onAppear {
             AppLog.shared.recording("AudioPlayerView appeared", level: .debug)
+            editableTitle = recording.name
+            currentSavedTitle = recording.name
             setupAudio()
+        }
+        .alert("Unable to Update Title", isPresented: Binding(
+            get: { titleUpdateError != nil },
+            set: { if !$0 { titleUpdateError = nil } }
+        )) {
+            Button("OK", role: .cancel) {
+                titleUpdateError = nil
+            }
+        } message: {
+            Text(titleUpdateError ?? "Unknown error")
         }
         .onDisappear {
             AppLog.shared.recording("AudioPlayerView disappeared", level: .debug)
@@ -167,5 +208,45 @@ struct AudioPlayerView: View {
         let minutes = Int(time) / 60
         let seconds = Int(time) % 60
         return String(format: "%d:%02d", minutes, seconds)
+    }
+
+    private func updateRecordingTitle() {
+        let trimmedName = editableTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !isUpdatingTitle,
+              !trimmedName.isEmpty,
+              trimmedName != recording.name else {
+            return
+        }
+
+        guard let recordingEntry = appCoordinator.getRecording(url: recording.url),
+              let recordingId = recordingEntry.id else {
+            titleUpdateError = "Could not find this recording in storage."
+            return
+        }
+
+        isUpdatingTitle = true
+
+        Task {
+            do {
+                try appCoordinator.coreDataManager.updateRecordingName(for: recordingId, newName: trimmedName)
+
+                await MainActor.run {
+                    isUpdatingTitle = false
+                    currentSavedTitle = trimmedName
+                    editableTitle = trimmedName
+                    NotificationCenter.default.post(
+                        name: NSNotification.Name("RecordingRenamed"),
+                        object: nil,
+                        userInfo: ["recordingId": recordingId, "newName": trimmedName]
+                    )
+                    AppLog.shared.recording("Updated recording title from AudioPlayerView to: \(trimmedName)")
+                }
+            } catch {
+                await MainActor.run {
+                    isUpdatingTitle = false
+                    titleUpdateError = error.localizedDescription
+                }
+            }
+        }
     }
 }

--- a/BisonNotes AI/BisonNotes AI/Views/TranscriptViews.swift
+++ b/BisonNotes AI/BisonNotes AI/Views/TranscriptViews.swift
@@ -1157,49 +1157,49 @@ struct EditableTranscriptView: View {
                     VStack(alignment: .leading, spacing: 16) {
                         recordingTitleEditor
 
-                    if editedSegments.isEmpty {
-                        VStack(spacing: 16) {
-                            Image(systemName: "doc.text")
-                                .font(.system(size: 48))
-                                .foregroundColor(.gray)
-                            Text("No transcript content available")
-                                .font(.title2)
-                                .foregroundColor(.secondary)
-                            Text("Transcript segments: \(editedSegments.count)")
-                                .font(.caption)
-                                .foregroundColor(.gray)
-                        }
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .padding()
-                    } else {
-                        LazyVStack(alignment: .leading, spacing: 16) {
-                            if !uniqueSpeakers.isEmpty {
-                                Button(action: { showingSpeakerEditor = true }) {
-                                    HStack {
-                                        Image(systemName: "person.2.fill")
-                                        Text("Edit Speakers (\(uniqueSpeakers.count))")
-                                        Spacer()
-                                        Image(systemName: "chevron.right")
-                                            .font(.caption)
+                        if editedSegments.isEmpty {
+                            VStack(spacing: 16) {
+                                Image(systemName: "doc.text")
+                                    .font(.system(size: 48))
+                                    .foregroundColor(.gray)
+                                Text("No transcript content available")
+                                    .font(.title2)
+                                    .foregroundColor(.secondary)
+                                Text("Transcript segments: \(editedSegments.count)")
+                                    .font(.caption)
+                                    .foregroundColor(.gray)
+                            }
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .padding()
+                        } else {
+                            LazyVStack(alignment: .leading, spacing: 16) {
+                                if !uniqueSpeakers.isEmpty {
+                                    Button(action: { showingSpeakerEditor = true }) {
+                                        HStack {
+                                            Image(systemName: "person.2.fill")
+                                            Text("Edit Speakers (\(uniqueSpeakers.count))")
+                                            Spacer()
+                                            Image(systemName: "chevron.right")
+                                                .font(.caption)
+                                        }
+                                        .font(.subheadline)
+                                        .fontWeight(.medium)
+                                        .padding(.horizontal, 16)
+                                        .padding(.vertical, 10)
+                                        .background(Color.purple.opacity(0.1))
+                                        .foregroundColor(.purple)
+                                        .cornerRadius(10)
                                     }
-                                    .font(.subheadline)
-                                    .fontWeight(.medium)
-                                    .padding(.horizontal, 16)
-                                    .padding(.vertical, 10)
-                                    .background(Color.purple.opacity(0.1))
-                                    .foregroundColor(.purple)
-                                    .cornerRadius(10)
+                                }
+
+                                ForEach(Array(editedSegments.enumerated()), id: \.offset) { index, segment in
+                                    TranscriptSegmentView(segment: $editedSegments[index], speakerMappings: speakerMappings)
                                 }
                             }
-
-                            ForEach(Array(editedSegments.enumerated()), id: \.offset) { index, segment in
-                                TranscriptSegmentView(segment: $editedSegments[index], speakerMappings: speakerMappings)
-                            }
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 12)
+                            .id("transcript-\(editedSegments.count)-\(editedSegments.first?.text.prefix(10).hashValue ?? 0)")
                         }
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 12)
-                        .id("transcript-\(editedSegments.count)-\(editedSegments.first?.text.prefix(10).hashValue ?? 0)")
-                    }
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -1329,32 +1329,12 @@ struct EditableTranscriptView: View {
     }
 
     private var recordingTitleEditor: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Recording Title")
-                .font(.caption)
-                .foregroundColor(.secondary)
-
-            HStack(spacing: 8) {
-                TextField("Enter title", text: $editableRecordingName)
-                    .textFieldStyle(.roundedBorder)
-                    .disabled(isUpdatingRecordingName)
-                    .onSubmit {
-                        renameRecordingFromTranscript()
-                    }
-
-                Button(action: renameRecordingFromTranscript) {
-                    if isUpdatingRecordingName {
-                        ProgressView()
-                            .scaleEffect(0.8)
-                    } else {
-                        Text("Save")
-                            .fontWeight(.semibold)
-                    }
-                }
-                .buttonStyle(.borderedProminent)
-                .disabled(isUpdatingRecordingName || editableRecordingName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || editableRecordingName.trimmingCharacters(in: .whitespacesAndNewlines) == savedRecordingName)
-            }
-        }
+        RecordingTitleEditorView(
+            title: $editableRecordingName,
+            savedTitle: savedRecordingName,
+            isSaving: isUpdatingRecordingName,
+            onSave: renameRecordingFromTranscript
+        )
         .padding(.horizontal, 16)
     }
 
@@ -1398,6 +1378,8 @@ struct EditableTranscriptView: View {
 
         Task {
             do {
+                // Updates the display name only (recordingName field in Core Data).
+                // Physical audio file renaming is not performed here, consistent with SummaryDetailView.
                 try appCoordinator.coreDataManager.updateRecordingName(for: recordingId, newName: trimmedName)
 
                 await MainActor.run {

--- a/BisonNotes AI/BisonNotes AI/Views/TranscriptViews.swift
+++ b/BisonNotes AI/BisonNotes AI/Views/TranscriptViews.swift
@@ -1116,6 +1116,10 @@ struct EditableTranscriptView: View {
     @State private var editedSegments: [TranscriptSegment]
     @State private var speakerMappings: [String: String]
     @State private var isRerunningTranscription = false
+    @State private var editableRecordingName: String
+    @State private var savedRecordingName: String
+    @State private var isUpdatingRecordingName = false
+    @State private var recordingRenameError: String?
     @State private var showingRerunAlert = false
     @State private var showingSaveSuccessAlert = false
     @State private var showingSaveErrorAlert = false
@@ -1139,6 +1143,9 @@ struct EditableTranscriptView: View {
         self.transcriptManager = transcriptManager
         self._editedSegments = State(initialValue: transcript.segments)
         self._speakerMappings = State(initialValue: transcript.speakerMappings)
+        let initialName = recording.recordingName ?? transcript.recordingName
+        self._editableRecordingName = State(initialValue: initialName)
+        self._savedRecordingName = State(initialValue: initialName)
     }
     
     var body: some View {
@@ -1147,6 +1154,9 @@ struct EditableTranscriptView: View {
                 
                 // Transcript Content
                 ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        recordingTitleEditor
+
                     if editedSegments.isEmpty {
                         VStack(spacing: 16) {
                             Image(systemName: "doc.text")
@@ -1189,6 +1199,7 @@ struct EditableTranscriptView: View {
                         .padding(.horizontal, 16)
                         .padding(.vertical, 12)
                         .id("transcript-\(editedSegments.count)-\(editedSegments.first?.text.prefix(10).hashValue ?? 0)")
+                    }
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -1268,6 +1279,16 @@ struct EditableTranscriptView: View {
             } message: {
                 Text(saveErrorMessage)
             }
+            .alert("Rename Failed", isPresented: Binding(
+                get: { recordingRenameError != nil },
+                set: { if !$0 { recordingRenameError = nil } }
+            )) {
+                Button("OK", role: .cancel) {
+                    recordingRenameError = nil
+                }
+            } message: {
+                Text(recordingRenameError ?? "Unknown error")
+            }
             .sheet(isPresented: $showingSpeakerEditor) {
                 SpeakerEditingView(
                     speakerIds: uniqueSpeakers,
@@ -1307,6 +1328,36 @@ struct EditableTranscriptView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
+    private var recordingTitleEditor: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Recording Title")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            HStack(spacing: 8) {
+                TextField("Enter title", text: $editableRecordingName)
+                    .textFieldStyle(.roundedBorder)
+                    .disabled(isUpdatingRecordingName)
+                    .onSubmit {
+                        renameRecordingFromTranscript()
+                    }
+
+                Button(action: renameRecordingFromTranscript) {
+                    if isUpdatingRecordingName {
+                        ProgressView()
+                            .scaleEffect(0.8)
+                    } else {
+                        Text("Save")
+                            .fontWeight(.semibold)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isUpdatingRecordingName || editableRecordingName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || editableRecordingName.trimmingCharacters(in: .whitespacesAndNewlines) == savedRecordingName)
+            }
+        }
+        .padding(.horizontal, 16)
+    }
+
     private func saveTranscript() -> Bool {
         guard let recordingId = recording.id else {
             AppLog.shared.transcription("Cannot save transcript: missing recording ID", level: .error)
@@ -1331,6 +1382,42 @@ struct EditableTranscriptView: View {
             AppLog.shared.transcription("Failed to save edited transcript", level: .error)
             saveErrorMessage = "We couldn't save your transcript changes. Please try again."
             return false
+        }
+    }
+
+    private func renameRecordingFromTranscript() {
+        let trimmedName = editableRecordingName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !isUpdatingRecordingName,
+              !trimmedName.isEmpty,
+              trimmedName != savedRecordingName,
+              let recordingId = recording.id else {
+            return
+        }
+
+        isUpdatingRecordingName = true
+
+        Task {
+            do {
+                try appCoordinator.coreDataManager.updateRecordingName(for: recordingId, newName: trimmedName)
+
+                await MainActor.run {
+                    isUpdatingRecordingName = false
+                    savedRecordingName = trimmedName
+                    editableRecordingName = trimmedName
+                    NotificationCenter.default.post(
+                        name: NSNotification.Name("RecordingRenamed"),
+                        object: nil,
+                        userInfo: ["recordingId": recordingId, "newName": trimmedName]
+                    )
+                    AppLog.shared.transcription("Updated recording title from transcript editor to: \(trimmedName)")
+                }
+            } catch {
+                await MainActor.run {
+                    isUpdatingRecordingName = false
+                    recordingRenameError = error.localizedDescription
+                }
+                AppLog.shared.transcription("Failed to update recording title from transcript editor: \(error)", level: .error)
+            }
         }
     }
     


### PR DESCRIPTION
### Motivation
- Users need the ability to rename a recording from the audio player or transcript editor and have that name stay in sync with the existing summary/title system.

### Description
- Added an inline `TextField` + Save button to `AudioPlayerView` to allow editing the recording title and added UI state for loading and errors in `BisonNotes AI/BisonNotes AI/Views/AudioPlayerView.swift`.
- Added a recording title editor at the top of the transcript editor in `EditableTranscriptView` with save/loading/error UI in `BisonNotes AI/BisonNotes AI/Views/TranscriptViews.swift`.
- Both flows resolve the Core Data `RecordingEntry` via `AppDataCoordinator`, persist the new name using `CoreDataManager.updateRecordingName(for:newName:)`, and post a `NotificationCenter` `RecordingRenamed` notification so other views refresh and remain synchronized.
- Local state (editable/saved title and is-updating flags) and user-facing alerts were added to surface errors and prevent duplicate/empty saves.

### Testing
- Attempted to run a project build with `xcodebuild -project 'BisonNotes AI/BisonNotes AI.xcodeproj' -scheme 'BisonNotes AI' -destination 'generic/platform=iOS' -quiet build`, but `xcodebuild` is not available in this environment so the build could not be executed.
- No automated test runs completed in this environment; manual UI validation should be performed in Xcode to verify save, loading state, error handling, and cross-view synchronization after `RecordingRenamed` is posted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfabdf2730833193701e1f07ffdc07)