### PR TITLE
fix(v2.3): improve cloud review and transcript actions

### DIFF
--- a/BisonNotes AI/BisonNotes AI/BisonNotesAIApp.swift
+++ b/BisonNotes AI/BisonNotes AI/BisonNotesAIApp.swift
@@ -895,6 +895,8 @@ struct BisonNotesAIApp: App {
         }
         .defaultSize(width: 760, height: 700)
 
+        // Restoration stays disabled so the window never reopens on its own at launch:
+        // its `.task` starts a CloudKit scan, which must remain user-initiated.
         Window("iCloud Items Review", id: NativeWindowID.cloudReview) {
             CloudReviewItemsView()
                 .environmentObject(appCoordinator)
@@ -902,6 +904,7 @@ struct BisonNotesAIApp: App {
         }
         .defaultSize(width: 780, height: 700)
         .windowResizability(.contentMinSize)
+        .restorationBehavior(.disabled)
 
         WindowGroup("Summary", id: NativeWindowID.summary, for: UUID.self) { $recordingID in
             if let recordingID {

--- a/BisonNotes AI/BisonNotes AI/BisonNotesAIApp.swift
+++ b/BisonNotes AI/BisonNotes AI/BisonNotesAIApp.swift
@@ -895,6 +895,14 @@ struct BisonNotesAIApp: App {
         }
         .defaultSize(width: 760, height: 700)
 
+        Window("iCloud Items Review", id: NativeWindowID.cloudReview) {
+            CloudReviewItemsView()
+                .environmentObject(appCoordinator)
+                .frame(minWidth: 680, minHeight: 520)
+        }
+        .defaultSize(width: 780, height: 700)
+        .windowResizability(.contentMinSize)
+
         WindowGroup("Summary", id: NativeWindowID.summary, for: UUID.self) { $recordingID in
             if let recordingID {
                 NativeSummaryWindowView(recordingID: recordingID)

--- a/BisonNotes AI/BisonNotes AI/Platform/NativeWindowRouting.swift
+++ b/BisonNotes AI/BisonNotes AI/Platform/NativeWindowRouting.swift
@@ -13,6 +13,7 @@ enum NativeWindowID {
     static let location = "location-detail"
     static let backgroundProcessing = "background-processing"
     static let processingJob = "processing-job-detail"
+    static let cloudReview = "cloud-review"
 }
 
 /// Settings destinations own their navigation stack on iOS. On native macOS,

--- a/BisonNotes AI/BisonNotes AI/Views/SettingsView.swift
+++ b/BisonNotes AI/BisonNotes AI/Views/SettingsView.swift
@@ -145,12 +145,12 @@ struct SettingsView: View {
                 )
             }
         }
+        #if !os(macOS)
         .sheet(isPresented: $showingCloudReview) {
-            CloudReviewItemsView(includeAudioFiles: iCloudBackupIncludeAudioFiles)
+            CloudReviewItemsView()
                 .environmentObject(appCoordinator)
-                .nativeMacModalSizing(width: 780, height: 700)
-                .nativeMacModalDismissControl()
         }
+        #endif
         .onAppear {
             refreshEngineStatuses()
             Task {
@@ -464,7 +464,7 @@ struct SettingsView: View {
                 }
 
                 Button {
-                    showingCloudReview = true
+                    presentCloudReview()
                 } label: {
                     Label("Review iCloud Items", systemImage: "tray.full")
                         .frame(maxWidth: .infinity)
@@ -838,7 +838,7 @@ struct SettingsView: View {
                 .disabled(isRunningCloudBackupAction)
 
                 Button {
-                    showingCloudReview = true
+                    presentCloudReview()
                 } label: {
                     Label("Review iCloud Items", systemImage: "tray.full")
                 }
@@ -1095,6 +1095,14 @@ struct SettingsView: View {
         openWindow(id: NativeWindowID.backgroundProcessing)
         #else
         showingBackgroundProcessing = true
+        #endif
+    }
+
+    private func presentCloudReview() {
+        #if os(macOS)
+        openWindow(id: NativeWindowID.cloudReview)
+        #else
+        showingCloudReview = true
         #endif
     }
 
@@ -1484,12 +1492,12 @@ private enum MacSystemAudioPermissionAlert: Identifiable {
     }
 }
 
-private struct CloudReviewItemsView: View {
+struct CloudReviewItemsView: View {
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject private var appCoordinator: AppDataCoordinator
     @ObservedObject private var iCloudManager = iCloudStorageManager.shared
 
-    let includeAudioFiles: Bool
+    @AppStorage("iCloudBackupIncludeAudioFiles") private var includeAudioFiles = false
 
     @State private var actionMessage = ""
     @State private var actionIsError = false
@@ -1562,17 +1570,45 @@ private struct CloudReviewItemsView: View {
                             }
                             .buttonStyle(.bordered)
                             .disabled(workingItemId != nil || iCloudManager.isScanningCloudReviewItems)
+                            .confirmationDialog(
+                                "Delete this item from iCloud?",
+                                isPresented: Binding(
+                                    get: { itemPendingDelete?.id == item.id },
+                                    set: { isPresented in
+                                        if !isPresented, itemPendingDelete?.id == item.id {
+                                            itemPendingDelete = nil
+                                        }
+                                    }
+                                ),
+                                titleVisibility: .visible
+                            ) {
+                                Button("Delete from iCloud", role: .destructive) {
+                                    Task { await delete(item) }
+                                }
+                                Button("Cancel", role: .cancel) {
+                                    itemPendingDelete = nil
+                                }
+                            } message: {
+                                Text(
+                                    "This removes app-created iCloud sync records for the selected item. " +
+                                    "It does not delete anything already stored locally on this device."
+                                )
+                            }
                         }
                     }
                     .padding(.vertical, 6)
                 }
             }
             .navigationTitle("iCloud Items Review")
+            #if !os(macOS)
             .navigationBarTitleDisplayMode(.inline)
+            #endif
             .toolbar {
+                #if !os(macOS)
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button("Done") { dismiss() }
                 }
+                #endif
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {
                         Task { await refresh() }
@@ -1581,25 +1617,6 @@ private struct CloudReviewItemsView: View {
                     }
                     .disabled(iCloudManager.isScanningCloudReviewItems || workingItemId != nil)
                 }
-            }
-            .confirmationDialog(
-                "Delete this item from iCloud?",
-                isPresented: Binding(
-                    get: { itemPendingDelete != nil },
-                    set: { if !$0 { itemPendingDelete = nil } }
-                ),
-                titleVisibility: .visible
-            ) {
-                Button("Delete from iCloud", role: .destructive) {
-                    if let item = itemPendingDelete {
-                        Task { await delete(item) }
-                    }
-                }
-                Button("Cancel", role: .cancel) {
-                    itemPendingDelete = nil
-                }
-            } message: {
-                Text("This removes app-created iCloud sync records for the selected item. It does not delete anything already stored locally on this device.")
             }
             .task {
                 await refresh()

--- a/BisonNotes AI/BisonNotes AI/Views/TranscriptViews.swift
+++ b/BisonNotes AI/BisonNotes AI/Views/TranscriptViews.swift
@@ -801,32 +801,45 @@ struct TranscriptsView: View {
                 HStack(spacing: 10) {
                     transcriptButtonView(recordingData)
                     summaryButtonView(recordingData)
+                    transcriptDeleteButtonView(recordingData)
                 }
 
                 VStack(alignment: .leading, spacing: 8) {
-                    transcriptButtonView(recordingData)
+                    HStack(spacing: 10) {
+                        transcriptButtonView(recordingData)
+                        transcriptDeleteButtonView(recordingData)
+                    }
                     summaryButtonView(recordingData)
                 }
-            }
-
-            if recordingData.transcript != nil {
-                Button(role: .destructive) {
-                    requestTranscriptDeletion(for: recordingData.recording, imported: false)
-                } label: {
-                    Label("Delete Transcript", systemImage: "trash")
-                        .font(.body.weight(.semibold))
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(Color(red: 0.65, green: 0.0, blue: 0.0))
-                .accessibilityLabel("Delete transcript for \(recordingData.recording.recordingName ?? "Unknown Recording")")
-                .accessibilityHint("Deletes only the transcript and keeps the recording and summary.")
             }
         }
         .padding(16)
         .background(Color(.secondarySystemGroupedBackground))
         .clipShape(RoundedRectangle(cornerRadius: 18))
         .accessibilityIdentifier(BisonNotesAccessibilityID.transcriptRowPrefix + recordingId)
+    }
+
+    @ViewBuilder
+    private func transcriptDeleteButtonView(
+        _ recordingData: (recording: RecordingEntry, transcript: TranscriptData?)
+    ) -> some View {
+        if recordingData.transcript != nil {
+            Button(role: .destructive) {
+                requestTranscriptDeletion(for: recordingData.recording, imported: false)
+            } label: {
+                Image(systemName: "trash")
+                    .font(.headline)
+                    .foregroundColor(.red)
+                    .frame(width: 44, height: 44)
+                    .background(Color.red.opacity(0.12))
+                    .clipShape(Circle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(
+                "Delete transcript for \(recordingData.recording.recordingName ?? "Unknown Recording")"
+            )
+            .accessibilityHint("Deletes only the transcript and keeps the recording and summary.")
+        }
     }
 
     private func importedTranscriptRowView(

--- a/BisonNotes AI/BisonNotes AI/Views/TranscriptViews.swift
+++ b/BisonNotes AI/BisonNotes AI/Views/TranscriptViews.swift
@@ -811,6 +811,15 @@ struct TranscriptsView: View {
                     }
                     summaryButtonView(recordingData)
                 }
+
+                // Fully stacked last resort: ViewThatFits renders its final candidate even
+                // when that candidate does not fit, so this one must always fit. At the
+                // largest Dynamic Type sizes the transcript button alone can fill the row.
+                VStack(alignment: .leading, spacing: 8) {
+                    transcriptButtonView(recordingData)
+                    transcriptDeleteButtonView(recordingData)
+                    summaryButtonView(recordingData)
+                }
             }
         }
         .padding(16)
@@ -835,6 +844,7 @@ struct TranscriptsView: View {
                     .clipShape(Circle())
             }
             .buttonStyle(.plain)
+            .contentShape(Rectangle())
             .accessibilityLabel(
                 "Delete transcript for \(recordingData.recording.recordingName ?? "Unknown Recording")"
             )

--- a/BisonNotes AI/BisonNotes AI/iCloudStorageManager.swift
+++ b/BisonNotes AI/BisonNotes AI/iCloudStorageManager.swift
@@ -4413,6 +4413,15 @@ extension iCloudStorageManager {
         }
     }
 
+    /// Publishes UI-only maintenance feedback after the current main-actor turn.
+    /// Queue persistence must remain synchronous so deletion intent survives a crash,
+    /// but publishing here during a SwiftUI update triggers undefined behavior.
+    private func publishMaintenanceMessage(_ message: String) {
+        DispatchQueue.main.async { [weak self] in
+            self?.lastMaintenanceMessage = message
+        }
+    }
+
     func enqueueRecordingDeletionForiCloud(
         recordingId: UUID,
         transcriptIds: [UUID],
@@ -4445,7 +4454,7 @@ extension iCloudStorageManager {
             pendingLocalOnlyCloudRemovals = queue
         }
         UserDefaults.standard.removeObject(forKey: Self.backupStateSignatureKey)
-        lastMaintenanceMessage = "Existing iCloud copies for local-only recordings will be removed when iCloud sync is available."
+        publishMaintenanceMessage("Existing iCloud copies for local-only recordings will be removed when iCloud sync is available.")
     }
 
     func enqueueSummaryRemovalFromiCloud(summaryId: UUID, recordingId: UUID? = nil) {
@@ -4464,7 +4473,7 @@ extension iCloudStorageManager {
         pendingSummaryCloudRemovals = queue
         pendingSyncQueue.removeAll { $0.id == summaryId }
         UserDefaults.standard.removeObject(forKey: Self.backupStateSignatureKey)
-        lastMaintenanceMessage = "Deleted summaries will be removed from iCloud sync records when iCloud sync is available."
+        publishMaintenanceMessage("Deleted summaries will be removed from iCloud sync records when iCloud sync is available.")
     }
 
     func enqueueTranscriptRemovalFromiCloud(transcriptId: UUID, recordingId: UUID? = nil) {
@@ -4482,7 +4491,7 @@ extension iCloudStorageManager {
         }
         pendingTranscriptCloudRemovals = queue
         UserDefaults.standard.removeObject(forKey: Self.backupStateSignatureKey)
-        lastMaintenanceMessage = "Deleted transcripts will be removed from iCloud sync records when iCloud sync is available."
+        publishMaintenanceMessage("Deleted transcripts will be removed from iCloud sync records when iCloud sync is available.")
     }
 
     func clearPendingLocalOnlyCloudRemoval(recordingId: UUID) {


### PR DESCRIPTION
### Summary

- Open iCloud Items Review in a dedicated native macOS window while preserving the iOS sheet flow.
- Make the transcript deletion action adapt to narrow rows with an accessible icon control.
- Defer iCloud maintenance-message publication until after the current SwiftUI update.

### Validation

- `swiftc -parse` passed for all five modified Swift files.
- `git diff --check` and `git diff HEAD^ --check` passed.
- Native macOS Debug build passed with `CODE_SIGNING_ALLOWED=NO ENABLE_DEBUG_DYLIB=NO`.
- SwiftLint reports the repository's existing baseline debt (387 total violations, 100 serious) rather than a clean pass.
- The iOS simulator test run was intentionally interrupted after simulator launch at the user's direction; no XCTest pass/fail result is claimed.