### PR TITLE
v1.11.1 hotfix: restore background recording when device locks

### DIFF
--- a/BisonNotes AI/BisonNotes AI.xcodeproj/project.pbxproj
+++ b/BisonNotes AI/BisonNotes AI.xcodeproj/project.pbxproj
@@ -880,7 +880,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 4W55VW7UXX;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "BisonNotes Watch Widget/Info.plist";
@@ -891,7 +891,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.11;
+				MARKETING_VERSION = 1.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Bison-Networking.BisonNotes-AI.watchkitapp.widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -912,7 +912,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 4W55VW7UXX;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "BisonNotes Watch Widget/Info.plist";
@@ -923,7 +923,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.11;
+				MARKETING_VERSION = 1.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Bison-Networking.BisonNotes-AI.watchkitapp.widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -943,7 +943,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "BisonNotes Share/BisonNotes Share.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 4W55VW7UXX;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "BisonNotes Share/Info.plist";
@@ -955,7 +955,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.11;
+				MARKETING_VERSION = 1.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Bison-Networking.BisonNotes-AI.BisonNotes-Share";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -973,7 +973,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "BisonNotes Share/BisonNotes Share.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 4W55VW7UXX;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "BisonNotes Share/Info.plist";
@@ -985,7 +985,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.11;
+				MARKETING_VERSION = 1.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Bison-Networking.BisonNotes-AI.BisonNotes-Share";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1005,7 +1005,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "BisonNotes AI Controls/BisonNotes AI Controls.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 4W55VW7UXX;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1020,7 +1020,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.11;
+				MARKETING_VERSION = 1.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Bison-Networking.BisonNotes-AI.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1039,7 +1039,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "BisonNotes AI Controls/BisonNotes AI Controls.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 4W55VW7UXX;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1054,7 +1054,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.11;
+				MARKETING_VERSION = 1.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Bison-Networking.BisonNotes-AI.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1071,10 +1071,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 4W55VW7UXX;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.11;
+				MARKETING_VERSION = 1.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Bison-Networking.BisonNotes-AI-Watch-AppTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1091,10 +1091,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 4W55VW7UXX;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.11;
+				MARKETING_VERSION = 1.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Bison-Networking.BisonNotes-AI-Watch-AppTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1110,10 +1110,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 4W55VW7UXX;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.11;
+				MARKETING_VERSION = 1.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Bison-Networking.BisonNotes-AI-Watch-AppUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1129,10 +1129,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 4W55VW7UXX;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.11;
+				MARKETING_VERSION = 1.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Bison-Networking.BisonNotes-AI-Watch-AppUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1277,7 +1277,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = "BisonNotes AI/BisonNotes AI.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 4W55VW7UXX;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1293,7 +1293,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.11;
+				MARKETING_VERSION = 1.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Bison-Networking.BisonNotes-AI";
 				PRODUCT_NAME = "BisonNotes AI";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1316,7 +1316,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = "BisonNotes AI/BisonNotes AI.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 4W55VW7UXX;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1332,7 +1332,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.11;
+				MARKETING_VERSION = 1.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Bison-Networking.BisonNotes-AI";
 				PRODUCT_NAME = "BisonNotes AI";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1350,11 +1350,11 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 4W55VW7UXX;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
-				MARKETING_VERSION = 1.11;
+				MARKETING_VERSION = 1.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Bison-Networking.Audio-JournalTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1373,11 +1373,11 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 4W55VW7UXX;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
-				MARKETING_VERSION = 1.11;
+				MARKETING_VERSION = 1.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Bison-Networking.Audio-JournalTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1395,10 +1395,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 4W55VW7UXX;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.11;
+				MARKETING_VERSION = 1.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Bison-Networking.Audio-JournalUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1416,10 +1416,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 4W55VW7UXX;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.11;
+				MARKETING_VERSION = 1.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Bison-Networking.Audio-JournalUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1440,7 +1440,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "BisonNotes AI ControlsExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 4W55VW7UXX;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "BisonNotes AI Controls/Info.plist";
@@ -1453,7 +1453,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.11;
+				MARKETING_VERSION = 1.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Bison-Networking.BisonNotes-AI.controls";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1478,7 +1478,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = "BisonNotes AI ControlsExtension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 4W55VW7UXX;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "BisonNotes AI Controls/Info.plist";
@@ -1491,7 +1491,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.11;
+				MARKETING_VERSION = 1.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Bison-Networking.BisonNotes-AI.controls";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/BisonNotes AI/BisonNotes AI.xcodeproj/project.pbxproj
+++ b/BisonNotes AI/BisonNotes AI.xcodeproj/project.pbxproj
@@ -13,8 +13,8 @@
 		1433F5462F7C9E44002AB9D6 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14EA428E2E7F5ECA0059271B /* SwiftUI.framework */; };
 		1433F5572F7C9E45002AB9D6 /* BisonNotes Watch WidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 1433F5442F7C9E44002AB9D6 /* BisonNotes Watch WidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		1435711D2F2137E1000BFF00 /* Textual in Frameworks */ = {isa = PBXBuildFile; productRef = 1435711C2F2137E1000BFF00 /* Textual */; };
-		1435735C2F2E92A500E93954 /* BisonNotes Share.appex in Embed Controls Extension */ = {isa = PBXBuildFile; fileRef = 143573522F2E92A500E93954 /* BisonNotes Share.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		1485FEC52E526FB30044121F /* BisonNotes AI Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 1485FEA52E526FB10044121F /* BisonNotes AI Watch App.app */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		1435735C2F2E92A500E93954 /* BisonNotes Share.appex in Embed Controls Extension */ = {isa = PBXBuildFile; fileRef = 143573522F2E92A500E93954 /* BisonNotes Share.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		1485FEC52E526FB30044121F /* BisonNotes AI Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 1485FEA52E526FB10044121F /* BisonNotes AI Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		1485FED52E5271970044121F /* WatchConnectivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1485FED42E5271970044121F /* WatchConnectivity.framework */; };
 		1485FED72E5271AF0044121F /* WatchConnectivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1485FED62E5271AF0044121F /* WatchConnectivity.framework */; };
 		1485FEDC2E5272FA0044121F /* WatchRecordingMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1485FED92E5272FA0044121F /* WatchRecordingMessage.swift */; };
@@ -27,7 +27,7 @@
 		14B0A0022F80000000BBD2FA /* MLXLMCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 14B0A0052F80000000BBD2FA /* MLXLMCommon */; };
 		14EA428D2E7F5ECA0059271B /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14EA428C2E7F5ECA0059271B /* WidgetKit.framework */; };
 		14EA428F2E7F5ECA0059271B /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14EA428E2E7F5ECA0059271B /* SwiftUI.framework */; };
-		14EA42A92E7F66370059271B /* BisonNotes AI ControlsExtension.appex in Embed Controls Extension */ = {isa = PBXBuildFile; fileRef = 14EA428B2E7F5ECA0059271B /* BisonNotes AI ControlsExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		14EA42A92E7F66370059271B /* BisonNotes AI ControlsExtension.appex in Embed Controls Extension */ = {isa = PBXBuildFile; fileRef = 14EA428B2E7F5ECA0059271B /* BisonNotes AI ControlsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		14FA00012F30000000BBD2FA /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = 14FA00022F30000000BBD2FA /* FluidAudio */; };
 		14FDF9082E3F8D5600BBD2FA /* AWSBedrock in Frameworks */ = {isa = PBXBuildFile; productRef = 14FDF9072E3F8D5600BBD2FA /* AWSBedrock */; };
 		14FDF90A2E3F8D5600BBD2FA /* AWSClientRuntime in Frameworks */ = {isa = PBXBuildFile; productRef = 14FDF9092E3F8D5600BBD2FA /* AWSClientRuntime */; };
@@ -1297,8 +1297,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "Bison-Networking.BisonNotes-AI";
 				PRODUCT_NAME = "BisonNotes AI";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = YES;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -1336,8 +1336,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "Bison-Networking.BisonNotes-AI";
 				PRODUCT_NAME = "BisonNotes AI";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = YES;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/BisonNotes AI/BisonNotes AI/AppFileProtection.swift
+++ b/BisonNotes AI/BisonNotes AI/AppFileProtection.swift
@@ -1,7 +1,11 @@
 import Foundation
 
 enum AppFileProtection {
-    static let sensitiveFileProtection: FileProtectionType = .complete
+    // .completeUntilFirstUserAuthentication keeps files encrypted at rest but
+    // available once the user has unlocked the device after boot. Background
+    // recording, transcription, and Core Data writes can fire while the device
+    // is locked again later, and .complete would make those reads/writes fail.
+    static let sensitiveFileProtection: FileProtectionType = .completeUntilFirstUserAuthentication
 
     static func apply(to url: URL) {
         try? FileManager.default.setAttributes(

--- a/BisonNotes AI/BisonNotes AI/BisonNotesAIApp.swift
+++ b/BisonNotes AI/BisonNotes AI/BisonNotesAIApp.swift
@@ -296,6 +296,37 @@ struct BisonNotesAIApp: App {
         UserDefaults.standard.set(true, forKey: migrationKey)
     }
 
+    /// Downgrades the file-protection class on existing files from .complete to
+    /// .completeUntilFirstUserAuthentication. v1.11 (initial release) created
+    /// recordings, transcripts, logs, and Core Data files with .complete, which
+    /// makes them unreadable while the device is locked — breaking background
+    /// recording and post-lock loads. Runs once after the user brings the app to
+    /// the foreground (so protected data is available).
+    private func migrateFileProtectionForExistingFiles() {
+        let migrationKey = "fileProtectionDowngradeMigration_v1.11.1"
+
+        guard !UserDefaults.standard.bool(forKey: migrationKey) else {
+            return
+        }
+
+        guard UIApplication.shared.isProtectedDataAvailable else {
+            return
+        }
+
+        let fileManager = FileManager.default
+        let directories: [URL] = [
+            fileManager.urls(for: .documentDirectory, in: .userDomainMask).first,
+            fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        ].compactMap { $0 }
+
+        for directory in directories {
+            AppFileProtection.applyRecursively(to: directory)
+        }
+
+        UserDefaults.standard.set(true, forKey: migrationKey)
+        AppLog.shared.general("Downgraded existing file protection class to completeUntilFirstUserAuthentication (1.11 → 1.11.1)")
+    }
+
     init() {
 #if DEBUG
         Self.configureCoverageOutputIfNeeded()
@@ -377,6 +408,8 @@ struct BisonNotesAIApp: App {
                     // scene-based SwiftUI apps where the UIApplicationDelegate method
                     // may be skipped.
                     appDelegate.clearAppBadge(reason: "activation")
+                    // Repair any files left at .complete protection by v1.11.0.
+                    migrateFileProtectionForExistingFiles()
                     // Scan for files placed by the Share Extension (Voice Memos, etc.)
                     scanSharedContainerForImports(trigger: .pendingToken)
                     // Also scan Documents/Inbox/ for files from "Open In" / document interaction.

--- a/BisonNotes AI/BisonNotes AI/EndpointSecurityPolicy.swift
+++ b/BisonNotes AI/BisonNotes AI/EndpointSecurityPolicy.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Darwin
 
 enum EndpointSecurityPolicy {
     static let allowInsecurePublicEndpointsKey = "allowInsecurePublicAIEndpoints"
@@ -68,7 +69,7 @@ enum EndpointSecurityPolicy {
     private static func isLocalOrPrivateHost(_ host: String) -> Bool {
         let normalized = host.trimmingCharacters(in: CharacterSet(charactersIn: "[]")).lowercased()
 
-        if normalized == "localhost" || normalized.hasSuffix(".localhost") || normalized == "::1" {
+        if normalized == "localhost" || normalized.hasSuffix(".localhost") {
             return true
         }
 
@@ -76,7 +77,14 @@ enum EndpointSecurityPolicy {
             return isPrivateIPv4(ipv4)
         }
 
-        return normalized.hasPrefix("fc") || normalized.hasPrefix("fd") || normalized.hasPrefix("fe80:")
+        // Only treat the host as an IPv6 literal if it actually parses as one —
+        // a DNS name like "fd-example.com" must not be accepted just because it
+        // starts with "fd".
+        if normalized.contains(":") {
+            return isPrivateIPv6Literal(normalized)
+        }
+
+        return false
     }
 
     private static func parseIPv4(_ host: String) -> [Int]? {
@@ -100,5 +108,40 @@ enum EndpointSecurityPolicy {
             || (first == 172 && (16...31).contains(second))
             || (first == 192 && second == 168)
             || (first == 169 && second == 254)
+    }
+
+    private static func isPrivateIPv6Literal(_ host: String) -> Bool {
+        // Strip any RFC 6874 zone identifier (e.g. "fe80::1%en0") before parsing.
+        var address = host
+        if let percent = address.firstIndex(of: "%") {
+            address = String(address[..<percent])
+        }
+
+        var parsed = in6_addr()
+        let result = address.withCString { inet_pton(AF_INET6, $0, &parsed) }
+        guard result == 1 else { return false }
+
+        return withUnsafeBytes(of: &parsed) { raw -> Bool in
+            let bytes = raw.bindMemory(to: UInt8.self)
+            let first = bytes[0]
+            let second = bytes[1]
+
+            // Loopback ::1
+            if bytes[15] == 1, (0..<15).allSatisfy({ bytes[$0] == 0 }) {
+                return true
+            }
+
+            // Unique local addresses: fc00::/7
+            if first == 0xfc || first == 0xfd {
+                return true
+            }
+
+            // Link-local: fe80::/10
+            if first == 0xfe, (second & 0xC0) == 0x80 {
+                return true
+            }
+
+            return false
+        }
     }
 }

--- a/BisonNotes AI/BisonNotes AI/Info.plist
+++ b/BisonNotes AI/BisonNotes AI/Info.plist
@@ -80,9 +80,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.11</string>
+	<string>1.11.1</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>googlecalendar</string>

--- a/BisonNotes AI/BisonNotes AI/Persistence.swift
+++ b/BisonNotes AI/BisonNotes AI/Persistence.swift
@@ -41,6 +41,10 @@ struct PersistenceController {
         container.persistentStoreDescriptions.forEach { description in
             description.setOption(true as NSNumber, forKey: NSMigratePersistentStoresAutomaticallyOption)
             description.setOption(true as NSNumber, forKey: NSInferMappingModelAutomaticallyOption)
+            description.setOption(
+                AppFileProtection.sensitiveFileProtection as NSObject,
+                forKey: NSPersistentStoreFileProtectionKey
+            )
         }
         container.loadPersistentStores(completionHandler: { (storeDescription, error) in
             if let error = error as NSError? {

--- a/BisonNotes AI/BisonNotes AITests/EndpointSecurityPolicyTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/EndpointSecurityPolicyTests.swift
@@ -35,4 +35,23 @@ final class EndpointSecurityPolicyTests: XCTestCase {
             )
         )
     }
+
+    func testBlocksPublicHostnamesThatLookLikeIPv6Literals() {
+        XCTAssertNotNil(EndpointSecurityPolicy.validationMessage(for: "http://fd-example.com/v1"))
+        XCTAssertNotNil(EndpointSecurityPolicy.validationMessage(for: "http://fc00.example.com/v1"))
+        XCTAssertNotNil(EndpointSecurityPolicy.validationMessage(for: "http://fe80.example.com/v1"))
+    }
+
+    func testAllowsPrivateAndLoopbackIPv6Literals() {
+        XCTAssertNil(EndpointSecurityPolicy.validationMessage(for: "http://[::1]:8080"))
+        XCTAssertNil(EndpointSecurityPolicy.validationMessage(for: "http://[fd00::1]:8080"))
+        XCTAssertNil(EndpointSecurityPolicy.validationMessage(for: "http://[fc00::1]"))
+        XCTAssertNil(EndpointSecurityPolicy.validationMessage(for: "http://[fe80::1]"))
+    }
+
+    func testBlocksPublicIPv6Literals() {
+        let message = EndpointSecurityPolicy.validationMessage(for: "http://[2001:db8::1]/v1")
+        XCTAssertNotNil(message)
+        XCTAssertTrue(message?.contains("Public HTTP endpoints are blocked") == true)
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes a v1.11.0 regression where recordings silently stopped (and became unreadable) whenever the device locked during background recording. Root cause: `AppFileProtection.sensitiveFileProtection` was set to `.complete`, which makes files inaccessible while the device is locked — so `AVAudioRecorder`'s writes failed mid-stream and post-stop duration loads hit "you don't have permission to view it" errors.
- Cherry-picks `5581bc1` from v2.0 (originally bundled with IPv6 endpoint policy tightening), switching the global sensitive-file class to `.completeUntilFirstUserAuthentication` and passing the same class to `NSPersistentStoreFileProtectionKey` so Core Data opens at the intended class from creation.
- Adds a one-shot migration (`fileProtectionDowngradeMigration_v1.11.1`) that re-applies the lower protection class recursively to Documents and Application Support the first time the app becomes active after the upgrade, gated by `UIApplication.shared.isProtectedDataAvailable` so we only touch files when the device is actually unlocked. This repairs files left at `.complete` by 1.11.0 — without it, the cherry-pick only helps new recordings.
- Bumps version to **1.11.1 (2)** across all targets and `Info.plist`.
- Switches distribution from Mac Catalyst to "Designed for iPad" (`SUPPORTS_MACCATALYST = NO`, `SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES`), matching how v2.0 is being shipped. Drops the iOS `platformFilter` from embedded Share extension / Watch app / Controls Extension entries.

## Commits
- `db8dd63` Tighten IPv6 endpoint policy and unlock background file access (cherry-picked from v2.0 `5581bc1`)
- `2225cc0` Bump to 1.11.1 and downgrade existing file protection on first foreground
- `22b23d9` Ship v1.11.1 via Designed for iPad

## Test plan
- [ ] Archive on the v1.11 branch and submit 1.11.1 as a new version in App Store Connect.
- [ ] Install the build on top of a v1.11.0 device that has existing recordings.
- [ ] Confirm the existing recordings can be opened/played after launch (migration ran on `didBecomeActive`).
- [ ] Start a new recording, lock the device, leave it for several minutes, unlock — confirm the recording is still going and the file plays back.
- [ ] Verify no regressions in Core Data reads (recordings list, transcripts, summaries) after the migration runs.
- [ ] Check `UserDefaults` flag `fileProtectionDowngradeMigration_v1.11.1` is set after first foreground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)