### PR TITLE
Add attachments & user notes to summaries with in‑app preview and export integration

### DIFF
--- a/BisonNotes AI/BisonNotes AI/Models/EnhancedSummaryData.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/EnhancedSummaryData.swift
@@ -281,6 +281,33 @@ struct TitleItem: Codable, Identifiable, Equatable, Hashable, Sendable {
     }
 }
 
+// MARK: - Summary Attachments
+
+struct SummaryAttachment: Codable, Identifiable, Equatable, Hashable, Sendable {
+    let id: UUID
+    let fileName: String
+    let storedFileName: String
+    let contentType: String?
+    let fileSize: Int64
+    let createdAt: Date
+
+    init(
+        id: UUID = UUID(),
+        fileName: String,
+        storedFileName: String,
+        contentType: String? = nil,
+        fileSize: Int64,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.fileName = fileName
+        self.storedFileName = storedFileName
+        self.contentType = contentType
+        self.fileSize = fileSize
+        self.createdAt = createdAt
+    }
+}
+
 // MARK: - Enhanced Summary Data
 
 public struct EnhancedSummaryData: Codable, Identifiable, Sendable {
@@ -296,6 +323,8 @@ public struct EnhancedSummaryData: Codable, Identifiable, Sendable {
     let tasks: [TaskItem]
     let reminders: [ReminderItem]
     let titles: [TitleItem]
+    let attachments: [SummaryAttachment]
+    let userNotes: String?
     
     // Metadata
     let contentType: ContentType
@@ -324,7 +353,7 @@ public struct EnhancedSummaryData: Codable, Identifiable, Sendable {
     }
     
     // Legacy initializer for backward compatibility
-    init(recordingURL: URL, recordingName: String, recordingDate: Date, summary: String, tasks: [TaskItem] = [], reminders: [ReminderItem] = [], titles: [TitleItem] = [], contentType: ContentType = .general, aiEngine: String = "Unknown", aiModel: String, originalLength: Int, processingTime: TimeInterval = 0) {
+    init(recordingURL: URL, recordingName: String, recordingDate: Date, summary: String, tasks: [TaskItem] = [], reminders: [ReminderItem] = [], titles: [TitleItem] = [], attachments: [SummaryAttachment] = [], userNotes: String? = nil, contentType: ContentType = .general, aiEngine: String = "Unknown", aiModel: String, originalLength: Int, processingTime: TimeInterval = 0) {
         self.id = UUID()
         self.recordingId = nil
         self.transcriptId = nil
@@ -335,6 +364,8 @@ public struct EnhancedSummaryData: Codable, Identifiable, Sendable {
         self.tasks = tasks.sorted { $0.priority.sortOrder < $1.priority.sortOrder }
         self.reminders = reminders.sorted { $0.urgency.sortOrder < $1.urgency.sortOrder }
         self.titles = titles.sorted { $0.confidence > $1.confidence }
+        self.attachments = attachments
+        self.userNotes = userNotes
         self.contentType = contentType
         self.aiEngine = aiEngine
         self.aiModel = aiModel
@@ -353,7 +384,7 @@ public struct EnhancedSummaryData: Codable, Identifiable, Sendable {
     }
     
     // New initializer for unified architecture
-    init(recordingId: UUID, transcriptId: UUID? = nil, recordingURL: URL, recordingName: String, recordingDate: Date, summary: String, tasks: [TaskItem] = [], reminders: [ReminderItem] = [], titles: [TitleItem] = [], contentType: ContentType = .general, aiEngine: String = "Unknown", aiModel: String, originalLength: Int, processingTime: TimeInterval = 0) {
+    init(recordingId: UUID, transcriptId: UUID? = nil, recordingURL: URL, recordingName: String, recordingDate: Date, summary: String, tasks: [TaskItem] = [], reminders: [ReminderItem] = [], titles: [TitleItem] = [], attachments: [SummaryAttachment] = [], userNotes: String? = nil, contentType: ContentType = .general, aiEngine: String = "Unknown", aiModel: String, originalLength: Int, processingTime: TimeInterval = 0) {
         self.id = UUID()
         self.recordingId = recordingId
         self.transcriptId = transcriptId
@@ -364,6 +395,8 @@ public struct EnhancedSummaryData: Codable, Identifiable, Sendable {
         self.tasks = tasks.sorted { $0.priority.sortOrder < $1.priority.sortOrder }
         self.reminders = reminders.sorted { $0.urgency.sortOrder < $1.urgency.sortOrder }
         self.titles = titles.sorted { $0.confidence > $1.confidence }
+        self.attachments = attachments
+        self.userNotes = userNotes
         self.contentType = contentType
         self.aiEngine = aiEngine
         self.aiModel = aiModel
@@ -382,7 +415,7 @@ public struct EnhancedSummaryData: Codable, Identifiable, Sendable {
     }
     
     // Initializer for Core Data conversion that preserves the original ID
-    init(id: UUID, recordingId: UUID, transcriptId: UUID? = nil, recordingURL: URL, recordingName: String, recordingDate: Date, summary: String, tasks: [TaskItem] = [], reminders: [ReminderItem] = [], titles: [TitleItem] = [], contentType: ContentType = .general, aiEngine: String = "Unknown", aiModel: String, originalLength: Int, processingTime: TimeInterval = 0, generatedAt: Date? = nil, version: Int = 1, wordCount: Int? = nil, compressionRatio: Double? = nil, confidence: Double? = nil) {
+    init(id: UUID, recordingId: UUID, transcriptId: UUID? = nil, recordingURL: URL, recordingName: String, recordingDate: Date, summary: String, tasks: [TaskItem] = [], reminders: [ReminderItem] = [], titles: [TitleItem] = [], attachments: [SummaryAttachment] = [], userNotes: String? = nil, contentType: ContentType = .general, aiEngine: String = "Unknown", aiModel: String, originalLength: Int, processingTime: TimeInterval = 0, generatedAt: Date? = nil, version: Int = 1, wordCount: Int? = nil, compressionRatio: Double? = nil, confidence: Double? = nil) {
         self.id = id
         self.recordingId = recordingId
         self.transcriptId = transcriptId
@@ -393,6 +426,8 @@ public struct EnhancedSummaryData: Codable, Identifiable, Sendable {
         self.tasks = tasks.sorted { $0.priority.sortOrder < $1.priority.sortOrder }
         self.reminders = reminders.sorted { $0.urgency.sortOrder < $1.urgency.sortOrder }
         self.titles = titles.sorted { $0.confidence > $1.confidence }
+        self.attachments = attachments
+        self.userNotes = userNotes
         self.contentType = contentType
         self.aiEngine = aiEngine
         self.aiModel = aiModel

--- a/BisonNotes AI/BisonNotes AI/Models/EnhancedSummaryData.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/EnhancedSummaryData.swift
@@ -448,9 +448,46 @@ public struct EnhancedSummaryData: Codable, Identifiable, Sendable {
     var formattedCompressionRatio: String {
         return String(format: "%.1f%%", compressionRatio * 100)
     }
-    
+
     var formattedProcessingTime: String {
         return String(format: "%.1fs", processingTime)
+    }
+
+    // Custom decoder so that legacy serialized summaries (which lack the
+    // `attachments` / `userNotes` keys) still decode successfully instead of
+    // throwing a keyNotFound error.
+    private enum CodingKeys: String, CodingKey {
+        case id, recordingId, transcriptId, recordingURL, recordingName, recordingDate
+        case summary, tasks, reminders, titles, attachments, userNotes
+        case contentType, aiEngine, aiModel, generatedAt, version
+        case wordCount, originalLength, compressionRatio, confidence, processingTime
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(UUID.self, forKey: .id)
+        recordingId = try c.decodeIfPresent(UUID.self, forKey: .recordingId)
+        transcriptId = try c.decodeIfPresent(UUID.self, forKey: .transcriptId)
+        recordingURL = try c.decode(URL.self, forKey: .recordingURL)
+        recordingName = try c.decode(String.self, forKey: .recordingName)
+        recordingDate = try c.decode(Date.self, forKey: .recordingDate)
+        summary = try c.decode(String.self, forKey: .summary)
+        tasks = try c.decode([TaskItem].self, forKey: .tasks)
+        reminders = try c.decode([ReminderItem].self, forKey: .reminders)
+        titles = try c.decode([TitleItem].self, forKey: .titles)
+        // New fields — fall back gracefully so legacy stored summaries still load.
+        attachments = try c.decodeIfPresent([SummaryAttachment].self, forKey: .attachments) ?? []
+        userNotes = try c.decodeIfPresent(String.self, forKey: .userNotes)
+        contentType = try c.decode(ContentType.self, forKey: .contentType)
+        aiEngine = try c.decode(String.self, forKey: .aiEngine)
+        aiModel = try c.decode(String.self, forKey: .aiModel)
+        generatedAt = try c.decode(Date.self, forKey: .generatedAt)
+        version = try c.decode(Int.self, forKey: .version)
+        wordCount = try c.decode(Int.self, forKey: .wordCount)
+        originalLength = try c.decode(Int.self, forKey: .originalLength)
+        compressionRatio = try c.decode(Double.self, forKey: .compressionRatio)
+        confidence = try c.decode(Double.self, forKey: .confidence)
+        processingTime = try c.decode(TimeInterval.self, forKey: .processingTime)
     }
 }
 

--- a/BisonNotes AI/BisonNotes AI/Models/SummaryAttachmentStore.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/SummaryAttachmentStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UniformTypeIdentifiers
 
 struct SummarySupplementalData: Codable, Sendable {
     var userNotes: String?
@@ -47,11 +48,13 @@ final class SummaryAttachmentStore {
         let attributes = try? fileManager.attributesOfItem(atPath: destinationURL.path)
         let fileSize = (attributes?[.size] as? NSNumber)?.int64Value ?? 0
 
+        let contentType = UTType(filenameExtension: sourceURL.pathExtension)?.identifier
+
         let attachment = SummaryAttachment(
             id: id,
             fileName: fileName,
             storedFileName: storedFileName,
-            contentType: nil,
+            contentType: contentType,
             fileSize: fileSize,
             createdAt: Date()
         )
@@ -77,8 +80,15 @@ final class SummaryAttachmentStore {
     func saveUserNotes(_ notes: String?, summaryId: UUID) throws {
         var supplemental = load(for: summaryId)
         let trimmed = notes?.trimmingCharacters(in: .whitespacesAndNewlines)
-        supplemental.userNotes = (trimmed?.isEmpty == true) ? nil : notes
+        supplemental.userNotes = (trimmed?.isEmpty == true) ? nil : trimmed
         try save(supplemental, summaryId: summaryId)
+    }
+
+    func deleteAll(for summaryId: UUID) throws {
+        let dir = storageDirectory(for: summaryId)
+        if fileManager.fileExists(atPath: dir.path) {
+            try fileManager.removeItem(at: dir)
+        }
     }
 
     func fileURL(for attachment: SummaryAttachment, summaryId: UUID) -> URL {

--- a/BisonNotes AI/BisonNotes AI/Models/SummaryAttachmentStore.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/SummaryAttachmentStore.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+struct SummarySupplementalData: Codable, Sendable {
+    var userNotes: String?
+    var attachments: [SummaryAttachment]
+
+    static let empty = SummarySupplementalData(userNotes: nil, attachments: [])
+}
+
+final class SummaryAttachmentStore {
+    static let shared = SummaryAttachmentStore()
+
+    private let fileManager = FileManager.default
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    private init() {
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    }
+
+    func load(for summaryId: UUID) -> SummarySupplementalData {
+        let metadataURL = metadataFileURL(for: summaryId)
+        guard let data = try? Data(contentsOf: metadataURL),
+              let decoded = try? decoder.decode(SummarySupplementalData.self, from: data) else {
+            return .empty
+        }
+        return decoded
+    }
+
+    @discardableResult
+    func addAttachment(from sourceURL: URL, summaryId: UUID) throws -> SummaryAttachment {
+        let fileName = sourceURL.lastPathComponent
+        let id = UUID()
+        let destinationFolder = attachmentsDirectory(for: summaryId)
+        try fileManager.createDirectory(at: destinationFolder, withIntermediateDirectories: true)
+
+        let sanitizedName = sanitizeFileName(fileName)
+        let storedFileName = "\(id.uuidString)_\(sanitizedName)"
+        let destinationURL = destinationFolder.appendingPathComponent(storedFileName)
+
+        if fileManager.fileExists(atPath: destinationURL.path) {
+            try fileManager.removeItem(at: destinationURL)
+        }
+
+        try fileManager.copyItem(at: sourceURL, to: destinationURL)
+
+        let attributes = try? fileManager.attributesOfItem(atPath: destinationURL.path)
+        let fileSize = (attributes?[.size] as? NSNumber)?.int64Value ?? 0
+
+        let attachment = SummaryAttachment(
+            id: id,
+            fileName: fileName,
+            storedFileName: storedFileName,
+            contentType: nil,
+            fileSize: fileSize,
+            createdAt: Date()
+        )
+
+        var supplemental = load(for: summaryId)
+        supplemental.attachments.insert(attachment, at: 0)
+        try save(supplemental, summaryId: summaryId)
+
+        return attachment
+    }
+
+    func removeAttachment(_ attachment: SummaryAttachment, summaryId: UUID) throws {
+        let fileURL = fileURL(for: attachment, summaryId: summaryId)
+        if fileManager.fileExists(atPath: fileURL.path) {
+            try fileManager.removeItem(at: fileURL)
+        }
+
+        var supplemental = load(for: summaryId)
+        supplemental.attachments.removeAll { $0.id == attachment.id }
+        try save(supplemental, summaryId: summaryId)
+    }
+
+    func saveUserNotes(_ notes: String?, summaryId: UUID) throws {
+        var supplemental = load(for: summaryId)
+        let trimmed = notes?.trimmingCharacters(in: .whitespacesAndNewlines)
+        supplemental.userNotes = (trimmed?.isEmpty == true) ? nil : notes
+        try save(supplemental, summaryId: summaryId)
+    }
+
+    func fileURL(for attachment: SummaryAttachment, summaryId: UUID) -> URL {
+        attachmentsDirectory(for: summaryId).appendingPathComponent(attachment.storedFileName)
+    }
+
+    private func save(_ supplemental: SummarySupplementalData, summaryId: UUID) throws {
+        let directory = storageDirectory(for: summaryId)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        let metadataURL = metadataFileURL(for: summaryId)
+        let data = try encoder.encode(supplemental)
+        try data.write(to: metadataURL, options: .atomic)
+    }
+
+    private func rootDirectory() -> URL {
+        let documents = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first ?? fileManager.temporaryDirectory
+        return documents.appendingPathComponent("SummaryAttachments", isDirectory: true)
+    }
+
+    private func storageDirectory(for summaryId: UUID) -> URL {
+        rootDirectory().appendingPathComponent(summaryId.uuidString, isDirectory: true)
+    }
+
+    private func attachmentsDirectory(for summaryId: UUID) -> URL {
+        storageDirectory(for: summaryId).appendingPathComponent("files", isDirectory: true)
+    }
+
+    private func metadataFileURL(for summaryId: UUID) -> URL {
+        storageDirectory(for: summaryId).appendingPathComponent("metadata.json")
+    }
+
+    private func sanitizeFileName(_ fileName: String) -> String {
+        let invalidCharacters = CharacterSet(charactersIn: "\\/:*?\"<>|")
+        return fileName.components(separatedBy: invalidCharacters).joined(separator: "_")
+    }
+}

--- a/BisonNotes AI/BisonNotes AI/Services/PDFExportService.swift
+++ b/BisonNotes AI/BisonNotes AI/Services/PDFExportService.swift
@@ -133,6 +133,21 @@ class PDFExportService {
                 exportDate: exportDate
             )
 
+            if let notes = summaryData.userNotes?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !notes.isEmpty {
+                currentY = drawUserNotesSection(
+                    notes,
+                    at: currentY,
+                    contentWidth: contentWidth,
+                    margins: margins,
+                    context: context,
+                    pageSize: pageSize,
+                    contentBottom: contentBottom,
+                    pageNumber: &pageNumber,
+                    exportDate: exportDate
+                )
+            }
+
             // Tasks
             if !summaryData.tasks.isEmpty {
                 currentY = drawTasksSection(
@@ -573,6 +588,53 @@ class PDFExportService {
         }
 
         return currentY + 10
+    }
+
+    private func drawUserNotesSection(
+        _ notes: String,
+        at y: CGFloat,
+        contentWidth: CGFloat,
+        margins: UIEdgeInsets,
+        context: UIGraphicsPDFRendererContext,
+        pageSize: CGSize,
+        contentBottom: CGFloat,
+        pageNumber: inout Int,
+        exportDate: Date
+    ) -> CGFloat {
+        var currentY = y
+
+        currentY = checkAndStartNewPageWithBranding(
+            currentY: currentY,
+            requiredHeight: 80,
+            pageSize: pageSize,
+            margins: margins,
+            context: context,
+            contentBottom: contentBottom,
+            pageNumber: &pageNumber,
+            exportDate: exportDate
+        )
+
+        currentY = drawSectionTitle("User Notes", at: currentY, contentWidth: contentWidth, margins: margins, context: context)
+
+        let attributed = SummaryExportFormatter.attributedSummary(
+            for: notes,
+            baseFontSize: 12,
+            textColor: .black
+        )
+
+        currentY = drawAttributedSummary(
+            attributed,
+            at: currentY,
+            contentWidth: contentWidth,
+            margins: margins,
+            context: context,
+            pageSize: pageSize,
+            contentBottom: contentBottom,
+            pageNumber: &pageNumber,
+            exportDate: exportDate
+        )
+
+        return currentY + 12
     }
 
     private func drawRemindersSection(

--- a/BisonNotes AI/BisonNotes AI/Services/RTFExportService.swift
+++ b/BisonNotes AI/BisonNotes AI/Services/RTFExportService.swift
@@ -55,6 +55,7 @@ final class RTFExportService {
             }
 
             appendSummarySection(for: summaryData, to: document)
+            appendNotesSection(for: summaryData, to: document)
 
             // Always include sections even if empty to match PDF export quality
             if !summaryData.tasks.isEmpty {
@@ -316,6 +317,23 @@ final class RTFExportService {
         document.append(withSpacing)
     }
 
+    private func appendNotesSection(for summaryData: EnhancedSummaryData, to document: NSMutableAttributedString) {
+        guard let notes = summaryData.userNotes?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !notes.isEmpty else {
+            return
+        }
+
+        appendSectionTitle("User Notes", to: document)
+        let attributed = SummaryExportFormatter.attributedSummary(
+            for: notes,
+            baseFontSize: 12,
+            textColor: .black
+        )
+        let withSpacing = NSMutableAttributedString(attributedString: attributed)
+        withSpacing.append(NSAttributedString(string: "\n\n"))
+        document.append(withSpacing)
+    }
+
     private func appendTasksSection(tasks: [TaskItem], to document: NSMutableAttributedString) {
         appendSectionTitle("Tasks (\(tasks.count))", to: document)
 
@@ -541,4 +559,3 @@ final class RTFExportService {
         document.append(list)
     }
 }
-

--- a/BisonNotes AI/BisonNotes AI/SummaryDetailView.swift
+++ b/BisonNotes AI/BisonNotes AI/SummaryDetailView.swift
@@ -6,6 +6,7 @@ import UIKit
 import LinkPresentation
 import UniformTypeIdentifiers
 import PDFKit
+import QuickLook
 
 private actor SummaryGeocodeCache {
     enum Entry: Sendable {
@@ -65,11 +66,14 @@ struct SummaryDetailView: View {
     @State private var attachmentError: String?
     @State private var attachments: [SummaryAttachment] = []
     @State private var noteDraft: String = ""
+    @State private var isLoadingSupplemental = false
+    @State private var noteSaveTask: Task<Void, Never>?
     @State private var showingTextAttachment = false
     @State private var showingPDFAttachment = false
     @State private var selectedAttachmentName: String = ""
     @State private var selectedAttachmentText: String = ""
     @State private var selectedAttachmentPDFURL: URL?
+    @State private var selectedAttachmentGenericURL: URL?
 
     private enum ExportFormat {
         case pdf
@@ -350,6 +354,7 @@ struct SummaryDetailView: View {
                 }
             }
         }
+        .quickLookPreview($selectedAttachmentGenericURL)
         .alert("Attachment Error", isPresented: .constant(attachmentError != nil)) {
             Button("OK") {
                 attachmentError = nil
@@ -914,7 +919,13 @@ struct SummaryDetailView: View {
                     .background(Color(.systemGray6))
                     .clipShape(RoundedRectangle(cornerRadius: 8))
                     .onChange(of: noteDraft) { _, _ in
-                        saveUserNotes()
+                        guard !isLoadingSupplemental else { return }
+                        noteSaveTask?.cancel()
+                        noteSaveTask = Task {
+                            try? await Task.sleep(for: .milliseconds(500))
+                            guard !Task.isCancelled else { return }
+                            saveUserNotes()
+                        }
                     }
             }
 
@@ -1207,6 +1218,9 @@ struct SummaryDetailView: View {
 
         Task {
             do {
+                // Clean up attachment files before removing the Core Data entry.
+                try? SummaryAttachmentStore.shared.deleteAll(for: summaryData.id)
+
                 // Delete the summary locally and from iCloud
                 try await appCoordinator.deleteSummary(id: summaryData.id)
                 AppLog.shared.summarization("Summary deleted from Core Data")
@@ -1546,6 +1560,8 @@ struct SummaryDetailView: View {
     // MARK: - Attachments / Notes
 
     private func loadSupplementalSummaryData() {
+        isLoadingSupplemental = true
+        defer { isLoadingSupplemental = false }
         let supplemental = SummaryAttachmentStore.shared.load(for: summaryData.id)
         attachments = supplemental.attachments
         noteDraft = supplemental.userNotes ?? ""
@@ -1610,16 +1626,21 @@ struct SummaryDetailView: View {
         }
 
         let textBasedExtensions: Set<String> = ["txt", "md", "markdown", "csv", "json", "log", "xml", "yaml", "yml"]
-        if textBasedExtensions.contains(ext),
-           let data = try? Data(contentsOf: url),
-           let text = String(data: data, encoding: .utf8) {
+        if textBasedExtensions.contains(ext) {
             selectedAttachmentName = attachment.fileName
-            selectedAttachmentText = text
-            showingTextAttachment = true
+            Task.detached {
+                guard let data = try? Data(contentsOf: url),
+                      let text = String(data: data, encoding: .utf8) else { return }
+                await MainActor.run {
+                    selectedAttachmentText = text
+                    showingTextAttachment = true
+                }
+            }
             return
         }
 
-        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        // Fallback: use QuickLook which can open any file type within the app sandbox.
+        selectedAttachmentGenericURL = url
     }
 
     private func iconName(for attachment: SummaryAttachment) -> String {

--- a/BisonNotes AI/BisonNotes AI/SummaryDetailView.swift
+++ b/BisonNotes AI/BisonNotes AI/SummaryDetailView.swift
@@ -4,6 +4,8 @@ import Contacts
 @preconcurrency import CoreLocation
 import UIKit
 import LinkPresentation
+import UniformTypeIdentifiers
+import PDFKit
 
 private actor SummaryGeocodeCache {
     enum Entry: Sendable {
@@ -59,6 +61,15 @@ struct SummaryDetailView: View {
     @State private var exportError: String?
     @State private var geocodingTask: Task<Void, Never>?
     @State private var showingExportFormatPicker = false
+    @State private var showingAttachmentPicker = false
+    @State private var attachmentError: String?
+    @State private var attachments: [SummaryAttachment] = []
+    @State private var noteDraft: String = ""
+    @State private var showingTextAttachment = false
+    @State private var showingPDFAttachment = false
+    @State private var selectedAttachmentName: String = ""
+    @State private var selectedAttachmentText: String = ""
+    @State private var selectedAttachmentPDFURL: URL?
 
     private enum ExportFormat {
         case pdf
@@ -161,6 +172,9 @@ struct SummaryDetailView: View {
                     
                     // Titles Section (Expandable)
                     titlesSection
+
+                    // Attachments + Note Section
+                    attachmentsSection
                     
                     // Date/Time Editor Section
                     dateTimeEditorSection
@@ -195,6 +209,7 @@ struct SummaryDetailView: View {
             }
 
             scheduleLocationGeocoding()
+            loadSupplementalSummaryData()
         }
         .onDisappear {
             geocodingTask?.cancel()
@@ -292,6 +307,55 @@ struct SummaryDetailView: View {
             Button("Cancel", role: .cancel) { }
         } message: {
             Text("Export includes summary, tasks, reminders, and processing details.")
+        }
+        .fileImporter(
+            isPresented: $showingAttachmentPicker,
+            allowedContentTypes: [.item],
+            allowsMultipleSelection: true
+        ) { result in
+            handleAttachmentImport(result)
+        }
+        .sheet(isPresented: $showingTextAttachment) {
+            NavigationView {
+                ScrollView {
+                    Text(selectedAttachmentText)
+                        .font(.body.monospaced())
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                }
+                .navigationTitle(selectedAttachmentName)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button("Done") {
+                            showingTextAttachment = false
+                        }
+                    }
+                }
+            }
+        }
+        .sheet(isPresented: $showingPDFAttachment) {
+            if let selectedAttachmentPDFURL {
+                NavigationView {
+                    SummaryAttachmentPDFView(url: selectedAttachmentPDFURL)
+                        .navigationTitle(selectedAttachmentName)
+                        .navigationBarTitleDisplayMode(.inline)
+                        .toolbar {
+                            ToolbarItem(placement: .topBarTrailing) {
+                                Button("Done") {
+                                    showingPDFAttachment = false
+                                }
+                            }
+                        }
+                }
+            }
+        }
+        .alert("Attachment Error", isPresented: .constant(attachmentError != nil)) {
+            Button("OK") {
+                attachmentError = nil
+            }
+        } message: {
+            Text(attachmentError ?? "")
         }
     }
     
@@ -820,7 +884,81 @@ struct SummaryDetailView: View {
             }
         }
     }
-    
+
+    // MARK: - Attachments Section
+
+    private var attachmentsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: "paperclip")
+                    .foregroundColor(.accentColor)
+                Text("Attachments & Notes")
+                    .font(.headline)
+                Spacer()
+                Button {
+                    showingAttachmentPicker = true
+                } label: {
+                    Label("Attach File", systemImage: "plus.circle")
+                        .font(.caption)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Note")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+
+                TextEditor(text: $noteDraft)
+                    .frame(minHeight: 110)
+                    .padding(6)
+                    .background(Color(.systemGray6))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .onChange(of: noteDraft) { _, _ in
+                        saveUserNotes()
+                    }
+            }
+
+            if attachments.isEmpty {
+                emptyStateView(message: "No attachments yet", icon: "paperclip")
+            } else {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(attachments, id: \.id) { attachment in
+                        HStack(spacing: 10) {
+                            Image(systemName: iconName(for: attachment))
+                                .foregroundColor(.secondary)
+
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(attachment.fileName)
+                                    .font(.subheadline)
+                                    .lineLimit(2)
+
+                                Text(ByteCountFormatter.string(fromByteCount: attachment.fileSize, countStyle: .file))
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            Spacer()
+
+                            Button("Open") {
+                                openAttachment(attachment)
+                            }
+                            .font(.caption)
+
+                            Button(role: .destructive) {
+                                removeAttachment(attachment)
+                            } label: {
+                                Image(systemName: "trash")
+                            }
+                            .buttonStyle(.plain)
+                        }
+                        .padding(10)
+                        .background(Color(.systemGray6))
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                    }
+                }
+            }
+        }
+    }
+
     // MARK: - Date/Time Editor Section
     
     private var dateTimeEditorSection: some View {
@@ -1234,6 +1372,8 @@ struct SummaryDetailView: View {
                         tasks: summaryData.tasks,
                         reminders: summaryData.reminders,
                         titles: summaryData.titles,
+                        attachments: attachments,
+                        userNotes: noteDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : noteDraft,
                         contentType: summaryData.contentType,
                         aiEngine: summaryData.aiEngine,
                         aiModel: summaryData.aiModel,
@@ -1298,6 +1438,8 @@ struct SummaryDetailView: View {
                         tasks: summaryData.tasks,
                         reminders: summaryData.reminders,
                         titles: summaryData.titles,
+                        attachments: attachments,
+                        userNotes: noteDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : noteDraft,
                         contentType: summaryData.contentType,
                         aiEngine: summaryData.aiEngine,
                         aiModel: summaryData.aiModel,
@@ -1399,6 +1541,149 @@ struct SummaryDetailView: View {
         recording.lastModified = Date()
         
         try appCoordinator.coreDataManager.saveContext()
+    }
+
+    // MARK: - Attachments / Notes
+
+    private func loadSupplementalSummaryData() {
+        let supplemental = SummaryAttachmentStore.shared.load(for: summaryData.id)
+        attachments = supplemental.attachments
+        noteDraft = supplemental.userNotes ?? ""
+        summaryData = rebuildSummaryData(userNotes: supplemental.userNotes, attachments: supplemental.attachments)
+    }
+
+    private func saveUserNotes() {
+        do {
+            try SummaryAttachmentStore.shared.saveUserNotes(noteDraft, summaryId: summaryData.id)
+            summaryData = rebuildSummaryData(userNotes: noteDraft, attachments: attachments)
+        } catch {
+            attachmentError = "Unable to save notes: \(error.localizedDescription)"
+        }
+    }
+
+    private func handleAttachmentImport(_ result: Result<[URL], Error>) {
+        do {
+            let urls = try result.get()
+            guard !urls.isEmpty else { return }
+
+            for url in urls {
+                let accessed = url.startAccessingSecurityScopedResource()
+                defer {
+                    if accessed {
+                        url.stopAccessingSecurityScopedResource()
+                    }
+                }
+
+                let attachment = try SummaryAttachmentStore.shared.addAttachment(from: url, summaryId: summaryData.id)
+                attachments.insert(attachment, at: 0)
+            }
+
+            summaryData = rebuildSummaryData(userNotes: noteDraft, attachments: attachments)
+        } catch {
+            attachmentError = "Unable to attach file: \(error.localizedDescription)"
+        }
+    }
+
+    private func removeAttachment(_ attachment: SummaryAttachment) {
+        do {
+            try SummaryAttachmentStore.shared.removeAttachment(attachment, summaryId: summaryData.id)
+            attachments.removeAll { $0.id == attachment.id }
+            summaryData = rebuildSummaryData(userNotes: noteDraft, attachments: attachments)
+        } catch {
+            attachmentError = "Unable to remove attachment: \(error.localizedDescription)"
+        }
+    }
+
+    private func openAttachment(_ attachment: SummaryAttachment) {
+        let url = SummaryAttachmentStore.shared.fileURL(for: attachment, summaryId: summaryData.id)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            attachmentError = "Attachment file no longer exists."
+            return
+        }
+
+        let ext = url.pathExtension.lowercased()
+        if ext == "pdf" {
+            selectedAttachmentName = attachment.fileName
+            selectedAttachmentPDFURL = url
+            showingPDFAttachment = true
+            return
+        }
+
+        let textBasedExtensions: Set<String> = ["txt", "md", "markdown", "csv", "json", "log", "xml", "yaml", "yml"]
+        if textBasedExtensions.contains(ext),
+           let data = try? Data(contentsOf: url),
+           let text = String(data: data, encoding: .utf8) {
+            selectedAttachmentName = attachment.fileName
+            selectedAttachmentText = text
+            showingTextAttachment = true
+            return
+        }
+
+        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+    }
+
+    private func iconName(for attachment: SummaryAttachment) -> String {
+        let ext = (attachment.fileName as NSString).pathExtension.lowercased()
+        switch ext {
+        case "pdf":
+            return "doc.richtext"
+        case "txt", "md", "markdown", "csv", "json":
+            return "doc.text"
+        case "doc", "docx":
+            return "doc"
+        case "jpg", "jpeg", "png", "heic", "gif":
+            return "photo"
+        default:
+            return "doc"
+        }
+    }
+
+    private func rebuildSummaryData(userNotes: String?, attachments: [SummaryAttachment]) -> EnhancedSummaryData {
+        let normalizedNotes = userNotes?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true ? nil : userNotes
+
+        if let recordingId = summaryData.recordingId {
+            return EnhancedSummaryData(
+                id: summaryData.id,
+                recordingId: recordingId,
+                transcriptId: summaryData.transcriptId,
+                recordingURL: summaryData.recordingURL,
+                recordingName: summaryData.recordingName,
+                recordingDate: summaryData.recordingDate,
+                summary: summaryData.summary,
+                tasks: summaryData.tasks,
+                reminders: summaryData.reminders,
+                titles: summaryData.titles,
+                attachments: attachments,
+                userNotes: normalizedNotes,
+                contentType: summaryData.contentType,
+                aiEngine: summaryData.aiEngine,
+                aiModel: summaryData.aiModel,
+                originalLength: summaryData.originalLength,
+                processingTime: summaryData.processingTime,
+                generatedAt: summaryData.generatedAt,
+                version: summaryData.version,
+                wordCount: summaryData.wordCount,
+                compressionRatio: summaryData.compressionRatio,
+                confidence: summaryData.confidence
+            )
+        }
+
+        return EnhancedSummaryData(
+            recordingURL: summaryData.recordingURL,
+            recordingName: summaryData.recordingName,
+            recordingDate: summaryData.recordingDate,
+            summary: summaryData.summary,
+            tasks: summaryData.tasks,
+            reminders: summaryData.reminders,
+            titles: summaryData.titles,
+            attachments: attachments,
+            userNotes: normalizedNotes,
+            contentType: summaryData.contentType,
+            aiEngine: summaryData.aiEngine,
+            aiModel: summaryData.aiModel,
+            originalLength: summaryData.originalLength,
+            processingTime: summaryData.processingTime
+        )
     }
 
     // MARK: - Export Functions
@@ -3083,6 +3368,27 @@ private struct StaticLocationMapView: View {
             }
             isLoadingSnapshot = true
             return true
+        }
+    }
+}
+
+// MARK: - Attachment Preview
+
+private struct SummaryAttachmentPDFView: UIViewRepresentable {
+    let url: URL
+
+    func makeUIView(context: Context) -> PDFView {
+        let view = PDFView()
+        view.autoScales = true
+        view.displayMode = .singlePageContinuous
+        view.displayDirection = .vertical
+        view.document = PDFDocument(url: url)
+        return view
+    }
+
+    func updateUIView(_ uiView: PDFView, context: Context) {
+        if uiView.document?.documentURL != url {
+            uiView.document = PDFDocument(url: url)
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Enable attaching arbitrary files to a summary and persist a user-written note alongside it so summaries are richer and portable. 
- Allow quick in-app viewing for common text/PDF attachments and fall back to system apps for other types. 
- Include any built-in note content in exports (`PDF`/`RTF`) so exports reflect what the user authored in the app.

### Description
- Added a new `SummaryAttachment` model and extended `EnhancedSummaryData` with `attachments` and optional `userNotes` to carry supplemental summary data. 
- Implemented `SummaryAttachmentStore` to persist per-summary metadata and copy attachments into a per-summary folder under the app Documents directory, with APIs to `addAttachment`, `removeAttachment`, `fileURL(for:)`, and `saveUserNotes`. 
- Extended `SummaryDetailView` with an **Attachments & Notes** section that uses `fileImporter` to attach files, shows a `TextEditor` for persistent notes, supports opening PDFs and text files in-app (PDF preview via `SummaryAttachmentPDFView` and text view), and opens other files using the system. State is kept in `attachments`/`noteDraft` and synchronized back into `summaryData`. 
- Updated exports: `PDFExportService` and `RTFExportService` now include a `User Notes` section when `userNotes` are present, using the existing markdown-aware `SummaryExportFormatter` so notes appear in exported PDF/RTF output.

### Testing
- Ran `swift --version` which succeeded in this environment. 
- Attempted an Xcode build with `xcodebuild -project 'BisonNotes AI/BisonNotes AI.xcodeproj' -scheme 'BisonNotes AI' -sdk iphonesimulator -configuration Debug build CODE_SIGNING_ALLOWED=NO` but `xcodebuild` is not available in this environment so a full compile was not performed. 
- No automated unit tests were added; changes are focused on model, persistence, UI, and export plumbing and will require an Xcode build / simulator run to validate UI flows and file permissions on-device.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfac87e1388331a4bc5a953f31744f)