### PR TITLE
[codex] Update v2.1 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,16 @@ SwiftUI app for recording audio, transcribing it with local or cloud engines, an
 
 AVAILABLE ON THE APP STORE: https://apps.apple.com/us/app/bisonnotes-ai-voice-notes/id6749189425
 
-Quick links: [Full User Guide](docs/bisonnotes-ai-guide.html) • [Mistral AI Free Setup](docs/mistral-free-setup.md) • [Build & Test](#build-and-test) • [Architecture](#architecture)
+Quick links: [Full User Guide](docs/bisonnotes-ai-guide.html) • [Mistral AI Free Setup](docs/mistral-free-setup.md) • [Regression Testing Regimen](docs/testing-regimen.md) • [Build & Test](#build-and-test) • [Architecture](#architecture)
 
-## v2.0 Highlights
+## v2.1 Highlights
+- Mac Catalyst can optionally record meeting audio from other Mac apps and mix it with the microphone recording. The setting lives in Settings > Recording as **Record Meeting Audio**, requires macOS Screen & System Audio Recording permission, and falls back to microphone-only audio if permission or mixing fails.
+- iCloud sync now uses stronger guardrails: a HIPAA notice before enabling sync, per-recording **Keep on This Device** exclusions, deletion markers, active-manifest review for older cloud-only items, and clearer production CloudKit schema errors.
+- Parakeet transcription recovery is more reliable. The app recognizes cached model files after app updates or settings resets, supports English v2 and multilingual v3 model choices, reports download/prepare progress more accurately, and avoids short final tail chunks during long on-device transcriptions.
+- Recording reliability is improved through stricter audio session ownership, safer background processing interruption handling, crash-safe recording recovery, and conservative cleanup of stale temporary audio files.
+- Release validation now has app/watch `.xctestplan` files, deterministic UI-test launch fixtures, focused iCloud and transcription regression tests, and a documented regression testing regimen.
+
+## v2.0 Foundation Highlights
 - Modernized SwiftUI interface across Recordings, Transcripts, Summaries, Setup, and Settings, with denser action placement and cleaner status surfaces.
 - Redesigned watchOS recorder around one large tap target: tap to record, tap to stop, and use mute to pause/resume the same file. Transfer status and low-battery warnings stay visible without crowding the primary action.
 - On Device AI is now backed by MLX Swift by default on supported devices. New/legacy users with 4 GB+ RAM migrate to MLX automatically; devices below that fall back to Mistral AI.
@@ -18,7 +25,7 @@ Quick links: [Full User Guide](docs/bisonnotes-ai-guide.html) • [Mistral AI Fr
 - Data: Core Data model at `BisonNotes AI/BisonNotes_AI.xcdatamodeld` stores recordings, transcripts, summaries, and jobs. Sensitive credentials (API keys, AWS access keys, Bedrock session tokens) live in the iOS Keychain, never on disk in plaintext.
 - Engines: Pluggable services for On Device transcription, OpenAI, OpenAI-compatible APIs, Mistral AI, Google AI Studio, AWS Bedrock/Transcribe, Whisper (REST), Wyoming streaming, Ollama, On Device AI (MLX Swift), On Device AI Legacy (llama.cpp), and Apple Native (Foundation Models). Each engine pairs a service with a settings view.
 - Background: `BackgroundProcessingManager` coordinates queued work with retries, timeouts, and recovery. Large files are chunked and processed streaming‑first.
-- Recording: A platform-aware audio pipeline — `AVAudioRecorder` on iOS/iPadOS, `AVAudioEngine` on Mac Catalyst (`AudioRecorderViewModel+CatalystEngine.swift`) — with shared Pause/Resume support and crash-safe interruption handling.
+- Recording: A platform-aware audio pipeline — `AVAudioRecorder` on iOS/iPadOS, `AVAudioEngine` on Mac Catalyst (`AudioRecorderViewModel+CatalystEngine.swift`) — with shared Pause/Resume support, optional Mac meeting-audio capture through `CatalystSystemAudioCapture`, and crash-safe interruption handling.
 - Watch Sync: `WatchConnectivityManager` (on iOS and watch targets) manages reachability, complete-file transfers, duplicate protection, queued acknowledgments, and import recovery. Watch complications and a Control Center recording widget are bundled as separate targets.
 - UI: SwiftUI views under `Views/` implement recording, summaries, transcripts, setup, and settings. AI-generated content uses MarkdownUI for professional formatting. View models isolate state and side effects.
 
@@ -40,6 +47,7 @@ Quick links: [Full User Guide](docs/bisonnotes-ai-guide.html) • [Mistral AI Fr
 - Build (Mac Catalyst): `xcodebuild -project "BisonNotes AI/BisonNotes AI.xcodeproj" -scheme "BisonNotes AI" -destination 'platform=macOS,variant=Mac Catalyst' -configuration Debug build`
 - Archive (Mac Catalyst): `Scripts/archive-catalyst.sh`. Use this script instead of Product > Archive so the arm64-only Catalyst setting reaches SwiftPM package targets.
 - Use the watch app scheme to run the watch target. SwiftPM resolves automatically in Xcode.
+- Release validation should follow [docs/testing-regimen.md](docs/testing-regimen.md), including app/watch test plans, Mac Catalyst build coverage, and manual hardware checks for microphone, watch transfer, iCloud, Parakeet, share import, Control Center, Action Button, and Mac meeting audio.
 - See `CLAUDE.md` for the manual `llama.xcframework` Mac Catalyst slice, duplicate-library modulemap cleanup, AWS/Smithy archive constraint, and `bisonbet/textual` Catalyst guards if you rebuild dependencies.
 
 ## Dependencies
@@ -73,6 +81,7 @@ The project uses Swift Package Manager for dependency management. Major dependen
 - **FluidAudio Parakeet**: On-device transcription using NVIDIA Parakeet models.
   - Complete privacy - audio never leaves device
   - Works offline after model download
+  - v2.1 supports Parakeet v2 (English) and Parakeet v3 (multilingual), keeps valid cached downloads across app updates/settings resets, and clears stale download state when model files are missing
   - WhisperKit was removed in v1.8; existing users are automatically migrated to Parakeet
 
 ### **Apple Frameworks**
@@ -90,7 +99,7 @@ All external dependencies are resolved automatically via Swift Package Manager w
 
 ## Key Features
 - **Modern v2.0 UI**: Recordings, Transcripts, Summaries, Setup, and Settings use refreshed SwiftUI layouts with clearer action placement, sectioned date lists, and Catalyst-friendly navigation.
-- **Mac Catalyst (v2.0)**: Native Apple Silicon Mac build with a Catalyst-specific audio pipeline, sandbox entitlements, iCloud archive support, and an arm64-only archive path.
+- **Mac Catalyst (v2.1)**: Native Apple Silicon Mac build with a Catalyst-specific audio pipeline, optional meeting-audio capture from other Mac apps, sandbox entitlements, iCloud archive support, and an arm64-only archive path.
 - **Pause and Resume Recording**: Pause mid-meeting without stopping the file. Resume seamlessly across iOS, iPadOS, watchOS mute/resume, and Mac Catalyst (separate `AVAudioEngine` path on Catalyst).
 - **Hardened Credential Storage (v1.11)**: API keys, AWS credentials, and Bedrock session tokens stored in the iOS Keychain. Legacy values are migrated automatically and kept out of iCloud settings backups. File protection is applied to recordings, transcripts, notes, attachments, and the Core Data SQLite files.
 - **Endpoint Safety (v1.11)**: User-configurable OpenAI, OpenAI-compatible, Ollama, and Whisper endpoints are validated — public cleartext (HTTP/WS) destinations are blocked by default; local/private endpoints stay allowed, with a Development Mode toggle for power users.
@@ -121,14 +130,14 @@ All external dependencies are resolved automatically via Swift Package Manager w
 - **Date Filters**: Filter recordings, transcripts, and summaries by date range. Select start and end dates to quickly find content from specific time periods.
 
 ## Key Modules
-- Recording: `EnhancedAudioSessionManager`, `AudioFileChunkingService`, `AudioRecorderViewModel` (+ `+CatalystEngine`, `+Interruptions`, `+Background`, `+CallIntelligence`, `+Warnings`), `RecordingCombiner`, `TranscriptionStarter`
+- Recording: `EnhancedAudioSessionManager`, `AudioFileChunkingService`, `AudioRecorderViewModel` (+ `+CatalystEngine`, `+Interruptions`, `+Background`, `+CallIntelligence`, `+Warnings`), `CatalystSystemAudioCapture`, `RecordingCombiner`, `TranscriptionStarter`
 - Transcription: `FluidAudioManager` (Parakeet), `OpenAITranscribeService`, `MistralTranscribeService`, `WhisperService`, `WyomingWhisperClient`, `AWSTranscribeService`, `LiveTranscriptionService`
 - Summarization: `OpenAISummarizationService`, `MistralAISummarizationService`, `GoogleAIStudioService`, `AWSBedrockService`, `OnDeviceLLMService`, `MLXSwiftEngine`, `AppleNativeEngine`
 - Security: `KeychainSecretStore`, `AWSCredentialsManager`, `AWSClientCredentialResolver`, `EndpointSecurityPolicy`, `AppFileProtection`
 - Export: `PDFExportService`, `SummaryExportFormatter`, `RecordingArchiveService`
 - UI: `SummariesView`, `SummaryDetailView`, `TranscriptionProgressView`, `AITextView` (with MarkdownUI), `CombineRecordingsView`
 - Persistence: `Persistence`, `CoreDataManager`, models under `Models/`
-- Background: `BackgroundProcessingManager`
+- Background: `BackgroundProcessingManager`, `TemporaryFileCleanupService`
 - Watch: `WatchConnectivityManager` (both targets), `BisonNotesComplications` (Watch Widget target)
 - Controls: `RecordingControlWidget` (Control Center recording widget)
 - Share Extension: `ShareViewController` (imports audio from other apps via share sheet)
@@ -186,6 +195,8 @@ Parakeet is the sole on-device transcription engine as of v1.8 (WhisperKit was r
 - **Privacy**: 100% local processing - audio never leaves your device
 - **Offline**: Works completely offline after initial model download
 - **Requirements**: iOS 17.0 or later
+- **Models**: Parakeet v2 for English long-form recall and Parakeet v3 for multilingual transcription across 25 European languages
+- **Reliability**: v2.1 recognizes valid cached model files, restores the selected model version when possible, resets stale download state when files are gone, and absorbs very short final tail chunks during long on-device transcriptions
 - **Migration**: Existing users who had WhisperKit selected are automatically switched to Parakeet on first launch of v1.8
 
 ### Mistral AI Transcription

--- a/docs/bisonnotes-ai-guide.html
+++ b/docs/bisonnotes-ai-guide.html
@@ -132,7 +132,7 @@ body.page .entry-header {
 <div class="bn-hero">
   <h1>BisonNotes AI</h1>
   <p>Complete User Guide &mdash; iPhone, iPad, Apple Watch, and Mac</p>
-  <span class="bn-ver">v2.0</span>
+  <span class="bn-ver">v2.1</span>
 </div>
 
 <!-- ===== TOC ===== -->
@@ -168,16 +168,16 @@ body.page .entry-header {
 </div>
 
 <!-- ============================================================ -->
-<!-- WHAT'S NEW IN V2.0                                             -->
+<!-- WHAT'S NEW IN V2.1                                             -->
 <!-- ============================================================ -->
 <div class="bn-ok">
-  <strong>What&rsquo;s new in v2.0:</strong>
+  <strong>What&rsquo;s new in v2.1:</strong>
   <ul>
-    <li><strong>Modernized interface.</strong> Recordings, Transcripts, Summaries, Setup, and Settings use refreshed layouts with clearer actions and better Mac/iPad navigation.</li>
-    <li><strong>Redesigned Apple Watch recorder.</strong> Tap once to record, tap again to stop, and use mute to pause/resume the same file. The watch records independently and syncs the finished file back to iPhone.</li>
-    <li><strong>On Device AI is now MLX-backed.</strong> Supported devices use MLX Swift and Ternary Bonsai models by default. Devices with 4GB+ RAM can run local summaries; devices below 4GB fall back to Mistral AI.</li>
-    <li><strong>Legacy local AI cleanup.</strong> The old llama.cpp engine remains available as On Device AI (Legacy) on 6GB+ devices. The removed LFM 2.5 model is deleted during migration and no longer appears in model lists.</li>
-    <li><strong>Mac Catalyst refinements.</strong> The Mac build is Apple Silicon only, with Catalyst-specific audio recording, sandbox/iCloud entitlements, and iCloud audio archive support.</li>
+    <li><strong>Mac meeting audio capture.</strong> On Apple Silicon Macs, BisonNotes can optionally record audio playing from other Mac apps and mix it with your microphone recording. Enable <em>Record Meeting Audio</em> in Settings &rarr; Recording and grant macOS Screen &amp; System Audio Recording permission.</li>
+    <li><strong>Stronger iCloud sync controls.</strong> iCloud Sync now shows a HIPAA notice, supports per-recording <em>Keep on This Device</em> exclusions, uses deletion markers, and provides Review iCloud Items for older cloud-only records.</li>
+    <li><strong>More reliable Parakeet transcription.</strong> BisonNotes recognizes cached Parakeet models after updates or settings resets, supports English v2 and multilingual v3 model choices, improves download/prepare status, and avoids tiny final tail chunks on long local transcriptions.</li>
+    <li><strong>Recording reliability cleanup.</strong> Audio session ownership, background interruption handling, crash recovery, and stale temporary audio cleanup were tightened for safer long recordings.</li>
+    <li><strong>Regression validation.</strong> App/watch test plans, seeded UI test launch modes, iCloud and transcription regression tests, and a documented release test regimen were added.</li>
   </ul>
 </div>
 
@@ -261,8 +261,9 @@ body.page .entry-header {
   <div class="dd">
     <div class="bn-info"><strong>When does this appear?</strong> After generating your first successful summary.</div>
     <ul>
-      <li><strong>"Enable iCloud Sync"</strong> — Summaries sync across all your devices. Uses your iCloud storage quota.</li>
-      <li><strong>"Keep Local Only"</strong> — Summaries stay on this device only. Better for privacy-sensitive content. Can be changed later.</li>
+      <li><strong>"Enable iCloud Sync"</strong> — Eligible recordings, transcripts, summaries, and selected settings sync across your devices through your private iCloud account. BisonNotes shows a HIPAA notice before enabling this.</li>
+      <li><strong>"Keep Local Only"</strong> — Content stays on this device only. Better for privacy-sensitive content. Can be changed later.</li>
+      <li><strong>Per-recording exclusions</strong> — Use <em>Keep on This Device</em> from a recording row or audio player to keep that recording, transcript, and summary out of BisonNotes iCloud sync and backup.</li>
     </ul>
   </div>
 </details>
@@ -287,14 +288,16 @@ body.page .entry-header {
 <!-- ============================================================ -->
 <h2 id="bn-recording">Recording Features</h2>
 
-<h3 id="bn-mac">Mac Catalyst (v2.0)</h3>
+<h3 id="bn-mac">Mac Catalyst (v2.1)</h3>
 <p>BisonNotes AI runs natively on Apple Silicon Macs as a Mac Catalyst app. The Mac build uses an <code>AVAudioEngine</code>-based recording pipeline tuned for desktop audio sessions:</p>
 <ul>
   <li><strong>Same Core Data store</strong> &mdash; Recordings, transcripts, and summaries sync with iPhone/iPad through iCloud (if enabled).</li>
   <li><strong>Pause &amp; Resume</strong> &mdash; Full pause/resume support, the same as on iOS.</li>
   <li><strong>Microphone selection</strong> &mdash; Choose your built-in mic, USB interface, or Bluetooth device from Transcription Settings.</li>
+  <li><strong>Record Meeting Audio</strong> &mdash; Optionally capture audio playing from other Mac apps while your microphone records your local speech. BisonNotes mixes both tracks into one M4A recording.</li>
+  <li><strong>macOS permission</strong> &mdash; Meeting audio capture requires Screen &amp; System Audio Recording permission. BisonNotes records audio only and does not save screen video. If permission changes or capture fails, the app saves microphone audio only.</li>
   <li><strong>Local AI</strong> &mdash; On Device AI uses MLX Swift by default. The legacy llama.cpp engine remains available for higher-memory devices.</li>
-  <li><strong>Archive support</strong> &mdash; The Mac build includes Catalyst sandbox, microphone, networking, calendar, file access, and iCloud entitlements for v2.0 archive workflows.</li>
+  <li><strong>Archive support</strong> &mdash; The Mac build includes Catalyst sandbox, microphone, networking, calendar, file access, and iCloud entitlements for archive workflows.</li>
   <li><strong>Settings and lists</strong> &mdash; Setup, Settings, Summaries, and Transcripts use Mac-friendly scrolling, navigation, and button hit targets.</li>
 </ul>
 
@@ -741,15 +744,17 @@ ollama pull mistral-small3.2</code></pre>
 <details>
   <summary>On Device Transcription (Parakeet) — Default</summary>
   <div class="dd">
-    <div class="bn-ok"><strong>v1.8:</strong> Parakeet is now the sole on-device transcription engine. WhisperKit has been removed. Users who had WhisperKit selected are automatically migrated to Parakeet on first launch.</div>
+    <div class="bn-ok"><strong>v2.1:</strong> Parakeet is the default on-device transcription path. BisonNotes now keeps valid cached model files across app updates or settings resets, clears stale download state when files are missing, and avoids tiny final tail chunks on long local transcriptions.</div>
 
     <h4>Initial Setup</h4>
     <ol class="bn-sl">
       <li><strong>Enable:</strong> Setup &rarr; Transcription Settings &rarr; select "On Device" &rarr; Parakeet is selected by default.</li>
-      <li><strong>Download the model:</strong> Tap "Download" to get the Parakeet model.</li>
+      <li><strong>Choose a model:</strong> Parakeet v2 is English-only with stronger long-form English recall. Parakeet v3 supports multilingual transcription across 25 European languages.</li>
+      <li><strong>Download the model:</strong> Tap "Download" to get the selected Parakeet model. Progress now shows checking, downloading, preparing, and ready states.</li>
       <li><strong>Requirements:</strong> iOS 17.0+, model download required.</li>
     </ol>
 
+    <div class="bn-info"><strong>Migration note:</strong> WhisperKit was removed in v1.8. Users who had WhisperKit selected are automatically migrated to Parakeet on first launch.</div>
     <div class="bn-ok"><strong>Benefits:</strong> Complete privacy, works offline, no API costs.</div>
   </div>
 </details>
@@ -968,6 +973,7 @@ docker run -d -p 9000:9000 \
       <li><strong>No Audio:</strong> Check microphone permissions in Settings &rarr; Privacy</li>
       <li><strong>Poor Quality:</strong> Adjust audio quality settings, ensure proper mic distance</li>
       <li><strong>Background Recording:</strong> Enable in app settings</li>
+      <li><strong>Mac meeting audio missing:</strong> Enable Record Meeting Audio in BisonNotes Settings &rarr; Recording, then grant BisonNotes access in macOS System Settings &rarr; Privacy &amp; Security &rarr; Screen &amp; System Audio Recording. If permission or mixing fails, the app still saves microphone audio.</li>
     </ul>
   </div>
 </details>
@@ -990,6 +996,7 @@ docker run -d -p 9000:9000 \
       <li><strong>No Transcription:</strong> Check engine configuration</li>
       <li><strong>Poor Quality:</strong> Try a different engine or model</li>
       <li><strong>Large File Issues:</strong> Enable chunking for files over 5 minutes</li>
+      <li><strong>Parakeet says a model is missing:</strong> Open Transcription Settings and re-download the selected Parakeet model. BisonNotes will reuse valid cached files when they exist, but clears stale settings if the files were removed.</li>
     </ul>
   </div>
 </details>
@@ -1031,6 +1038,7 @@ docker run -d -p 9000:9000 \
       <li><strong>Live Transcription</strong> (v1.8) &mdash; On-device speech-to-text streamed in real time during recording via SFSpeechRecognizer; transcript auto-saved when recording stops</li>
       <li><strong>Duplicate Summary Cleanup</strong> (v1.8) &mdash; Automatically detects and removes duplicate summaries; manual cleanup available in Database Tools</li>
       <li><strong>Explicit credential resolvers</strong> (v1.11) &mdash; Background AWS jobs always pull fresh credentials from the Keychain so stale process-environment values can&rsquo;t leak in</li>
+      <li><strong>Temporary audio cleanup</strong> (v2.1) &mdash; Conservative startup cleanup removes stale scratch, merge, and chunk files left by failed or interrupted audio workflows without touching active recordings.</li>
     </ul>
   </div>
 </details>


### PR DESCRIPTION
## Summary

- Add v2.1 highlights to the README and link the regression testing regimen.
- Update README architecture/features/modules for Mac meeting-audio capture, Parakeet recovery, temporary cleanup, and v2.1 validation coverage.
- Update the WordPress HTML guide to show v2.1, document Mac meeting-audio setup/permission behavior, refresh iCloud sync setup language, expand Parakeet setup/recovery notes, and add targeted troubleshooting.

## Validation

- Reviewed the merged v2.1 commit range from PR #98 (`1d341c3a^1..1d341c3a^2`).
- Ran `git diff --check`.
- Confirmed branch `v2.1-doc` is pushed to `origin` at `50464b3ccc3ba5f65f40c595c1397af5d280e082`.

No app build or Swift tests were run because this PR only changes Markdown/HTML documentation.