### PR TITLE
Bugfixes: bound runaway caches and logs, transcript resurrection, macOS import and mic fallback

### DIFF
--- a/BisonNotes AI/BisonNotes AI/BisonNotesAIApp.swift
+++ b/BisonNotes AI/BisonNotes AI/BisonNotesAIApp.swift
@@ -820,6 +820,7 @@ struct BisonNotesAIApp: App {
                     _ = OnDeviceAIDownloadMonitor.shared
                     queueParakeetStartupRepairIfNeeded()
                     TemporaryFileCleanupService.shared.cleanupStaleFiles()
+                    CacheMaintenanceService.shared.pruneCachesIfDue()
                     appCoordinator.observeNetworkRestorationForiCloud()
                     appCoordinator.reconcileiCloudIfEnabled(reason: .appLaunch, force: true)
                 }
@@ -848,6 +849,10 @@ struct BisonNotesAIApp: App {
                     // Repair any files left at .complete protection by v1.11.0.
                     migrateFileProtectionForExistingFiles()
                     TemporaryFileCleanupService.shared.cleanupStaleFiles()
+                    // Throttled internally: a Mac can stay open for days, so a
+                    // launch-only sweep would never run on the machine that
+                    // accumulates the most.
+                    CacheMaintenanceService.shared.pruneCachesIfDue()
                     // Scan for files placed by the Share Extension (Voice Memos, etc.)
                     scanSharedContainerForImports(trigger: .pendingToken)
                     // Also scan Documents/Inbox/ for files from "Open In" / document interaction.

--- a/BisonNotes AI/BisonNotes AI/EnhancedAudioSessionManager.swift
+++ b/BisonNotes AI/BisonNotes AI/EnhancedAudioSessionManager.swift
@@ -464,6 +464,7 @@ class EnhancedAudioSessionManager: NSObject, ObservableObject {
 
     private var preferredInputDeviceID: AudioDeviceID?
     private var configuredInputDeviceID: AudioDeviceID?
+    private var configuredInputIsAutomaticFallback = false
     private var inputDeviceMonitor: MacInputDeviceMonitor?
 
     deinit {
@@ -511,20 +512,13 @@ class EnhancedAudioSessionManager: NSObject, ObservableObject {
         }
 
         preferredInputDeviceID = input.audioDeviceID
+        configuredInputIsAutomaticFallback = false
         AppLog.shared.audioSession("Preferred Mac input set to: \(input.portName) (\(input.uid))")
     }
 
     func clearPreferredInput() async throws {
         preferredInputDeviceID = nil
         AppLog.shared.audioSession("Preferred Mac input cleared; using the system default microphone")
-    }
-
-    /// True when a recording would be explicitly bound to a user-selected
-    /// input rather than the current macOS default. Startup recovery can use
-    /// this to try the default route after a selected USB device produces no
-    /// input buffers, without forgetting the persisted user preference.
-    func hasPreferredInput() -> Bool {
-        preferredInputDeviceID != nil
     }
 
     func getAvailableInputs() -> [AVAudioSessionPortDescription] {
@@ -580,16 +574,43 @@ class EnhancedAudioSessionManager: NSObject, ObservableObject {
         return Self.defaultInputDeviceID()
     }
 
+    /// Returns the inputs that can be tried for a new engine, in preference
+    /// order. A meeting app can register a virtual input after this app was
+    /// launched, so callers must use this live list rather than only the
+    /// remembered input or the current default.
+    func recordingInputCandidates() -> [AudioDeviceID] {
+        let inputs = getAvailableInputs()
+        return MacRecordingInputSelection.orderedDeviceIDs(
+            preferredDeviceID: preferredInputDeviceID,
+            defaultDeviceID: Self.defaultInputDeviceID(),
+            available: inputs.map {
+                MacRecordingInputCandidate(deviceID: $0.audioDeviceID, name: $0.portName)
+            }
+        )
+    }
+
+    /// Returns currently available inputs other than the one that just failed.
+    /// The list is intentionally rebuilt for every retry because virtual audio
+    /// drivers may appear while the meeting application is starting.
+    func recordingInputCandidates(excluding deviceID: AudioDeviceID?) -> [AudioDeviceID] {
+        recordingInputCandidates().filter { $0 != deviceID }
+    }
+
     /// True when the engine is still bound to the device the current preference
     /// resolves to. Device-list and default-input listeners use this to ignore
     /// unrelated audio-device changes.
     func recordingInputNeedsRecovery() -> Bool {
         guard let configuredInputDeviceID else { return false }
+        if configuredInputIsAutomaticFallback {
+            let availableDeviceIDs = Set(getAvailableInputs().map(\.audioDeviceID))
+            return !availableDeviceIDs.contains(configuredInputDeviceID)
+        }
         return configuredInputDeviceID != resolvedInputDeviceID()
     }
 
     func clearConfiguredInputDevice() {
         configuredInputDeviceID = nil
+        configuredInputIsAutomaticFallback = false
     }
 
     /// Watches both the system default input and the complete Core Audio device
@@ -608,8 +629,11 @@ class EnhancedAudioSessionManager: NSObject, ObservableObject {
 
     /// Applies the selected Mac input to this engine without changing the
     /// user's system-wide default input device.
-    func configureInputDevice(for engine: AVAudioEngine) throws {
-        guard let deviceID = resolvedInputDeviceID() else {
+    func configureInputDevice(
+        for engine: AVAudioEngine,
+        deviceID requestedDeviceID: AudioDeviceID? = nil
+    ) throws {
+        guard let deviceID = requestedDeviceID ?? resolvedInputDeviceID() else {
             let error = AudioProcessingError.audioSessionConfigurationFailed("No microphone is available.")
             lastError = error
             throw error
@@ -640,6 +664,7 @@ class EnhancedAudioSessionManager: NSObject, ObservableObject {
             throw error
         }
         configuredInputDeviceID = deviceID
+        configuredInputIsAutomaticFallback = requestedDeviceID != nil && deviceID != resolvedInputDeviceID()
 
         let inputName = getAvailableInputs()
             .first(where: { $0.audioDeviceID == deviceID })?

--- a/BisonNotes AI/BisonNotes AI/EnhancedLoggingSystem.swift
+++ b/BisonNotes AI/BisonNotes AI/EnhancedLoggingSystem.swift
@@ -80,6 +80,84 @@ enum LogTrimPolicy {
     }
 }
 
+// MARK: - Rolling Log File
+
+/// One rolling file that survives a crash.
+///
+/// Split out of `AppLog` so the append-and-compact behavior can be exercised
+/// against a real file. The budgets in `LogTrimPolicy` are pure and were already
+/// covered, but they cannot catch a file handle opened in the wrong mode — which
+/// is exactly the defect this type was extracted to make testable.
+struct PersistentLogFile: Sendable {
+    let url: URL
+    let maxLines: Int
+    let maxBytes: Int
+    /// Compaction rewrites the file, so it must not run on every line. Appending is
+    /// cheap; the rewrite happens only once the file crosses its ceiling, and then
+    /// takes it well under, leaving room for many more appends before the next one.
+    var compactionTargetFraction = 0.75
+
+    /// Appends one already-clamped line, compacting only once the file is over budget.
+    func append(_ line: String) {
+        guard let sizeAfterAppend = appendToExistingFile(line) else {
+            // No file yet, or it was removed under us — create it.
+            try? (line + "\n").write(to: url, atomically: true, encoding: .utf8)
+            AppFileProtection.apply(to: url)
+            return
+        }
+
+        guard sizeAfterAppend > UInt64(maxBytes) else { return }
+        compact(toByteBudget: Int(Double(maxBytes) * compactionTargetFraction))
+    }
+
+    /// Appends and returns the file's new size, or `nil` when there is no file to
+    /// append to so `append` can create one.
+    ///
+    /// Two things here are easy to get wrong, and both were:
+    ///
+    /// The handle is opened for *updating* rather than writing, because the
+    /// separator check reads a byte and a write-only descriptor fails that read
+    /// with EBADF. When it did, this reported failure and `append` replaced the
+    /// whole log with the single newest line, losing all history on every call.
+    ///
+    /// The new size comes from the handle rather than `URL.resourceValues`, which
+    /// caches the first value it reads for the lifetime of the `URL`. `AppLog`
+    /// holds one URL per log for the whole process, so a cached size froze at
+    /// whatever the file measured first and the byte ceiling never fired.
+    ///
+    /// Files written by earlier versions end without a trailing newline, so the
+    /// separator is added when the existing content lacks one; otherwise the first
+    /// append after an upgrade would run onto the end of the last line.
+    private func appendToExistingFile(_ line: String) -> UInt64? {
+        guard let handle = try? FileHandle(forUpdating: url) else { return nil }
+        defer { try? handle.close() }
+        do {
+            let end = try handle.seekToEnd()
+            var needsSeparator = false
+            if end > 0 {
+                try handle.seek(toOffset: end - 1)
+                needsSeparator = try handle.read(upToCount: 1) != Data([0x0A])
+                try handle.seek(toOffset: end)
+            }
+            guard let data = ((needsSeparator ? "\n" : "") + line + "\n").data(using: .utf8) else {
+                return end
+            }
+            try handle.write(contentsOf: data)
+            return try handle.offset()
+        } catch {
+            return nil
+        }
+    }
+
+    private func compact(toByteBudget budget: Int) {
+        let existing = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+        let lines = existing.components(separatedBy: "\n").filter { !$0.isEmpty }
+        let kept = LogTrimPolicy.trim(lines: lines, maxLines: maxLines, maxBytes: budget)
+        try? (kept.joined(separator: "\n") + "\n").write(to: url, atomically: true, encoding: .utf8)
+        AppFileProtection.apply(to: url)
+    }
+}
+
 // MARK: - App Logger
 
 final class AppLog: Sendable {
@@ -124,10 +202,6 @@ final class AppLog: Sendable {
     private static let maxErrorLogBytes = 512 * 1024
     private static let maxBreadcrumbLogBytes = 256 * 1024
     private static let maxPersistedLineBytes = 8 * 1024
-    /// Compaction rewrites the file, so it must not run on every line. Appending is
-    /// cheap; the rewrite happens only once the file crosses its ceiling, and then
-    /// takes it well under, leaving room for many more appends before the next one.
-    private static let compactionTargetFraction = 0.75
     private static let cleanShutdownKey = "AppLog_CleanShutdown"
     private let sessionId = UUID().uuidString
     private struct LifecycleState {
@@ -186,72 +260,25 @@ final class AppLog: Sendable {
         (try? String(contentsOf: persistentBreadcrumbURL, encoding: .utf8)) ?? ""
     }
 
-    private func persistLine(_ line: String, to url: URL, maxLines: Int, maxBytes: Int) {
+    private func persistLine(_ line: String, to file: PersistentLogFile) {
         let clamped = LogTrimPolicy.clamp(line, maxBytes: Self.maxPersistedLineBytes)
-        bufferQueue.async {
-            let appended = self.append(clamped, to: url)
-            if !appended {
-                // No file yet (or it was removed under us) — create it.
-                try? (clamped + "\n").write(to: url, atomically: true, encoding: .utf8)
-                AppFileProtection.apply(to: url)
-                return
-            }
-
-            guard self.byteSize(of: url) > maxBytes else { return }
-            self.compact(url, maxLines: maxLines, maxBytes: Int(Double(maxBytes) * Self.compactionTargetFraction))
-        }
-    }
-
-    /// Appends without reading the file back. Returns false when there is nothing
-    /// to append to, so the caller can create the file instead.
-    ///
-    /// Files written by earlier versions end without a trailing newline, so the
-    /// separator is added here when the existing content lacks one — otherwise the
-    /// first append after an upgrade would run onto the end of the last line.
-    private func append(_ line: String, to url: URL) -> Bool {
-        guard let handle = try? FileHandle(forWritingTo: url) else { return false }
-        defer { try? handle.close() }
-        do {
-            let end = try handle.seekToEnd()
-            var needsSeparator = false
-            if end > 0 {
-                try handle.seek(toOffset: end - 1)
-                needsSeparator = try handle.read(upToCount: 1) != Data([0x0A])
-                try handle.seek(toOffset: end)
-            }
-            guard let data = ((needsSeparator ? "\n" : "") + line + "\n").data(using: .utf8) else {
-                return true
-            }
-            try handle.write(contentsOf: data)
-            return true
-        } catch {
-            return false
-        }
-    }
-
-    private func byteSize(of url: URL) -> Int {
-        (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
-    }
-
-    private func compact(_ url: URL, maxLines: Int, maxBytes: Int) {
-        let existing = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
-        let lines = existing.components(separatedBy: "\n").filter { !$0.isEmpty }
-        let kept = LogTrimPolicy.trim(lines: lines, maxLines: maxLines, maxBytes: maxBytes)
-        try? (kept.joined(separator: "\n") + "\n").write(to: url, atomically: true, encoding: .utf8)
-        AppFileProtection.apply(to: url)
+        bufferQueue.async { file.append(clamped) }
     }
 
     private func persistErrorLine(_ line: String) {
-        persistLine(line, to: persistentLogURL, maxLines: Self.maxBufferLines, maxBytes: Self.maxErrorLogBytes)
+        persistLine(line, to: PersistentLogFile(
+            url: persistentLogURL,
+            maxLines: Self.maxBufferLines,
+            maxBytes: Self.maxErrorLogBytes
+        ))
     }
 
     private func persistBreadcrumbLine(_ line: String) {
-        persistLine(
-            line,
-            to: persistentBreadcrumbURL,
+        persistLine(line, to: PersistentLogFile(
+            url: persistentBreadcrumbURL,
             maxLines: Self.maxBreadcrumbLines,
             maxBytes: Self.maxBreadcrumbLogBytes
-        )
+        ))
     }
 
     private func lifecycleBreadcrumb(_ message: String) {

--- a/BisonNotes AI/BisonNotes AI/EnhancedLoggingSystem.swift
+++ b/BisonNotes AI/BisonNotes AI/EnhancedLoggingSystem.swift
@@ -34,6 +34,52 @@ enum LogCategory: String, CaseIterable, Sendable {
     case general = "General"
 }
 
+// MARK: - Persisted Log Budgets
+
+/// Budget rules for the rolling files that survive a crash.
+///
+/// A line-count cap alone does not bound a log file. A single message can be a
+/// model response, a decoded payload, or a CloudKit error description, and one
+/// 350 KB line was enough to push a 500-line error log past 4 MB — which then
+/// cost a 4 MB read and a 4 MB rewrite on *every* subsequent log call. So each
+/// line is clamped first and the file carries a byte ceiling as well.
+///
+/// Pure so the budgets can be tested without touching the filesystem.
+enum LogTrimPolicy {
+    /// Clamps one line so a single huge message cannot consume the whole budget.
+    /// Keeps the head, which is where the message and the first frames live.
+    static func clamp(_ line: String, maxBytes: Int) -> String {
+        let flattened = line.replacingOccurrences(of: "\n", with: "⏎")
+        guard flattened.utf8.count > maxBytes else { return flattened }
+
+        let marker = "…[truncated]"
+        let budget = max(0, maxBytes - marker.utf8.count)
+        var kept = String()
+        var used = 0
+        for character in flattened {
+            let width = String(character).utf8.count
+            if used + width > budget { break }
+            kept.append(character)
+            used += width
+        }
+        return kept + marker
+    }
+
+    /// Drops the oldest lines until the joined text fits both budgets.
+    /// Always keeps at least the newest line, so a log call is never a no-op.
+    static func trim(lines: [String], maxLines: Int, maxBytes: Int) -> [String] {
+        var kept = lines.count > maxLines ? Array(lines.suffix(maxLines)) : lines
+        var total = kept.reduce(0) { $0 + $1.utf8.count + 1 }
+        var firstKept = 0
+        while total > maxBytes, firstKept < kept.count - 1 {
+            total -= kept[firstKept].utf8.count + 1
+            firstKept += 1
+        }
+        if firstKept > 0 { kept = Array(kept.dropFirst(firstKept)) }
+        return kept
+    }
+}
+
 // MARK: - App Logger
 
 final class AppLog: Sendable {
@@ -73,6 +119,15 @@ final class AppLog: Sendable {
     private let bufferQueue = DispatchQueue(label: "com.bisonnotes.logbuffer", qos: .utility)
     private static let maxBufferLines = 500
     private static let maxBreadcrumbLines = 750
+    /// Byte ceilings. See ``LogTrimPolicy`` for why the line counts above are not
+    /// enough on their own. Sized so a full export stays small enough to email.
+    private static let maxErrorLogBytes = 512 * 1024
+    private static let maxBreadcrumbLogBytes = 256 * 1024
+    private static let maxPersistedLineBytes = 8 * 1024
+    /// Compaction rewrites the file, so it must not run on every line. Appending is
+    /// cheap; the rewrite happens only once the file crosses its ceiling, and then
+    /// takes it well under, leaving room for many more appends before the next one.
+    private static let compactionTargetFraction = 0.75
     private static let cleanShutdownKey = "AppLog_CleanShutdown"
     private let sessionId = UUID().uuidString
     private struct LifecycleState {
@@ -131,26 +186,72 @@ final class AppLog: Sendable {
         (try? String(contentsOf: persistentBreadcrumbURL, encoding: .utf8)) ?? ""
     }
 
-    private func persistLine(_ line: String, to url: URL, maxLines: Int) {
+    private func persistLine(_ line: String, to url: URL, maxLines: Int, maxBytes: Int) {
+        let clamped = LogTrimPolicy.clamp(line, maxBytes: Self.maxPersistedLineBytes)
         bufferQueue.async {
-            let existing = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
-            var lines = existing.components(separatedBy: "\n").filter { !$0.isEmpty }
-            lines.append(line)
-            // Keep only the last N lines
-            if lines.count > maxLines {
-                lines = Array(lines.suffix(maxLines))
+            let appended = self.append(clamped, to: url)
+            if !appended {
+                // No file yet (or it was removed under us) — create it.
+                try? (clamped + "\n").write(to: url, atomically: true, encoding: .utf8)
+                AppFileProtection.apply(to: url)
+                return
             }
-            try? lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
-            AppFileProtection.apply(to: url)
+
+            guard self.byteSize(of: url) > maxBytes else { return }
+            self.compact(url, maxLines: maxLines, maxBytes: Int(Double(maxBytes) * Self.compactionTargetFraction))
         }
     }
 
+    /// Appends without reading the file back. Returns false when there is nothing
+    /// to append to, so the caller can create the file instead.
+    ///
+    /// Files written by earlier versions end without a trailing newline, so the
+    /// separator is added here when the existing content lacks one — otherwise the
+    /// first append after an upgrade would run onto the end of the last line.
+    private func append(_ line: String, to url: URL) -> Bool {
+        guard let handle = try? FileHandle(forWritingTo: url) else { return false }
+        defer { try? handle.close() }
+        do {
+            let end = try handle.seekToEnd()
+            var needsSeparator = false
+            if end > 0 {
+                try handle.seek(toOffset: end - 1)
+                needsSeparator = try handle.read(upToCount: 1) != Data([0x0A])
+                try handle.seek(toOffset: end)
+            }
+            guard let data = ((needsSeparator ? "\n" : "") + line + "\n").data(using: .utf8) else {
+                return true
+            }
+            try handle.write(contentsOf: data)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private func byteSize(of url: URL) -> Int {
+        (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+    }
+
+    private func compact(_ url: URL, maxLines: Int, maxBytes: Int) {
+        let existing = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+        let lines = existing.components(separatedBy: "\n").filter { !$0.isEmpty }
+        let kept = LogTrimPolicy.trim(lines: lines, maxLines: maxLines, maxBytes: maxBytes)
+        try? (kept.joined(separator: "\n") + "\n").write(to: url, atomically: true, encoding: .utf8)
+        AppFileProtection.apply(to: url)
+    }
+
     private func persistErrorLine(_ line: String) {
-        persistLine(line, to: persistentLogURL, maxLines: Self.maxBufferLines)
+        persistLine(line, to: persistentLogURL, maxLines: Self.maxBufferLines, maxBytes: Self.maxErrorLogBytes)
     }
 
     private func persistBreadcrumbLine(_ line: String) {
-        persistLine(line, to: persistentBreadcrumbURL, maxLines: Self.maxBreadcrumbLines)
+        persistLine(
+            line,
+            to: persistentBreadcrumbURL,
+            maxLines: Self.maxBreadcrumbLines,
+            maxBytes: Self.maxBreadcrumbLogBytes
+        )
     }
 
     private func lifecycleBreadcrumb(_ message: String) {

--- a/BisonNotes AI/BisonNotes AI/LogExporter.swift
+++ b/BisonNotes AI/BisonNotes AI/LogExporter.swift
@@ -124,8 +124,35 @@ struct LogExporter {
 
         let fileName = "BisonNotes-Logs-\(timestamp).txt"
         let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
+        // Each export is multi-megabyte and nothing ever removed the previous ones,
+        // so tmp accumulated one copy per support request. Drop the old ones first;
+        // only the file we are about to hand to the share sheet needs to exist.
+        removePreviousExports(keeping: fileURL)
         try text.write(to: fileURL, atomically: true, encoding: .utf8)
         return fileURL
+    }
+
+    /// Name of a diagnostic export, used here and by `TemporaryFileCleanupService`
+    /// for the exports a crash leaves behind between runs.
+    static let exportFileNamePrefix = "BisonNotes-Logs-"
+
+    static func isExportFileName(_ name: String) -> Bool {
+        name.hasPrefix(exportFileNamePrefix) && name.hasSuffix(".txt")
+    }
+
+    private static func removePreviousExports(keeping current: URL) {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory
+        guard let contents = try? fileManager.contentsOfDirectory(
+            at: tempRoot,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else { return }
+
+        for url in contents
+        where isExportFileName(url.lastPathComponent) && url.lastPathComponent != current.lastPathComponent {
+            try? fileManager.removeItem(at: url)
+        }
     }
 
     private static func sectionHeader(_ title: String) -> String {

--- a/BisonNotes AI/BisonNotes AI/MLXSwiftEngine.swift
+++ b/BisonNotes AI/BisonNotes AI/MLXSwiftEngine.swift
@@ -370,6 +370,35 @@ extension MLXSwiftDownloadManager {
         if FileManager.default.fileExists(atPath: dir.path) {
             try FileManager.default.removeItem(at: dir)
         }
+        // `defaultHubApi` downloads through a content-addressed blob cache and then
+        // copies into its `downloadBase`, so the directory above is only half of what
+        // the model occupies. Removing just it left a full second copy behind — two
+        // "deleted" models were still costing 3.3 GB. `CacheMaintenanceService` also
+        // sweeps these, but a delete the user asked for should free the space now.
+        removeHubBlobCache(for: modelId)
+    }
+
+    private func removeHubBlobCache(for modelId: String) {
+        guard let hubRepo = FileManager.default
+            .urls(for: .cachesDirectory, in: .userDomainMask).first?
+            .appendingPathComponent("huggingface", isDirectory: true)
+            .appendingPathComponent("hub", isDirectory: true)
+            .appendingPathComponent(
+                CacheMaintenancePolicy.hubRepoDirectoryName(forModelID: modelId),
+                isDirectory: true
+            ),
+            FileManager.default.fileExists(atPath: hubRepo.path) else {
+            return
+        }
+
+        do {
+            try FileManager.default.removeItem(at: hubRepo)
+        } catch {
+            AppLog.shared.fileManagement(
+                "Could not remove blob cache for \(modelId): \(error.localizedDescription)",
+                level: .error
+            )
+        }
     }
 }
 

--- a/BisonNotes AI/BisonNotes AI/MLXSwiftEngine.swift
+++ b/BisonNotes AI/BisonNotes AI/MLXSwiftEngine.swift
@@ -351,6 +351,20 @@ extension MLXSwiftDownloadManager {
                 self?.downloadProgress = progress.fractionCompleted
             }
         }
+
+        // `defaultHubApi` downloads through a content-addressed blob cache and then
+        // copies the result into its `downloadBase`, so a finished model sits on disk
+        // twice — 15.8 GB for a 7.9 GB model.
+        //
+        // The blobs are only useful *during* a download: everything that resumes an
+        // interrupted one lives in that cache, which is why disabling it outright is
+        // the wrong fix. Once the materialized copy is complete they are dead weight,
+        // so they go here rather than waiting for the next maintenance sweep.
+        //
+        // Gated on the model actually being usable: if the download somehow did not
+        // materialize, the blobs are what a retry resumes from and must survive.
+        guard checkModelExists(modelId: id) else { return }
+        removeHubBlobCache(for: id)
     }
 
     func checkModelExists() -> Bool {

--- a/BisonNotes AI/BisonNotes AI/MLXSwiftEngine.swift
+++ b/BisonNotes AI/BisonNotes AI/MLXSwiftEngine.swift
@@ -18,6 +18,7 @@ enum MLXSwiftSettingsKeys {
     static let topK = "mlxSwiftTopK"
     static let topP = "mlxSwiftTopP"
     static let repetitionPenalty = "mlxSwiftRepeatPenalty"
+    static let inFlightDownloadModelID = "mlxSwiftInFlightDownloadModelID"
 
     static let smallModelId = "prism-ml/Ternary-Bonsai-1.7B-mlx-2bit"
     static let defaultModelId = "prism-ml/Ternary-Bonsai-4B-mlx-2bit"
@@ -103,6 +104,8 @@ final class MLXSwiftDownloadManager: ObservableObject {
     @Published private(set) var isModelDownloaded = false
 
     private var downloadTask: Task<Void, Never>?
+    private var isCacheMaintenanceInProgress = false
+    private var downloadRequestedDuringCacheMaintenance = false
 
     var modelId: String {
         UserDefaults.standard.string(forKey: MLXSwiftSettingsKeys.modelId)
@@ -125,14 +128,48 @@ final class MLXSwiftDownloadManager: ObservableObject {
         #endif
     }
 
+    /// Reserves the Hub cache for the off-main maintenance sweep. Both this
+    /// method and `startDownload()` run on the main actor, so acquisition and
+    /// download startup are mutually exclusive rather than a check followed by
+    /// an unprotected filesystem operation.
+    @discardableResult
+    func beginCacheMaintenance() -> Bool {
+        guard !isDownloading, !isCacheMaintenanceInProgress else { return false }
+        isCacheMaintenanceInProgress = true
+        return true
+    }
+
+    /// Releases the cache reservation after the detached filesystem sweep has
+    /// finished. A download requested while the sweep was running starts now.
+    func endCacheMaintenance() {
+        guard isCacheMaintenanceInProgress else { return }
+        isCacheMaintenanceInProgress = false
+        guard downloadRequestedDuringCacheMaintenance else { return }
+        downloadRequestedDuringCacheMaintenance = false
+        startDownload()
+    }
+
     func startDownload() {
         guard !isDownloading else { return }
+        if isCacheMaintenanceInProgress {
+            downloadRequestedDuringCacheMaintenance = true
+            return
+        }
+        let id = modelId
         isDownloading = true
         downloadError = nil
         downloadProgress = 0
+        UserDefaults.standard.set(id, forKey: MLXSwiftSettingsKeys.inFlightDownloadModelID)
 
         downloadTask = Task { [weak self] in
             guard let self else { return }
+            defer {
+                self.isDownloading = false
+                self.downloadTask = nil
+                if UserDefaults.standard.string(forKey: MLXSwiftSettingsKeys.inFlightDownloadModelID) == id {
+                    UserDefaults.standard.removeObject(forKey: MLXSwiftSettingsKeys.inFlightDownloadModelID)
+                }
+            }
             do {
                 #if canImport(MLXLLM) && canImport(MLXLMCommon)
                 try await self.performDownload()
@@ -140,13 +177,12 @@ final class MLXSwiftDownloadManager: ObservableObject {
                 throw NSError(domain: "MLXSwift", code: -1,
                               userInfo: [NSLocalizedDescriptionKey: "MLX libraries not available"])
                 #endif
-                self.isDownloading = false
+                guard !Task.isCancelled else { return }
                 self.isModelDownloaded = true
                 AppLog.shared.summarization("[MLXSwift] Model pre-download complete: \(self.modelId)")
             } catch {
                 if !Task.isCancelled {
                     self.downloadError = error.localizedDescription
-                    self.isDownloading = false
                     AppLog.shared.summarization("[MLXSwift] Download failed: \(error.localizedDescription)", level: .error)
                 }
             }
@@ -155,8 +191,6 @@ final class MLXSwiftDownloadManager: ObservableObject {
 
     func cancelDownload() {
         downloadTask?.cancel()
-        downloadTask = nil
-        isDownloading = false
         downloadProgress = 0
         downloadError = nil
     }
@@ -361,9 +395,16 @@ extension MLXSwiftDownloadManager {
         // the wrong fix. Once the materialized copy is complete they are dead weight,
         // so they go here rather than waiting for the next maintenance sweep.
         //
-        // Gated on the model actually being usable: if the download somehow did not
-        // materialize, the blobs are what a retry resumes from and must survive.
-        guard checkModelExists(modelId: id) else { return }
+        // Gated on the model actually being usable: if the download was interrupted
+        // after config.json landed, the blobs are what a retry resumes from and must
+        // survive, and the manager must not report a partial model as downloaded.
+        guard checkModelExists(modelId: id) else {
+            throw NSError(
+                domain: "MLXSwift",
+                code: -2,
+                userInfo: [NSLocalizedDescriptionKey: "The model download did not finish materializing its weights."]
+            )
+        }
         removeHubBlobCache(for: id)
     }
 
@@ -374,8 +415,7 @@ extension MLXSwiftDownloadManager {
     func checkModelExists(modelId: String) -> Bool {
         let config = ModelConfiguration(id: modelId)
         let dir = config.modelDirectory(hub: defaultHubApi)
-        let configFile = dir.appendingPathComponent("config.json")
-        return FileManager.default.fileExists(atPath: configFile.path)
+        return CacheMaintenancePolicy.isMaterializedModelComplete(at: dir)
     }
 
     func removeModelFiles() throws {

--- a/BisonNotes AI/BisonNotes AI/Models/AppDataCoordinator.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/AppDataCoordinator.swift
@@ -323,9 +323,11 @@ class AppDataCoordinator: ObservableObject {
         }
 
         do {
-            if let transcriptId {
+            for transcriptId in transcriptIds {
                 // The marker is already queued; this only removes the local row.
-                // Works when the request's relationship is stale, too.
+                // Remove every identity collected above, including stale ids from
+                // the recording and summary relationships. Otherwise backup can
+                // select an older remaining row and recreate the deleted transcript.
                 try coreDataManager.deleteTranscript(id: transcriptId, enqueueCloudDeletion: false)
                 committedTranscriptIds.insert(transcriptId)
             }

--- a/BisonNotes AI/BisonNotes AI/Models/AppDataCoordinator.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/AppDataCoordinator.swift
@@ -306,10 +306,19 @@ class AppDataCoordinator: ObservableObject {
             requestedAt: deletionDate
         )
 
-        func withdrawQueuedRemovals() {
-            for transcriptId in transcriptIds {
+        // `deleteTranscript` commits a save of its own, so its rows can be durably
+        // gone even when the work below fails. Withdrawing a marker for one of those
+        // would leave the transcript deleted locally with nothing telling the other
+        // devices — the resurrection this method exists to prevent — so only intents
+        // whose mutation has not committed are taken back.
+        var committedTranscriptIds: Set<UUID> = []
+
+        func withdrawUncommittedRemovals() {
+            for transcriptId in transcriptIds where !committedTranscriptIds.contains(transcriptId) {
                 iCloudManager.clearPendingTranscriptRemoval(transcriptId: transcriptId)
             }
+            // `recordingURL` is only cleared by the `saveContext()` below, so if that
+            // did not land the audio is still referenced locally and its intent goes.
             iCloudManager.clearPendingImportedAudioRemoval(recordingId: recordingId)
         }
 
@@ -318,6 +327,7 @@ class AppDataCoordinator: ObservableObject {
                 // The marker is already queued; this only removes the local row.
                 // Works when the request's relationship is stale, too.
                 try coreDataManager.deleteTranscript(id: transcriptId, enqueueCloudDeletion: false)
+                committedTranscriptIds.insert(transcriptId)
             }
 
             guard let recording = coreDataManager.getRecording(id: recordingId) else {
@@ -347,7 +357,7 @@ class AppDataCoordinator: ObservableObject {
             recording.lastModified = deletionDate
             try coreDataManager.saveContext()
         } catch {
-            withdrawQueuedRemovals()
+            withdrawUncommittedRemovals()
             throw error
         }
 

--- a/BisonNotes AI/BisonNotes AI/Models/AppDataCoordinator.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/AppDataCoordinator.swift
@@ -283,40 +283,17 @@ class AppDataCoordinator: ObservableObject {
             initialSummary?.transcript?.id
         ].compactMap { $0 })
 
-        if let transcriptId {
-            // Cloud deletion is queued below, only after the local save succeeds.
-            // This also works when the request's relationship is stale.
-            try coreDataManager.deleteTranscript(id: transcriptId, enqueueCloudDeletion: false)
-        }
-
-        guard let recording = coreDataManager.getRecording(id: recordingId) else {
-            throw NSError(
-                domain: "AppDataCoordinator",
-                code: 404,
-                userInfo: [NSLocalizedDescriptionKey: "Recording no longer exists."]
-            )
-        }
-
-        let currentTranscriptId = recording.transcriptId ?? recording.transcript?.id
-        if currentTranscriptId.map({ transcriptIds.contains($0) }) ?? true {
-            recording.transcript = nil
-            recording.transcriptId = nil
-            recording.transcriptionStatus = ProcessingStatus.notStarted.rawValue
-        }
-
-        if let summary = coreDataManager.getSummary(for: recordingId) ?? recording.summary {
-            let currentSummaryTranscriptId = summary.transcriptId ?? summary.transcript?.id
-            if currentSummaryTranscriptId.map({ transcriptIds.contains($0) }) ?? true {
-                summary.transcript = nil
-                summary.transcriptId = nil
-            }
-        }
-
+        // Persist both removal intents before touching anything locally, the same
+        // way `deleteSummary` and `setCloudSyncDisabled` do. Queuing them after the
+        // save left a window where a termination between the two would take the
+        // transcript and audio away locally with nothing durable telling the other
+        // devices — and the next sync would restore exactly what the user deleted,
+        // which is the resurrection this method exists to prevent. Withdrawn below
+        // if the local work does not commit.
+        //
+        // `deletionDate` is when the user asked, which is also what the markers must
+        // carry: a marker that reaches CloudKit days later must not erase newer work.
         let deletionDate = Date()
-        recording.recordingURL = nil
-        recording.lastModified = deletionDate
-        try coreDataManager.saveContext()
-
         for transcriptId in transcriptIds {
             iCloudManager.enqueueTranscriptRemovalFromiCloud(
                 transcriptId: transcriptId,
@@ -328,6 +305,51 @@ class AppDataCoordinator: ObservableObject {
             recordingId: recordingId,
             requestedAt: deletionDate
         )
+
+        func withdrawQueuedRemovals() {
+            for transcriptId in transcriptIds {
+                iCloudManager.clearPendingTranscriptRemoval(transcriptId: transcriptId)
+            }
+            iCloudManager.clearPendingImportedAudioRemoval(recordingId: recordingId)
+        }
+
+        do {
+            if let transcriptId {
+                // The marker is already queued; this only removes the local row.
+                // Works when the request's relationship is stale, too.
+                try coreDataManager.deleteTranscript(id: transcriptId, enqueueCloudDeletion: false)
+            }
+
+            guard let recording = coreDataManager.getRecording(id: recordingId) else {
+                throw NSError(
+                    domain: "AppDataCoordinator",
+                    code: 404,
+                    userInfo: [NSLocalizedDescriptionKey: "Recording no longer exists."]
+                )
+            }
+
+            let currentTranscriptId = recording.transcriptId ?? recording.transcript?.id
+            if currentTranscriptId.map({ transcriptIds.contains($0) }) ?? true {
+                recording.transcript = nil
+                recording.transcriptId = nil
+                recording.transcriptionStatus = ProcessingStatus.notStarted.rawValue
+            }
+
+            if let summary = coreDataManager.getSummary(for: recordingId) ?? recording.summary {
+                let currentSummaryTranscriptId = summary.transcriptId ?? summary.transcript?.id
+                if currentSummaryTranscriptId.map({ transcriptIds.contains($0) }) ?? true {
+                    summary.transcript = nil
+                    summary.transcriptId = nil
+                }
+            }
+
+            recording.recordingURL = nil
+            recording.lastModified = deletionDate
+            try coreDataManager.saveContext()
+        } catch {
+            withdrawQueuedRemovals()
+            throw error
+        }
 
         do {
             try await iCloudManager.flushPendingiCloudDeletions(appCoordinator: self)

--- a/BisonNotes AI/BisonNotes AI/Models/AppDataCoordinator.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/AppDataCoordinator.swift
@@ -257,6 +257,89 @@ class AppDataCoordinator: ObservableObject {
         objectWillChange.send()
     }
 
+    /// Removes an imported transcript placeholder while retaining its recording
+    /// metadata and summary. Unlike an ordinary missing-file cleanup, this is an
+    /// explicit user deletion: its cloud audio removal and any stale transcript
+    /// identity must survive until CloudKit accepts them.
+    func deleteImportedTranscriptPreservingSummary(
+        recordingId: UUID,
+        transcriptId: UUID? = nil
+    ) async throws {
+        guard let initialRecording = coreDataManager.getRecording(id: recordingId) else {
+            throw NSError(
+                domain: "AppDataCoordinator",
+                code: 404,
+                userInfo: [NSLocalizedDescriptionKey: "Recording no longer exists."]
+            )
+        }
+
+        let iCloudManager = SummaryManager.shared.getiCloudManager()
+        let initialSummary = coreDataManager.getSummary(for: recordingId) ?? initialRecording.summary
+        let transcriptIds = Set([
+            transcriptId,
+            initialRecording.transcriptId,
+            initialRecording.transcript?.id,
+            initialSummary?.transcriptId,
+            initialSummary?.transcript?.id
+        ].compactMap { $0 })
+
+        if let transcriptId {
+            // Cloud deletion is queued below, only after the local save succeeds.
+            // This also works when the request's relationship is stale.
+            try coreDataManager.deleteTranscript(id: transcriptId, enqueueCloudDeletion: false)
+        }
+
+        guard let recording = coreDataManager.getRecording(id: recordingId) else {
+            throw NSError(
+                domain: "AppDataCoordinator",
+                code: 404,
+                userInfo: [NSLocalizedDescriptionKey: "Recording no longer exists."]
+            )
+        }
+
+        let currentTranscriptId = recording.transcriptId ?? recording.transcript?.id
+        if currentTranscriptId.map({ transcriptIds.contains($0) }) ?? true {
+            recording.transcript = nil
+            recording.transcriptId = nil
+            recording.transcriptionStatus = ProcessingStatus.notStarted.rawValue
+        }
+
+        if let summary = coreDataManager.getSummary(for: recordingId) ?? recording.summary {
+            let currentSummaryTranscriptId = summary.transcriptId ?? summary.transcript?.id
+            if currentSummaryTranscriptId.map({ transcriptIds.contains($0) }) ?? true {
+                summary.transcript = nil
+                summary.transcriptId = nil
+            }
+        }
+
+        let deletionDate = Date()
+        recording.recordingURL = nil
+        recording.lastModified = deletionDate
+        try coreDataManager.saveContext()
+
+        for transcriptId in transcriptIds {
+            iCloudManager.enqueueTranscriptRemovalFromiCloud(
+                transcriptId: transcriptId,
+                recordingId: recordingId,
+                requestedAt: deletionDate
+            )
+        }
+        iCloudManager.enqueueImportedAudioRemovalFromiCloud(
+            recordingId: recordingId,
+            requestedAt: deletionDate
+        )
+
+        do {
+            try await iCloudManager.flushPendingiCloudDeletions(appCoordinator: self)
+        } catch {
+            AppLog.shared.coreData(
+                "Imported transcript cleanup saved locally; queued iCloud removal for retry: \(error)",
+                level: .error
+            )
+        }
+        objectWillChange.send()
+    }
+
     func deleteSummary(id: UUID) async throws {
         let iCloudManager = SummaryManager.shared.getiCloudManager()
         let summary = coreDataManager.getSummary(id: id)

--- a/BisonNotes AI/BisonNotes AI/Models/MacRecordingReliability.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/MacRecordingReliability.swift
@@ -7,6 +7,88 @@
 
 import Foundation
 
+/// The small, platform-neutral part of native Mac microphone selection.
+///
+/// Core Audio device IDs are UInt32 values on macOS, but keeping this ordering
+/// helper independent of CoreAudio lets the fallback policy be covered by the
+/// regular cross-platform reliability tests.
+struct MacRecordingInputCandidate: Equatable, Sendable {
+    let deviceID: UInt32
+    let name: String
+}
+
+enum MacRecordingInputSelection {
+    /// Orders startup candidates without changing the user's persisted choice:
+    /// use that choice first, then the current system default, then other
+    /// available inputs. Virtual meeting bridges are tried before unrelated
+    /// secondary devices once the preferred/default routes have failed.
+    static func orderedDeviceIDs(
+        preferredDeviceID: UInt32?,
+        defaultDeviceID: UInt32?,
+        available: [MacRecordingInputCandidate]
+    ) -> [UInt32] {
+        let uniqueAvailable = uniqueCandidates(available)
+        let availableIDs = Set(uniqueAvailable.map(\.deviceID))
+        var orderedIDs: [UInt32] = []
+
+        func appendIfAvailable(_ deviceID: UInt32?) {
+            guard let deviceID,
+                  availableIDs.contains(deviceID),
+                  !orderedIDs.contains(deviceID) else { return }
+            orderedIDs.append(deviceID)
+        }
+
+        appendIfAvailable(preferredDeviceID)
+        appendIfAvailable(defaultDeviceID)
+
+        for candidate in uniqueAvailable.sorted(by: isPreferredFallbackOrder) {
+            appendIfAvailable(candidate.deviceID)
+        }
+
+        // A default Core Audio input can briefly be absent from AVCapture's
+        // discovery list while a virtual driver is being registered. It is
+        // still a valid input candidate, so keep it in the returned order.
+        if let defaultDeviceID, !orderedIDs.contains(defaultDeviceID) {
+            let preferredIsAvailable = preferredDeviceID.map(availableIDs.contains) ?? false
+            orderedIDs.insert(defaultDeviceID, at: preferredIsAvailable ? min(1, orderedIDs.count) : 0)
+        }
+
+        return orderedIDs
+    }
+
+    private static func uniqueCandidates(
+        _ candidates: [MacRecordingInputCandidate]
+    ) -> [MacRecordingInputCandidate] {
+        var seen = Set<UInt32>()
+        return candidates.filter { seen.insert($0.deviceID).inserted }
+    }
+
+    private static func isPreferredFallbackOrder(
+        _ lhs: MacRecordingInputCandidate,
+        _ rhs: MacRecordingInputCandidate
+    ) -> Bool {
+        let lhsBridge = isMeetingAudioBridge(lhs.name)
+        let rhsBridge = isMeetingAudioBridge(rhs.name)
+        if lhsBridge != rhsBridge {
+            return lhsBridge
+        }
+        return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+    }
+
+    private static func isMeetingAudioBridge(_ name: String) -> Bool {
+        let normalizedName = name.lowercased()
+        return [
+            "zoom",
+            "teams",
+            "virtual",
+            "blackhole",
+            "loopback",
+            "soundflower",
+            "aggregate"
+        ].contains(where: { normalizedName.contains($0) })
+    }
+}
+
 struct RecordingCaptureHealthSnapshot: Equatable, Sendable {
     let monitoringStartedAt: Date?
     let firstWriteAt: Date?

--- a/BisonNotes AI/BisonNotes AI/Models/MacRecordingReliability.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/MacRecordingReliability.swift
@@ -17,7 +17,42 @@ struct MacRecordingInputCandidate: Equatable, Sendable {
     let name: String
 }
 
+/// Why a microphone recovery attempt is starting.
+///
+/// The distinction matters because the exclusion below is a hard filter
+/// (`recordingInputCandidates(excluding:)` drops the device outright rather than
+/// deprioritizing it), so a device left out is not tried at all.
+enum MacInputRecoveryTrigger: Equatable, Sendable {
+    /// The bound input stopped producing audio, or stopped resolving.
+    case currentInputFailed
+    /// A device became available while the recording was waiting for one.
+    case deviceBecameAvailable
+}
+
 enum MacRecordingInputSelection {
+    /// The input the next recovery attempt must skip, if any.
+    ///
+    /// Core Audio can hand a reconnected microphone the same device ID it had
+    /// before, so the ID the recording was last bound to is only evidence of a bad
+    /// device while that device is the one that just failed. On a reconnection it
+    /// is just as likely to be the device the user plugged back in.
+    ///
+    /// Carrying the exclusion into a reconnection is what left a recording stuck:
+    /// the failure path never clears `macInputDeviceID`, so a mic that came back
+    /// with its old ID was filtered out of its own recovery, and with no other
+    /// input present the recording stayed in `waitingForMicrophone` for good.
+    static func excludedDeviceID(
+        currentInputDeviceID: UInt32?,
+        trigger: MacInputRecoveryTrigger
+    ) -> UInt32? {
+        switch trigger {
+        case .currentInputFailed:
+            return currentInputDeviceID
+        case .deviceBecameAvailable:
+            return nil
+        }
+    }
+
     /// Orders startup candidates without changing the user's persisted choice:
     /// use that choice first, then the current system default, then other
     /// available inputs. Virtual meeting bridges are tried before unrelated

--- a/BisonNotes AI/BisonNotes AI/Services/CacheMaintenanceService.swift
+++ b/BisonNotes AI/BisonNotes AI/Services/CacheMaintenanceService.swift
@@ -60,6 +60,37 @@ enum CacheMaintenancePolicy {
         return "\(namespace)/\(repository)"
     }
 
+    /// A materialized model is usable only when its configuration and at least
+    /// one non-empty weight file have landed. `config.json` can be copied before
+    /// the download is interrupted, so it is not a completion marker by itself.
+    static func isMaterializedModelComplete(at directory: URL) -> Bool {
+        let fileManager = FileManager.default
+        let configURL = directory.appendingPathComponent("config.json")
+        let configValues = try? configURL.resourceValues(
+            forKeys: [.isRegularFileKey, .fileSizeKey]
+        )
+        guard configValues?.isRegularFile == true, (configValues?.fileSize ?? 0) > 0 else {
+            return false
+        }
+
+        guard let enumerator = fileManager.enumerator(
+            at: directory,
+            includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return false
+        }
+
+        while let file = enumerator.nextObject() as? URL {
+            guard file.pathExtension.lowercased() == "safetensors" else { continue }
+            let values = try? file.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            if values?.isRegularFile == true, (values?.fileSize ?? 0) > 0 {
+                return true
+            }
+        }
+        return false
+    }
+
     /// Why a hub repository directory is being removed. Only used for reporting —
     /// both cases are equally safe to delete — but the two mean very different
     /// things when reading the log, so they are counted apart.
@@ -141,7 +172,7 @@ enum CacheMaintenancePolicy {
 
 // MARK: - Report
 
-struct CacheMaintenanceReport: Equatable {
+struct CacheMaintenanceReport: Equatable, Sendable {
     var duplicateModelBlobBytes: Int64 = 0
     var orphanedModelBlobBytes: Int64 = 0
     var cloudKitAssetBytes: Int64 = 0
@@ -185,6 +216,11 @@ final class CacheMaintenanceService {
     /// isolated, and handed to the sweep as a value.
     func pruneCachesIfDue(now: Date = Date()) {
         if let lastSweep, now.timeIntervalSince(lastSweep) < Self.sweepInterval { return }
+
+        // Reserve the shared Hub cache before leaving the main actor. The
+        // filesystem sweep is deliberately off-main, so a point-in-time
+        // `isDownloading` read cannot protect the interval before removeItem.
+        guard MLXSwiftDownloadManager.shared.beginCacheMaintenance() else { return }
         lastSweep = now
 
         Task.detached(priority: .utility) {
@@ -195,14 +231,17 @@ final class CacheMaintenanceService {
             let report = await CacheMaintenanceSweep().run {
                 await MainActor.run { MLXSwiftDownloadManager.shared.isDownloading }
             }
-            guard report.didReclaimAnything else { return }
-            AppLog.shared.fileManagement(
-                "Cache maintenance reclaimed \(report.formattedReclaimedBytes) — "
-                + "model blobs: \(report.formattedDuplicateModelBlobBytes) duplicate, "
-                + "\(report.formattedOrphanedModelBlobBytes) orphaned; "
-                + "CloudKit assets: \(report.formattedCloudKitAssetBytes) "
-                + "across \(report.cloudKitAssetCount) file(s)"
-            )
+            await MainActor.run {
+                MLXSwiftDownloadManager.shared.endCacheMaintenance()
+                guard report.didReclaimAnything else { return }
+                AppLog.shared.fileManagement(
+                    "Cache maintenance reclaimed \(report.formattedReclaimedBytes) — "
+                    + "model blobs: \(report.formattedDuplicateModelBlobBytes) duplicate, "
+                    + "\(report.formattedOrphanedModelBlobBytes) orphaned; "
+                    + "CloudKit assets: \(report.formattedCloudKitAssetBytes) "
+                    + "across \(report.cloudKitAssetCount) file(s)"
+                )
+            }
         }
     }
 }
@@ -266,11 +305,20 @@ struct CacheMaintenanceSweep {
 
         for directory in directChildren(of: hubCacheRoot) {
             guard isDirectory(directory),
-                  CacheMaintenancePolicy.modelID(
+                  let modelID = CacheMaintenancePolicy.modelID(
                       forHubRepoDirectoryName: directory.lastPathComponent
-                  ) != nil else {
+                  ) else {
                 continue
             }
+
+            // A process can die between two file copies, after a complete blob
+            // has been promoted, or with only config.json materialized. Keep the
+            // durable resume state until a complete materialized model exists.
+            guard !shouldKeepRepositoryForResume(
+                directory,
+                modelID: modelID,
+                materializedModelsRoot: materializedModelsRoot
+            ) else { continue }
 
             // Sizing walks the whole repository, which for a multi-gigabyte model is
             // far from instant. Nothing slow may sit between the download check and
@@ -303,21 +351,72 @@ struct CacheMaintenanceSweep {
         }
     }
 
-    /// A model counts as installed only once its `config.json` is present — the
-    /// same check `MLXSwiftDownloadManager` uses to decide a model is usable. A
-    /// half-materialized directory is treated as not installed, which at worst
-    /// files its blobs under "orphaned"; either way they are safe to remove,
-    /// because a download is not in flight.
+    /// A model counts as installed only once its configuration and weights are
+    /// present. A half-materialized directory must not make its blob cache look
+    /// like a duplicate or make the download manager report a usable model.
     private func installedModelIDs(under root: URL) -> Set<String> {
         var ids = Set<String>()
         for namespace in directChildren(of: root) where isDirectory(namespace) {
             for repository in directChildren(of: namespace) where isDirectory(repository) {
-                let configURL = repository.appendingPathComponent("config.json")
-                guard fileManager.fileExists(atPath: configURL.path) else { continue }
+                guard CacheMaintenancePolicy.isMaterializedModelComplete(at: repository) else { continue }
                 ids.insert("\(namespace.lastPathComponent)/\(repository.lastPathComponent)")
             }
         }
         return ids
+    }
+
+    private func shouldKeepRepositoryForResume(
+        _ directory: URL,
+        modelID: String,
+        materializedModelsRoot: URL
+    ) -> Bool {
+        if let materializedDirectory = materializedModelDirectory(
+            for: modelID,
+            under: materializedModelsRoot
+        ) {
+            if CacheMaintenancePolicy.isMaterializedModelComplete(at: materializedDirectory) {
+                return false
+            }
+            if isDirectory(materializedDirectory) {
+                return true
+            }
+        }
+
+        if containsIncompleteBlob(in: directory) {
+            return true
+        }
+
+        // This marker survives a crash or force-quit. It covers the small window
+        // after a blob is promoted but before the corresponding materialized file
+        // is copied, when neither the `.incomplete` file nor config.json is enough.
+        return UserDefaults.standard.string(
+            forKey: MLXSwiftSettingsKeys.inFlightDownloadModelID
+        ) == modelID
+    }
+
+    private func materializedModelDirectory(for modelID: String, under root: URL) -> URL? {
+        let components = modelID.split(separator: "/", maxSplits: 1)
+        guard components.count == 2 else { return nil }
+        return root
+            .appendingPathComponent(String(components[0]), isDirectory: true)
+            .appendingPathComponent(String(components[1]), isDirectory: true)
+    }
+
+    private func containsIncompleteBlob(in repository: URL) -> Bool {
+        let blobs = repository.appendingPathComponent("blobs", isDirectory: true)
+        guard let enumerator = fileManager.enumerator(
+            at: blobs,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return false
+        }
+
+        while let file = enumerator.nextObject() as? URL {
+            guard file.pathExtension == "incomplete" else { continue }
+            if isRegularFile(file) { return true }
+        }
+        return false
     }
 
     // MARK: CloudKit asset cache

--- a/BisonNotes AI/BisonNotes AI/Services/CacheMaintenanceService.swift
+++ b/BisonNotes AI/BisonNotes AI/Services/CacheMaintenanceService.swift
@@ -60,20 +60,51 @@ enum CacheMaintenancePolicy {
         return "\(namespace)/\(repository)"
     }
 
-    /// A materialized model is usable only when its configuration and at least
-    /// one non-empty weight file have landed. `config.json` can be copied before
-    /// the download is interrupted, so it is not a completion marker by itself.
+    /// A materialized model is usable only when its configuration and all of its
+    /// weights have landed. `config.json` can be copied before the download is
+    /// interrupted, so it is not a completion marker by itself.
+    ///
+    /// A sharded model publishes `model.safetensors.index.json`, whose weight map
+    /// names every shard. One non-empty shard is no evidence the rest arrived —
+    /// and treating a half-copied model as installed is what let the sweep delete
+    /// the very blob cache the interrupted download needed to resume, and made
+    /// the model read as ready in Settings. So when the index is present, every
+    /// shard it names must be present and non-empty; an index that cannot be read
+    /// is itself a partly copied model, and counts as incomplete.
     static func isMaterializedModelComplete(at directory: URL) -> Bool {
-        let fileManager = FileManager.default
         let configURL = directory.appendingPathComponent("config.json")
-        let configValues = try? configURL.resourceValues(
-            forKeys: [.isRegularFileKey, .fileSizeKey]
-        )
-        guard configValues?.isRegularFile == true, (configValues?.fileSize ?? 0) > 0 else {
-            return false
+        guard isNonEmptyRegularFile(configURL) else { return false }
+
+        if let shardNames = shardedWeightFilenames(at: directory) {
+            guard !shardNames.isEmpty else { return false }
+            return shardNames.allSatisfy {
+                isNonEmptyRegularFile(directory.appendingPathComponent($0))
+            }
         }
 
-        guard let enumerator = fileManager.enumerator(
+        return containsNonEmptyWeightFile(at: directory)
+    }
+
+    /// Every distinct filename the safetensors weight map references, or `nil`
+    /// when this model is not sharded (no index file at all).
+    ///
+    /// An index that exists but cannot be parsed returns an empty set rather than
+    /// `nil`: the file is there, so the model claims to be sharded, and falling
+    /// back to the single-weight check would call it complete on one shard.
+    private static func shardedWeightFilenames(at directory: URL) -> Set<String>? {
+        let indexURL = directory.appendingPathComponent("model.safetensors.index.json")
+        guard isNonEmptyRegularFile(indexURL) else { return nil }
+
+        guard let data = try? Data(contentsOf: indexURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let weightMap = json["weight_map"] as? [String: String] else {
+            return []
+        }
+        return Set(weightMap.values)
+    }
+
+    private static func containsNonEmptyWeightFile(at directory: URL) -> Bool {
+        guard let enumerator = FileManager.default.enumerator(
             at: directory,
             includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
             options: [.skipsHiddenFiles]
@@ -83,12 +114,14 @@ enum CacheMaintenancePolicy {
 
         while let file = enumerator.nextObject() as? URL {
             guard file.pathExtension.lowercased() == "safetensors" else { continue }
-            let values = try? file.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            if values?.isRegularFile == true, (values?.fileSize ?? 0) > 0 {
-                return true
-            }
+            if isNonEmptyRegularFile(file) { return true }
         }
         return false
+    }
+
+    private static func isNonEmptyRegularFile(_ url: URL) -> Bool {
+        let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+        return values?.isRegularFile == true && (values?.fileSize ?? 0) > 0
     }
 
     /// Why a hub repository directory is being removed. Only used for reporting —

--- a/BisonNotes AI/BisonNotes AI/Services/CacheMaintenanceService.swift
+++ b/BisonNotes AI/BisonNotes AI/Services/CacheMaintenanceService.swift
@@ -216,6 +216,14 @@ final class CacheMaintenanceService {
 struct CacheMaintenanceSweep {
 
     private let fileManager = FileManager()
+    private let cachesRootOverride: URL?
+
+    /// - Parameter cachesRoot: overrides the container's `Library/Caches`. Only tests
+    ///   pass this; it is what lets the deletion behavior be exercised against a real
+    ///   directory tree rather than only through the pure policy.
+    init(cachesRoot: URL? = nil) {
+        self.cachesRootOverride = cachesRoot
+    }
 
     /// - Parameter isDownloadInFlight: consulted again before every model-cache
     ///   deletion, so a download that starts mid-sweep still protects its blobs.
@@ -227,7 +235,7 @@ struct CacheMaintenanceSweep {
     }
 
     private var cachesRoot: URL? {
-        fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first
+        cachesRootOverride ?? fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first
     }
 
     // MARK: Hugging Face blob cache
@@ -257,16 +265,27 @@ struct CacheMaintenanceSweep {
         let installed = installedModelIDs(under: materializedModelsRoot)
 
         for directory in directChildren(of: hubCacheRoot) {
-            guard isDirectory(directory) else { continue }
-            // Re-read per directory. Deleting a repo a download is actively writing
-            // would break both the download and the resume state it depends on.
+            guard isDirectory(directory),
+                  CacheMaintenancePolicy.modelID(
+                      forHubRepoDirectoryName: directory.lastPathComponent
+                  ) != nil else {
+                continue
+            }
+
+            // Sizing walks the whole repository, which for a multi-gigabyte model is
+            // far from instant. Nothing slow may sit between the download check and
+            // the delete it authorizes, so the traversal happens first and the check
+            // is read immediately before the removal — a download that starts while
+            // this is measuring is still seen. Re-read per directory, because a
+            // single reading taken before the sweep goes stale the moment it is used.
+            let size = directorySize(directory)
+
             guard let reason = CacheMaintenancePolicy.hubPruneReason(
                 directoryName: directory.lastPathComponent,
                 installedModelIDs: installed,
                 isDownloadInFlight: await isDownloadInFlight()
             ) else { continue }
 
-            let size = directorySize(directory)
             do {
                 try fileManager.removeItem(at: directory)
                 report.removedDirectoryCount += 1

--- a/BisonNotes AI/BisonNotes AI/Services/CacheMaintenanceService.swift
+++ b/BisonNotes AI/BisonNotes AI/Services/CacheMaintenanceService.swift
@@ -1,0 +1,378 @@
+//
+//  CacheMaintenanceService.swift
+//  BisonNotes AI
+//
+//  Bounds the two caches that grow without limit inside the app container.
+//
+//  On a Mac that had been running the app for a few months, `Library/Caches`
+//  reached 29 GB and had to be cleared by hand:
+//
+//    * 11 GB of Hugging Face blobs. `defaultHubApi` downloads through a
+//      content-addressed blob cache and then *copies* the result into its
+//      `downloadBase`, so every MLX model is stored twice — and deleting a model
+//      in Settings only ever removed the copy, leaving the blobs forever. A 7.9 GB
+//      model the user still had cost 15.8 GB, and two models they had already
+//      deleted were still costing 3.3 GB.
+//    * 9.8 GB of CloudKit asset cache. CloudKit copies every `CKAsset` it uploads
+//      or downloads into `Caches/CloudKit/<container>/Assets` and never reclaims
+//      it, so a single sync of 570 recordings left a second full copy of the
+//      user's audio library on disk.
+//
+//  Both are caches in the strict sense: the app reads neither of them, and both
+//  are rebuilt on demand. The rules for what may be removed are pure static
+//  functions on `CacheMaintenancePolicy` and are covered by
+//  `CacheMaintenanceTests` — change them there, not inline in the sweeps.
+//
+
+import Foundation
+
+// MARK: - Policy
+
+enum CacheMaintenancePolicy {
+
+    /// Hugging Face repository directory name for a model id, e.g.
+    /// `mlx-community/Qwen3-4B` → `models--mlx-community--Qwen3-4B`. This is the
+    /// layout `HubCache` writes and the Python `huggingface_hub` standard.
+    static func hubRepoDirectoryName(forModelID modelID: String) -> String {
+        "models--" + modelID.replacingOccurrences(of: "/", with: "--")
+    }
+
+    /// Inverse of `hubRepoDirectoryName(forModelID:)`. Returns `nil` for anything
+    /// that is not a model repository directory, so a sweep never touches
+    /// `.metadata`, `datasets--…`, or a stray file.
+    ///
+    /// A model id can itself contain `--`, so this only splits off the `models--`
+    /// prefix and then the *first* remaining `--`, which separates namespace from
+    /// repository name.
+    static func modelID(forHubRepoDirectoryName name: String) -> String? {
+        let prefix = "models--"
+        guard name.hasPrefix(prefix) else { return nil }
+        let body = String(name.dropFirst(prefix.count))
+        guard let separator = body.range(of: "--") else { return nil }
+        let namespace = String(body[body.startIndex..<separator.lowerBound])
+        let repository = String(body[separator.upperBound...])
+        guard !namespace.isEmpty, !repository.isEmpty else { return nil }
+        return "\(namespace)/\(repository)"
+    }
+
+    /// Why a hub repository directory is being removed. Only used for reporting —
+    /// both cases are equally safe to delete — but the two mean very different
+    /// things when reading the log, so they are counted apart.
+    enum HubPruneReason: Equatable {
+        /// The model is installed. These blobs are a byte-for-byte second copy.
+        case duplicateOfInstalledModel
+        /// No installed model claims these blobs — an aborted or deleted download.
+        case orphaned
+    }
+
+    /// Blobs are only ever read while a download is running: afterwards the app
+    /// resolves models out of `downloadBase` alone. So a sweep is safe whenever no
+    /// download is in flight, and must never run when one is, because the blob
+    /// cache is also what lets an interrupted download resume.
+    static func hubPruneReason(
+        directoryName: String,
+        installedModelIDs: Set<String>,
+        isDownloadInFlight: Bool
+    ) -> HubPruneReason? {
+        guard !isDownloadInFlight else { return nil }
+        guard let modelID = modelID(forHubRepoDirectoryName: directoryName) else { return nil }
+        return installedModelIDs.contains(modelID) ? .duplicateOfInstalledModel : .orphaned
+    }
+
+    /// Nothing younger than this is ever removed. It is what stands in for an
+    /// in-flight check, without coupling this service to the sync engine: the
+    /// longest sync run on record took six minutes, so an hour is a wide margin,
+    /// and an asset a running operation still needs is minutes old at most.
+    static let cloudKitAssetMinimumAge: TimeInterval = 60 * 60
+
+    /// An eligible asset older than this goes regardless of how small the cache is.
+    static let cloudKitAssetMaximumAge: TimeInterval = 24 * 60 * 60
+
+    /// Ceiling for the whole asset cache. Age alone is not enough: this cache was
+    /// observed growing from 9.8 GB to 32 GB in about an hour of syncing, because
+    /// CloudKit keeps a copy of every asset it moves. Past this, the oldest go
+    /// first until the cache is back under budget.
+    static let cloudKitAssetCacheBudget: Int64 = 2 * 1024 * 1024 * 1024
+
+    /// One file in `Caches/CloudKit/<container>/Assets`.
+    struct AssetEntry: Equatable {
+        let identifier: String
+        let byteCount: Int64
+        let modifiedAt: Date?
+    }
+
+    /// Decides which cached assets to remove, oldest first.
+    ///
+    /// An asset with no readable timestamp is never removed — an unknown age must
+    /// not be read as "old enough to delete".
+    static func assetsToPrune(
+        _ entries: [AssetEntry],
+        now: Date,
+        budget: Int64 = cloudKitAssetCacheBudget,
+        minimumAge: TimeInterval = cloudKitAssetMinimumAge,
+        maximumAge: TimeInterval = cloudKitAssetMaximumAge
+    ) -> [AssetEntry] {
+        let eligible = entries
+            .filter { entry in
+                guard let modifiedAt = entry.modifiedAt else { return false }
+                return now.timeIntervalSince(modifiedAt) >= minimumAge
+            }
+            // `modifiedAt` is non-nil for everything that survived the filter.
+            .sorted { ($0.modifiedAt ?? .distantPast) < ($1.modifiedAt ?? .distantPast) }
+
+        var doomed: [AssetEntry] = []
+        var remaining = entries.reduce(Int64(0)) { $0 + $1.byteCount }
+
+        for entry in eligible {
+            let isPastMaximumAge = now.timeIntervalSince(entry.modifiedAt ?? .distantPast) >= maximumAge
+            guard isPastMaximumAge || remaining > budget else { break }
+            doomed.append(entry)
+            remaining -= entry.byteCount
+        }
+
+        return doomed
+    }
+}
+
+// MARK: - Report
+
+struct CacheMaintenanceReport: Equatable {
+    var duplicateModelBlobBytes: Int64 = 0
+    var orphanedModelBlobBytes: Int64 = 0
+    var cloudKitAssetBytes: Int64 = 0
+    var cloudKitAssetCount = 0
+    var removedDirectoryCount = 0
+
+    var reclaimedBytes: Int64 {
+        duplicateModelBlobBytes + orphanedModelBlobBytes + cloudKitAssetBytes
+    }
+
+    var didReclaimAnything: Bool { reclaimedBytes > 0 }
+
+    var formattedReclaimedBytes: String { Self.format(reclaimedBytes) }
+    var formattedDuplicateModelBlobBytes: String { Self.format(duplicateModelBlobBytes) }
+    var formattedOrphanedModelBlobBytes: String { Self.format(orphanedModelBlobBytes) }
+    var formattedCloudKitAssetBytes: String { Self.format(cloudKitAssetBytes) }
+
+    private static func format(_ bytes: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+    }
+}
+
+// MARK: - Scheduling
+
+@MainActor
+final class CacheMaintenanceService {
+    static let shared = CacheMaintenanceService()
+
+    /// A sweep walks the whole blob cache, so it is not something to do on every
+    /// activation. A Mac stays open for days, so a launch-only pass would never run
+    /// on the machine that needs it most.
+    static let sweepInterval: TimeInterval = 6 * 60 * 60
+
+    private var lastSweep: Date?
+
+    /// Sweeps unless one already ran within `sweepInterval`.
+    ///
+    /// The work happens off the main actor: a first pass on the machine that
+    /// prompted this had 21 GB to delete, and doing that inline would have hung
+    /// the app at launch. Only the download check is read here, where it is
+    /// isolated, and handed to the sweep as a value.
+    func pruneCachesIfDue(now: Date = Date()) {
+        if let lastSweep, now.timeIntervalSince(lastSweep) < Self.sweepInterval { return }
+        lastSweep = now
+
+        let isDownloadInFlight = MLXSwiftDownloadManager.shared.isDownloading
+        Task.detached(priority: .utility) {
+            let report = CacheMaintenanceSweep().run(isDownloadInFlight: isDownloadInFlight)
+            guard report.didReclaimAnything else { return }
+            AppLog.shared.fileManagement(
+                "Cache maintenance reclaimed \(report.formattedReclaimedBytes) — "
+                + "model blobs: \(report.formattedDuplicateModelBlobBytes) duplicate, "
+                + "\(report.formattedOrphanedModelBlobBytes) orphaned; "
+                + "CloudKit assets: \(report.formattedCloudKitAssetBytes) "
+                + "across \(report.cloudKitAssetCount) file(s)"
+            )
+        }
+    }
+}
+
+// MARK: - Sweep
+
+/// The filesystem half. Deliberately not main-actor isolated — see
+/// `pruneCachesIfDue`. Creates its own `FileManager`, which is the supported way
+/// to use one off the main thread; it is constructed inside the detached task, so
+/// nothing non-`Sendable` crosses an isolation boundary.
+struct CacheMaintenanceSweep {
+
+    private let fileManager = FileManager()
+
+    func run(isDownloadInFlight: Bool) -> CacheMaintenanceReport {
+        var report = CacheMaintenanceReport()
+        pruneHuggingFaceBlobCache(into: &report, isDownloadInFlight: isDownloadInFlight)
+        pruneCloudKitAssetCache(into: &report)
+        return report
+    }
+
+    private var cachesRoot: URL? {
+        fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first
+    }
+
+    // MARK: Hugging Face blob cache
+
+    /// `Library/Caches/huggingface/hub`, where `HubCache` stores downloaded blobs.
+    /// Resolved by convention rather than by asking `HubCache`, so this file does
+    /// not need the Hub modules linked; the app never sets `HF_HOME` or the other
+    /// overrides, so a sandboxed container always resolves here.
+    private var hubCacheRoot: URL? {
+        cachesRoot?
+            .appendingPathComponent("huggingface", isDirectory: true)
+            .appendingPathComponent("hub", isDirectory: true)
+    }
+
+    /// `Library/Caches/models/<namespace>/<name>`, the `downloadBase` that
+    /// `defaultHubApi` materializes models into and the only copy the app reads.
+    private var materializedModelsRoot: URL? {
+        cachesRoot?.appendingPathComponent("models", isDirectory: true)
+    }
+
+    private func pruneHuggingFaceBlobCache(
+        into report: inout CacheMaintenanceReport,
+        isDownloadInFlight: Bool
+    ) {
+        guard let hubCacheRoot, let materializedModelsRoot else { return }
+
+        let installed = installedModelIDs(under: materializedModelsRoot)
+
+        for directory in directChildren(of: hubCacheRoot) {
+            guard isDirectory(directory) else { continue }
+            guard let reason = CacheMaintenancePolicy.hubPruneReason(
+                directoryName: directory.lastPathComponent,
+                installedModelIDs: installed,
+                isDownloadInFlight: isDownloadInFlight
+            ) else { continue }
+
+            let size = directorySize(directory)
+            do {
+                try fileManager.removeItem(at: directory)
+                report.removedDirectoryCount += 1
+                switch reason {
+                case .duplicateOfInstalledModel: report.duplicateModelBlobBytes += size
+                case .orphaned: report.orphanedModelBlobBytes += size
+                }
+            } catch {
+                AppLog.shared.fileManagement(
+                    "Could not prune model blob cache \(directory.lastPathComponent): "
+                    + error.localizedDescription,
+                    level: .error
+                )
+            }
+        }
+    }
+
+    /// A model counts as installed only once its `config.json` is present — the
+    /// same check `MLXSwiftDownloadManager` uses to decide a model is usable. A
+    /// half-materialized directory is treated as not installed, which at worst
+    /// files its blobs under "orphaned"; either way they are safe to remove,
+    /// because a download is not in flight.
+    private func installedModelIDs(under root: URL) -> Set<String> {
+        var ids = Set<String>()
+        for namespace in directChildren(of: root) where isDirectory(namespace) {
+            for repository in directChildren(of: namespace) where isDirectory(repository) {
+                let configURL = repository.appendingPathComponent("config.json")
+                guard fileManager.fileExists(atPath: configURL.path) else { continue }
+                ids.insert("\(namespace.lastPathComponent)/\(repository.lastPathComponent)")
+            }
+        }
+        return ids
+    }
+
+    // MARK: CloudKit asset cache
+
+    private func pruneCloudKitAssetCache(into report: inout CacheMaintenanceReport) {
+        guard let cachesRoot else { return }
+        let cloudKitRoot = cachesRoot.appendingPathComponent("CloudKit", isDirectory: true)
+        let now = Date()
+
+        // One subdirectory per CloudKit container, named by a hash we cannot predict.
+        // Each container's cache is budgeted on its own, so a second container can
+        // never be starved by the first one's backlog.
+        for container in directChildren(of: cloudKitRoot) where isDirectory(container) {
+            let assets = container.appendingPathComponent("Assets", isDirectory: true)
+            guard isSafeChild(assets, of: cloudKitRoot) else { continue }
+
+            var urlsByIdentifier: [String: URL] = [:]
+            var entries: [CacheMaintenancePolicy.AssetEntry] = []
+            for asset in directChildren(of: assets) where isRegularFile(asset) {
+                let identifier = asset.standardizedFileURL.path
+                urlsByIdentifier[identifier] = asset
+                entries.append(
+                    CacheMaintenancePolicy.AssetEntry(
+                        identifier: identifier,
+                        byteCount: fileSize(asset),
+                        modifiedAt: modificationOrCreationDate(asset)
+                    )
+                )
+            }
+
+            for doomed in CacheMaintenancePolicy.assetsToPrune(entries, now: now) {
+                guard let url = urlsByIdentifier[doomed.identifier] else { continue }
+                do {
+                    try fileManager.removeItem(at: url)
+                    report.cloudKitAssetCount += 1
+                    report.cloudKitAssetBytes += doomed.byteCount
+                } catch {
+                    // A file CloudKit still holds open is expected to fail; the next
+                    // pass picks it up. Not worth an error line per asset.
+                    continue
+                }
+            }
+        }
+    }
+
+    // MARK: File helpers
+
+    private func directChildren(of directory: URL) -> [URL] {
+        (try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isDirectoryKey, .isRegularFileKey, .fileSizeKey, .contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+    }
+
+    private func isDirectory(_ url: URL) -> Bool {
+        (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+    }
+
+    private func isRegularFile(_ url: URL) -> Bool {
+        (try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true
+    }
+
+    private func modificationOrCreationDate(_ url: URL) -> Date? {
+        let values = try? url.resourceValues(forKeys: [.contentModificationDateKey, .creationDateKey])
+        return values?.contentModificationDate ?? values?.creationDate
+    }
+
+    private func fileSize(_ url: URL) -> Int64 {
+        Int64((try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0)
+    }
+
+    private func directorySize(_ directory: URL) -> Int64 {
+        guard let enumerator = fileManager.enumerator(
+            at: directory,
+            includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey]
+        ) else { return 0 }
+
+        var total: Int64 = 0
+        for case let url as URL in enumerator where isRegularFile(url) {
+            total += fileSize(url)
+        }
+        return total
+    }
+
+    private func isSafeChild(_ url: URL, of root: URL) -> Bool {
+        let childPath = url.standardizedFileURL.path
+        let rootPath = root.standardizedFileURL.path
+        return childPath == rootPath || childPath.hasPrefix(rootPath + "/")
+    }
+}

--- a/BisonNotes AI/BisonNotes AI/Services/CacheMaintenanceService.swift
+++ b/BisonNotes AI/BisonNotes AI/Services/CacheMaintenanceService.swift
@@ -18,6 +18,11 @@
 //      it, so a single sync of 570 recordings left a second full copy of the
 //      user's audio library on disk.
 //
+//  `MLXSwiftDownloadManager` now drops a model's blobs as soon as the download
+//  materializes, and again when the user deletes the model, so the blob sweep here
+//  is a backstop rather than the primary fix: it collects what a killed download
+//  left behind and what earlier versions of the app already accumulated.
+//
 //  Both are caches in the strict sense: the app reads neither of them, and both
 //  are rebuilt on demand. The rules for what may be removed are pure static
 //  functions on `CacheMaintenancePolicy` and are covered by

--- a/BisonNotes AI/BisonNotes AI/Services/CacheMaintenanceService.swift
+++ b/BisonNotes AI/BisonNotes AI/Services/CacheMaintenanceService.swift
@@ -187,9 +187,14 @@ final class CacheMaintenanceService {
         if let lastSweep, now.timeIntervalSince(lastSweep) < Self.sweepInterval { return }
         lastSweep = now
 
-        let isDownloadInFlight = MLXSwiftDownloadManager.shared.isDownloading
         Task.detached(priority: .utility) {
-            let report = CacheMaintenanceSweep().run(isDownloadInFlight: isDownloadInFlight)
+            // Checked again immediately before each deletion rather than sampled
+            // once: the sweep can spend a long time enumerating and deleting tens
+            // of gigabytes, and a download started in that window would otherwise
+            // have the repository it is writing deleted out from under it.
+            let report = await CacheMaintenanceSweep().run {
+                await MainActor.run { MLXSwiftDownloadManager.shared.isDownloading }
+            }
             guard report.didReclaimAnything else { return }
             AppLog.shared.fileManagement(
                 "Cache maintenance reclaimed \(report.formattedReclaimedBytes) — "
@@ -212,9 +217,11 @@ struct CacheMaintenanceSweep {
 
     private let fileManager = FileManager()
 
-    func run(isDownloadInFlight: Bool) -> CacheMaintenanceReport {
+    /// - Parameter isDownloadInFlight: consulted again before every model-cache
+    ///   deletion, so a download that starts mid-sweep still protects its blobs.
+    func run(isDownloadInFlight: @Sendable () async -> Bool) async -> CacheMaintenanceReport {
         var report = CacheMaintenanceReport()
-        pruneHuggingFaceBlobCache(into: &report, isDownloadInFlight: isDownloadInFlight)
+        await pruneHuggingFaceBlobCache(into: &report, isDownloadInFlight: isDownloadInFlight)
         pruneCloudKitAssetCache(into: &report)
         return report
     }
@@ -243,18 +250,20 @@ struct CacheMaintenanceSweep {
 
     private func pruneHuggingFaceBlobCache(
         into report: inout CacheMaintenanceReport,
-        isDownloadInFlight: Bool
-    ) {
+        isDownloadInFlight: @Sendable () async -> Bool
+    ) async {
         guard let hubCacheRoot, let materializedModelsRoot else { return }
 
         let installed = installedModelIDs(under: materializedModelsRoot)
 
         for directory in directChildren(of: hubCacheRoot) {
             guard isDirectory(directory) else { continue }
+            // Re-read per directory. Deleting a repo a download is actively writing
+            // would break both the download and the resume state it depends on.
             guard let reason = CacheMaintenancePolicy.hubPruneReason(
                 directoryName: directory.lastPathComponent,
                 installedModelIDs: installed,
-                isDownloadInFlight: isDownloadInFlight
+                isDownloadInFlight: await isDownloadInFlight()
             ) else { continue }
 
             let size = directorySize(directory)

--- a/BisonNotes AI/BisonNotes AI/Services/CloudKitBatchExecutor.swift
+++ b/BisonNotes AI/BisonNotes AI/Services/CloudKitBatchExecutor.swift
@@ -301,6 +301,31 @@ final class CloudKitBatchExecutor {
         attempt: Int,
         into outcome: inout CloudKitModifyOutcome
     ) async throws {
+        // Halving the two lists independently makes no progress when a chunk
+        // holds one save and one delete: each half comes back whole, so the
+        // first recursion is handed the identical chunk and the split repeats
+        // for as long as CloudKit keeps rejecting it. Separating the two kinds
+        // is what shrinks such a chunk, and it shrinks any mixed chunk.
+        if !records.isEmpty, !recordIDs.isEmpty {
+            try await modifyChunk(
+                saving: records,
+                deleting: [],
+                savePolicy: savePolicy,
+                attempt: attempt,
+                into: &outcome
+            )
+            try await modifyChunk(
+                saving: [],
+                deleting: recordIDs,
+                savePolicy: savePolicy,
+                attempt: attempt,
+                into: &outcome
+            )
+            return
+        }
+
+        // One kind only, and a chunk is split only when it holds more than one
+        // record, so both halves are strictly smaller than what was rejected.
         let saveHalves = Self.halved(records)
         let deleteHalves = Self.halved(recordIDs)
         try await modifyChunk(

--- a/BisonNotes AI/BisonNotes AI/Services/TemporaryFileCleanupService.swift
+++ b/BisonNotes AI/BisonNotes AI/Services/TemporaryFileCleanupService.swift
@@ -14,7 +14,7 @@ final class TemporaryFileCleanupService {
 
     private let fileManager = FileManager.default
     private let defaultMaxAge: TimeInterval = 6 * 60 * 60
-    /// Floor for the iCloud audio staging directory. See `cleanupAudioStagingDirectory`.
+    /// Floor for the iCloud audio staging directory. See `scheduleAudioStagingCleanup`.
     private static let audioStagingMinimumAge: TimeInterval = 6 * 60 * 60
 
     private init() {}
@@ -50,12 +50,7 @@ final class TemporaryFileCleanupService {
             reclaimedBytes: &reclaimedBytes,
             errors: &errors
         )
-        cleanupAudioStagingDirectory(
-            cutoff: cutoff,
-            deletedCount: &deletedCount,
-            reclaimedBytes: &reclaimedBytes,
-            errors: &errors
-        )
+        scheduleAudioStagingCleanup(cutoff: cutoff)
 
         if deletedCount > 0 {
             AppLog.shared.fileManagement("Cleaned up \(deletedCount) stale temporary file(s), reclaimed \(formatBytes(reclaimedBytes))")
@@ -147,57 +142,34 @@ final class TemporaryFileCleanupService {
     /// behind — the staging copies are the recordings themselves, so a single orphaned
     /// run can be gigabytes.
     ///
-    /// A run directory's timestamp only moves when the run stages another file, so a
-    /// sync that is slow between files must not look abandoned. This keeps its own
-    /// floor rather than trusting the caller's `maxAge`, which is 30 minutes on the
-    /// background-processing path.
-    private func cleanupAudioStagingDirectory(
-        cutoff: Date,
-        deletedCount: inout Int,
-        reclaimedBytes: inout Int64,
-        errors: inout [String]
-    ) {
-        let stagingRoot = fileManager.temporaryDirectory
-            .appendingPathComponent("iCloudAudioStaging", isDirectory: true)
-        guard isSafeChild(stagingRoot, of: fileManager.temporaryDirectory) else { return }
-
+    /// That size is why this one runs off the main actor while the rest of this
+    /// service stays inline: `cleanupStaleFiles()` is called straight from the launch
+    /// and activation handlers, and measuring then recursively deleting gigabytes
+    /// there would block the UI for the whole traversal. Its totals are logged when
+    /// it finishes rather than folded into this call's return value.
+    private func scheduleAudioStagingCleanup(cutoff: Date) {
+        // A run directory's timestamp only moves when the run stages another file, so
+        // a sync that is slow between files must not look abandoned. This keeps its
+        // own floor rather than trusting the caller's `maxAge`, which is 30 minutes
+        // on the background-processing path.
         let stagingCutoff = min(cutoff, Date().addingTimeInterval(-Self.audioStagingMinimumAge))
+        Task.detached(priority: .utility) {
+            let sweep = AudioStagingCleanupSweep()
+            let result = sweep.run(cutoff: stagingCutoff)
 
-        for runDirectory in directChildren(of: stagingRoot) {
-            guard isDirectory(runDirectory),
-                  let ageDate = modificationOrCreationDate(runDirectory),
-                  ageDate < stagingCutoff else {
-                continue
+            if result.deletedCount > 0 {
+                AppLog.shared.fileManagement(
+                    "Cleaned up \(result.deletedCount) orphaned iCloud audio staging run(s), "
+                    + "reclaimed \(ByteCountFormatter.string(fromByteCount: result.reclaimedBytes, countStyle: .file))"
+                )
             }
-
-            let size = directorySize(runDirectory)
-            do {
-                try fileManager.removeItem(at: runDirectory)
-                deletedCount += 1
-                reclaimedBytes += size
-            } catch {
-                errors.append("\(runDirectory.lastPathComponent): \(error.localizedDescription)")
+            if !result.errors.isEmpty {
+                AppLog.shared.fileManagement(
+                    "Staging cleanup skipped \(result.errors.count) run(s): \(result.errors.joined(separator: "; "))",
+                    level: .error
+                )
             }
         }
-
-        removeDirectoryIfEmpty(stagingRoot)
-    }
-
-    private func isDirectory(_ url: URL) -> Bool {
-        (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
-    }
-
-    private func directorySize(_ directory: URL) -> Int64 {
-        guard let enumerator = fileManager.enumerator(
-            at: directory,
-            includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey]
-        ) else { return 0 }
-
-        var total: Int64 = 0
-        for case let url as URL in enumerator where isRegularFile(url) {
-            total += fileSize(url)
-        }
-        return total
     }
 
     private func directChildren(of directory: URL) -> [URL] {
@@ -281,5 +253,99 @@ final class TemporaryFileCleanupService {
 
     private func formatBytes(_ bytes: Int64) -> String {
         ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+    }
+}
+
+// MARK: - Audio Staging Sweep
+
+/// Removes iCloud audio staging runs that a crash or kill orphaned.
+///
+/// Deliberately not main-actor isolated: an orphaned run holds a full copy of
+/// every recording it staged, so measuring and deleting one can take long enough
+/// to be visible in the UI. Constructed inside the detached task, so nothing
+/// non-`Sendable` crosses an isolation boundary.
+struct AudioStagingCleanupSweep {
+
+    struct Result {
+        var deletedCount = 0
+        var reclaimedBytes: Int64 = 0
+        var errors: [String] = []
+    }
+
+    private let fileManager = FileManager()
+
+    func run(cutoff: Date) -> Result {
+        var result = Result()
+        let tempRoot = fileManager.temporaryDirectory
+        let stagingRoot = tempRoot.appendingPathComponent("iCloudAudioStaging", isDirectory: true)
+        guard isSafeChild(stagingRoot, of: tempRoot) else { return result }
+
+        for runDirectory in directChildren(of: stagingRoot) {
+            guard isDirectory(runDirectory),
+                  let ageDate = modificationOrCreationDate(runDirectory),
+                  ageDate < cutoff else {
+                continue
+            }
+
+            let size = directorySize(runDirectory)
+            do {
+                try fileManager.removeItem(at: runDirectory)
+                result.deletedCount += 1
+                result.reclaimedBytes += size
+            } catch {
+                result.errors.append("\(runDirectory.lastPathComponent): \(error.localizedDescription)")
+            }
+        }
+
+        removeDirectoryIfEmpty(stagingRoot)
+        return result
+    }
+
+    private func directChildren(of directory: URL) -> [URL] {
+        (try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isDirectoryKey, .contentModificationDateKey, .creationDateKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+    }
+
+    private func isDirectory(_ url: URL) -> Bool {
+        (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+    }
+
+    private func isRegularFile(_ url: URL) -> Bool {
+        (try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true
+    }
+
+    private func modificationOrCreationDate(_ url: URL) -> Date? {
+        let values = try? url.resourceValues(forKeys: [.contentModificationDateKey, .creationDateKey])
+        return values?.contentModificationDate ?? values?.creationDate
+    }
+
+    private func directorySize(_ directory: URL) -> Int64 {
+        guard let enumerator = fileManager.enumerator(
+            at: directory,
+            includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey]
+        ) else { return 0 }
+
+        var total: Int64 = 0
+        for case let url as URL in enumerator where isRegularFile(url) {
+            total += Int64((try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0)
+        }
+        return total
+    }
+
+    private func isSafeChild(_ url: URL, of root: URL) -> Bool {
+        let childPath = url.standardizedFileURL.path
+        let rootPath = root.standardizedFileURL.path
+        return childPath == rootPath || childPath.hasPrefix(rootPath + "/")
+    }
+
+    private func removeDirectoryIfEmpty(_ directory: URL) {
+        guard let contents = try? fileManager.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil),
+              contents.isEmpty else {
+            return
+        }
+        try? fileManager.removeItem(at: directory)
     }
 }

--- a/BisonNotes AI/BisonNotes AI/Services/TemporaryFileCleanupService.swift
+++ b/BisonNotes AI/BisonNotes AI/Services/TemporaryFileCleanupService.swift
@@ -14,6 +14,8 @@ final class TemporaryFileCleanupService {
 
     private let fileManager = FileManager.default
     private let defaultMaxAge: TimeInterval = 6 * 60 * 60
+    /// Floor for the iCloud audio staging directory. See `cleanupAudioStagingDirectory`.
+    private static let audioStagingMinimumAge: TimeInterval = 6 * 60 * 60
 
     private init() {}
 
@@ -43,6 +45,12 @@ final class TemporaryFileCleanupService {
 
         cleanupAudioChunksDirectory(cutoff: cutoff, deletedCount: &deletedCount, reclaimedBytes: &reclaimedBytes, errors: &errors)
         cleanupWebImportsDirectory(
+            cutoff: cutoff,
+            deletedCount: &deletedCount,
+            reclaimedBytes: &reclaimedBytes,
+            errors: &errors
+        )
+        cleanupAudioStagingDirectory(
             cutoff: cutoff,
             deletedCount: &deletedCount,
             reclaimedBytes: &reclaimedBytes,
@@ -134,6 +142,64 @@ final class TemporaryFileCleanupService {
         removeDirectoryIfEmpty(importsRoot)
     }
 
+    /// `TemporaryDirectoryAssetStaging` removes its own run directory from a `defer`,
+    /// but a crash or a kill mid-upload leaves a full copy of every staged recording
+    /// behind — the staging copies are the recordings themselves, so a single orphaned
+    /// run can be gigabytes.
+    ///
+    /// A run directory's timestamp only moves when the run stages another file, so a
+    /// sync that is slow between files must not look abandoned. This keeps its own
+    /// floor rather than trusting the caller's `maxAge`, which is 30 minutes on the
+    /// background-processing path.
+    private func cleanupAudioStagingDirectory(
+        cutoff: Date,
+        deletedCount: inout Int,
+        reclaimedBytes: inout Int64,
+        errors: inout [String]
+    ) {
+        let stagingRoot = fileManager.temporaryDirectory
+            .appendingPathComponent("iCloudAudioStaging", isDirectory: true)
+        guard isSafeChild(stagingRoot, of: fileManager.temporaryDirectory) else { return }
+
+        let stagingCutoff = min(cutoff, Date().addingTimeInterval(-Self.audioStagingMinimumAge))
+
+        for runDirectory in directChildren(of: stagingRoot) {
+            guard isDirectory(runDirectory),
+                  let ageDate = modificationOrCreationDate(runDirectory),
+                  ageDate < stagingCutoff else {
+                continue
+            }
+
+            let size = directorySize(runDirectory)
+            do {
+                try fileManager.removeItem(at: runDirectory)
+                deletedCount += 1
+                reclaimedBytes += size
+            } catch {
+                errors.append("\(runDirectory.lastPathComponent): \(error.localizedDescription)")
+            }
+        }
+
+        removeDirectoryIfEmpty(stagingRoot)
+    }
+
+    private func isDirectory(_ url: URL) -> Bool {
+        (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+    }
+
+    private func directorySize(_ directory: URL) -> Int64 {
+        guard let enumerator = fileManager.enumerator(
+            at: directory,
+            includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey]
+        ) else { return 0 }
+
+        var total: Int64 = 0
+        for case let url as URL in enumerator where isRegularFile(url) {
+            total += fileSize(url)
+        }
+        return total
+    }
+
     private func directChildren(of directory: URL) -> [URL] {
         (try? fileManager.contentsOfDirectory(
             at: directory,
@@ -163,6 +229,10 @@ final class TemporaryFileCleanupService {
         if name.hasPrefix("catalyst_meeting_mix_") && ext == "m4a" { return true }
         if name.hasSuffix("-system.m4a") { return true }
         if name.hasPrefix("temp_merge_") && ext == "m4a" { return true }
+        // Diagnostic exports are written for the share sheet and are multi-megabyte.
+        // `LogExporter` clears the previous ones each time it exports; this catches
+        // the ones a crash or a dismissed share sheet left behind.
+        if LogExporter.isExportFileName(name) { return true }
 
         return false
     }

--- a/BisonNotes AI/BisonNotes AI/ViewModels/AudioRecorderViewModel+MacCaptureHealth.swift
+++ b/BisonNotes AI/BisonNotes AI/ViewModels/AudioRecorderViewModel+MacCaptureHealth.swift
@@ -181,6 +181,11 @@ extension AudioRecorderViewModel {
                 reason: "The selected microphone did not provide any audio after automatic recovery."
             )
         } else {
+            // The failed engine still owns the current scratch segment. Seal it
+            // before switching to system-only capture; otherwise a later
+            // reconnect treats this as an already-waiting recording and replaces
+            // the engine without ever adding this segment to the finalization set.
+            sealMacScratchSegment()
             if continueMacSystemAudioWithoutMicrophone(
                 after: NSError(
                     domain: "AudioRecorderViewModel.Mac",

--- a/BisonNotes AI/BisonNotes AI/ViewModels/AudioRecorderViewModel+MacCaptureHealth.swift
+++ b/BisonNotes AI/BisonNotes AI/ViewModels/AudioRecorderViewModel+MacCaptureHealth.swift
@@ -54,7 +54,10 @@ extension AudioRecorderViewModel {
 
     func handleMacFirstSuccessfulWrite() {
         let health = macCaptureHealth.snapshot()
-        let inputName = enhancedAudioSessionManager.getActiveInput()?.portName ?? "system default"
+        let inputName = macInputDeviceID.flatMap { deviceID in
+            enhancedAudioSessionManager.getAvailableInputs()
+                .first(where: { input in input.audioDeviceID == deviceID })?.portName
+        } ?? enhancedAudioSessionManager.getActiveInput()?.portName ?? "system default"
         recordDelayedMacMicrophoneStartOffsetIfNeeded()
         AppLog.shared.recording(
             "Mac microphone first buffer committed from \(inputName) " +
@@ -119,7 +122,10 @@ extension AudioRecorderViewModel {
     ) async {
         guard isStartingRecording || isRecording else { return }
         let health = macCaptureHealth.snapshot()
-        let inputName = enhancedAudioSessionManager.getActiveInput()?.portName ?? "system default"
+        let inputName = macInputDeviceID.flatMap { deviceID in
+            enhancedAudioSessionManager.getAvailableInputs()
+                .first(where: { input in input.audioDeviceID == deviceID })?.portName
+        } ?? enhancedAudioSessionManager.getActiveInput()?.portName ?? "system default"
         AppLog.shared.recording(
             "Mac microphone capture unhealthy on \(inputName): \(assessment) " +
             "(segmentFrames=\(health.segmentFramesWritten), totalFrames=\(health.totalFramesWritten))",
@@ -134,31 +140,17 @@ extension AudioRecorderViewModel {
         macAutomaticRecoveryAttempts += 1
         let attempt = macAutomaticRecoveryAttempts
         let neverProducedAudio = health.totalFramesWritten == 0
-        var didFallBackToDefaultInput = false
-        if neverProducedAudio,
-           attempt == 1,
-           enhancedAudioSessionManager.hasPreferredInput() {
-            // Keep the persisted preference so the user's selected device is
-            // restored for a later recording, but avoid retrying a present-but-
-            // silent USB route indefinitely during this startup.
-            try? await enhancedAudioSessionManager.clearPreferredInput()
-            didFallBackToDefaultInput = true
-            AppLog.shared.audioSession(
-                "Preferred Mac input produced no initial audio; retrying startup with the system default",
-                level: .error
-            )
-        }
         // A device that never delivered a buffer never "stopped" providing audio,
         // and the fallback silently changes which microphone is used — say so.
         let cause = neverProducedAudio
             ? "\(inputName) did not provide any audio."
             : "\(inputName) stopped providing audio."
-        let action: String
-        if didFallBackToDefaultInput {
-            action = "Switching to the system default microphone"
-        } else {
-            action = neverProducedAudio ? "Retrying" : "Reconnecting"
-        }
+        let hasAlternateInput = !enhancedAudioSessionManager
+            .recordingInputCandidates(excluding: macInputDeviceID)
+            .isEmpty
+        let action = hasAlternateInput
+            ? "Trying another available microphone"
+            : (neverProducedAudio ? "Waiting for an available microphone" : "Reconnecting")
         errorMessage = "\(cause) \(action) (attempt \(attempt) of " +
             "\(Self.maximumAutomaticCaptureRecoveryAttempts))…"
         if !macSystemAudioContinuesWithoutMicrophone {
@@ -176,10 +168,28 @@ extension AudioRecorderViewModel {
     @MainActor
     private func stopAfterExhaustingCaptureRecovery(inputName: String) async {
         if isStartingRecording {
+            if continueMacSystemAudioWithoutMicrophone(
+                after: NSError(
+                    domain: "AudioRecorderViewModel.Mac",
+                    code: -20,
+                    userInfo: [NSLocalizedDescriptionKey: "The microphone did not provide audio."]
+                )
+            ) {
+                return
+            }
             await abortMacRecordingStartup(
                 reason: "The selected microphone did not provide any audio after automatic recovery."
             )
         } else {
+            if continueMacSystemAudioWithoutMicrophone(
+                after: NSError(
+                    domain: "AudioRecorderViewModel.Mac",
+                    code: -21,
+                    userInfo: [NSLocalizedDescriptionKey: "The microphone stopped providing audio."]
+                )
+            ) {
+                return
+            }
             let microphoneFailure = macCaptureHealth.snapshot().totalFramesWritten == 0
                 ? "did not provide any audio"
                 : "stopped providing audio"
@@ -191,11 +201,18 @@ extension AudioRecorderViewModel {
 
     @MainActor
     private func restartMacCaptureDuringStartup() async {
+        let failedInputDeviceID = macInputDeviceID
         sealMacScratchSegment()
         do {
             guard let finalURL = recordingURL else { throw CocoaError(.fileNoSuchFile) }
-            try startMacContinuation(at: finalURL)
+            try startMacContinuationWithAutomaticInputFallback(
+                at: finalURL,
+                excluding: failedInputDeviceID
+            )
         } catch {
+            if continueMacSystemAudioWithoutMicrophone(after: error) {
+                return
+            }
             await abortMacRecordingStartup(
                 reason: "The microphone could not be restarted: \(error.localizedDescription)"
             )
@@ -240,6 +257,7 @@ extension AudioRecorderViewModel {
         macScratchSegmentURLs = []
         macSystemAudioURL = nil
         macMicrophoneStartOffset = 0
+        macInputDeviceID = nil
         macAwaitingRecoveryBuffer = false
         resetRecordingLocation()
         recordingStartedAt = nil

--- a/BisonNotes AI/BisonNotes AI/ViewModels/AudioRecorderViewModel+MacEngine.swift
+++ b/BisonNotes AI/BisonNotes AI/ViewModels/AudioRecorderViewModel+MacEngine.swift
@@ -13,6 +13,7 @@
 import Foundation
 @preconcurrency import AVFoundation
 import CoreGraphics
+import CoreAudio
 
 /// Builds the AVAudioEngine tap outside `AudioRecorderViewModel`'s MainActor
 /// isolation. AVAudioEngine invokes this block on its real-time audio queue;
@@ -75,6 +76,7 @@ extension AudioRecorderViewModel {
 		macCaptureHealth.resetSession()
 		cancelMacSystemAudioStartupGate()
 		macMicrophoneStartOffset = 0
+		macInputDeviceID = nil
 		macSystemAudioCapture = nil
 		macSystemAudioURL = nil
 
@@ -108,12 +110,15 @@ extension AudioRecorderViewModel {
 			// Mac: drive microphone recording with AVAudioEngine + AVAudioFile
 			// so we bypass AVAudioRecorder's broken converter setup. The scratch
 			// file is exported to M4A when recording stops.
-			try startMacEngineRecording(at: url)
+			try await startMacEngineRecordingWithAutomaticInputFallback(at: url)
 
 			if let systemAudioError {
 				errorMessage = "Meeting audio could not be captured: \(systemAudioError.localizedDescription). Recording microphone audio only."
 			}
 		} catch {
+			if continueMacSystemAudioWithoutMicrophone(after: error) {
+				return
+			}
 			cancelMacSystemAudioStartupGate()
 			if let capture = macSystemAudioCapture {
 				if let abandonedSystemAudioURL = try? await capture.stop() {
@@ -128,17 +133,99 @@ extension AudioRecorderViewModel {
 		}
 	}
 
+	/// Try the remembered/default input first, then every live input exposed by
+	/// Core Audio. Zoom and similar meeting apps can register a virtual input
+	/// after BisonNotes launched; selecting that device in Settings should not
+	/// be required just to make a new recording start.
+	@MainActor
+	private func startMacEngineRecordingWithAutomaticInputFallback(at url: URL) async throws {
+		var attemptedDeviceIDs = Set<AudioDeviceID>()
+		var lastError: Error?
+
+		for refreshIndex in 0..<2 {
+			let candidates = enhancedAudioSessionManager.recordingInputCandidates()
+			for deviceID in candidates where attemptedDeviceIDs.insert(deviceID).inserted {
+				do {
+					try startMacEngineRecording(at: url, inputDeviceID: deviceID)
+					if attemptedDeviceIDs.count > 1 {
+						let inputName = enhancedAudioSessionManager.getAvailableInputs()
+							.first(where: { $0.audioDeviceID == deviceID })?.portName ?? "available input"
+						AppLog.shared.audioSession(
+							"Mac recording started after automatic microphone fallback to \(inputName)"
+						)
+					}
+					return
+				} catch {
+					lastError = error
+					AppLog.shared.audioSession(
+						"Mac microphone startup failed for device \(deviceID): \(error.localizedDescription)",
+						level: .error
+					)
+				}
+			}
+
+			guard refreshIndex == 0 else { break }
+			// A meeting application's HAL driver may be visible to Core Audio a
+			// moment after its first device-list notification. Give that registration
+			// one bounded opportunity to settle before falling back to system audio.
+			do {
+				try await Task.sleep(for: .milliseconds(250))
+			} catch {
+				throw error
+			}
+		}
+
+		if let lastError {
+			throw lastError
+		}
+		try startMacEngineRecording(at: url)
+	}
+
+	/// A failed microphone engine must not discard an otherwise valid meeting
+	/// capture. Keep ScreenCaptureKit running, expose the recording as waiting
+	/// for a microphone, and let the normal device monitor reconnect it later.
+	@MainActor
+	@discardableResult
+	func continueMacSystemAudioWithoutMicrophone(after error: Error) -> Bool {
+		guard isStartingRecording || isRecording, macSystemAudioCapture != nil else { return false }
+
+		let didReleaseStartupGate = releaseMacSystemAudioStartupGate(reason: .safetyTimeout)
+		if !didReleaseStartupGate {
+			macSystemAudioContinuesWithoutMicrophone = true
+			macSystemAudioCapture?.setPaused(false)
+		}
+		if !isStartingRecording {
+			macSystemAudioContinuesWithoutMicrophone = true
+			macSystemAudioCapture?.setPaused(false)
+			if !isPaused {
+				startRecordingTimer()
+			}
+		}
+		let waitingSince = Date()
+		recordingState = .waitingForMicrophone(disconnectedAt: waitingSince)
+		errorMessage = "Microphone could not be started (\(error.localizedDescription)). " +
+			"Recording meeting audio while the microphone reconnects."
+		startNativeMacInputRecoveryMonitoring()
+		AppLog.shared.audioSession(
+			"Mac microphone startup failed; continuing with system audio while waiting for an input",
+			level: .error
+		)
+		return true
+	}
+
 	/// Start recording on Mac using AVAudioEngine. Writes native PCM
 	/// into a temporary CAF file, which is exported to the caller's M4A URL in
 	/// `finalizeMacRecording(at:)`.
-	func startMacEngineRecording(at url: URL) throws {
+	func startMacEngineRecording(at url: URL, inputDeviceID: AudioDeviceID? = nil) throws {
 		// Tear down any leftover engine state from a previous run.
 		stopMacEngineRecording(closingFile: false)
+		let deviceID = inputDeviceID ?? enhancedAudioSessionManager.resolvedInputDeviceID()
 
 		// Native macOS uses Core Audio directly. AVAudioSession is an iOS API
 		// and the Mac-only fallback must never run here.
 		do {
-			try startMacEnginePipeline(at: url)
+			try startMacEnginePipeline(at: url, inputDeviceID: deviceID)
+			macInputDeviceID = deviceID
 		} catch {
 			// The pipeline assigns its engine/file/scratch URL before the final start
 			// call. If that call fails, release the partial state before the next retry.
@@ -150,11 +237,12 @@ extension AudioRecorderViewModel {
 	private func startMacEnginePipeline(
 		at url: URL,
 		scratchURL suppliedScratchURL: URL? = nil,
-		removingFinalOutput: Bool = true
+		removingFinalOutput: Bool = true,
+		inputDeviceID: AudioDeviceID? = nil
 	) throws {
 		let engine = AVAudioEngine()
 		#if os(macOS)
-		try enhancedAudioSessionManager.configureInputDevice(for: engine)
+		try enhancedAudioSessionManager.configureInputDevice(for: engine, deviceID: inputDeviceID)
 		#endif
 		let inputNode = engine.inputNode
 		// Apple documents the input-scope format as the hardware-availability
@@ -297,24 +385,60 @@ extension AudioRecorderViewModel {
 
 	/// Starts the next PCM segment on the currently resolved Core Audio input.
 	/// The original final URL is retained for the normal stop/finalize flow.
-	func startMacContinuation(at finalURL: URL) throws {
+	func startMacContinuation(
+		at finalURL: URL,
+		inputDeviceID: AudioDeviceID? = nil
+	) throws {
 		let segmentIndex = macScratchSegmentURLs.count + 1
 		let scratchURL = Self.macScratchURL(for: finalURL, segmentIndex: segmentIndex)
 		registerRecordingAttemptArtifact(at: scratchURL)
+		let deviceID = inputDeviceID ?? enhancedAudioSessionManager.resolvedInputDeviceID()
 		try startMacEnginePipeline(
 			at: finalURL,
 			scratchURL: scratchURL,
-			removingFinalOutput: false
+			removingFinalOutput: false,
+			inputDeviceID: deviceID
+		)
+		macInputDeviceID = deviceID
+	}
+
+	/// Rebuild a continuation on any live input other than the route that just
+	/// failed. A failed AudioUnit setup is cheap to discard, so try all current
+	/// candidates before leaving the recording in the waiting state.
+	@MainActor
+	func startMacContinuationWithAutomaticInputFallback(
+		at finalURL: URL,
+		excluding failedInputDeviceID: AudioDeviceID?
+	) throws {
+		var lastError: Error?
+		for deviceID in enhancedAudioSessionManager
+			.recordingInputCandidates(excluding: failedInputDeviceID) {
+			do {
+				try startMacContinuation(at: finalURL, inputDeviceID: deviceID)
+				return
+			} catch {
+				lastError = error
+				discardFailedMacCaptureState()
+				AppLog.shared.audioSession(
+					"Mac microphone continuation failed for device \(deviceID): \(error.localizedDescription)",
+					level: .error
+				)
+			}
+		}
+
+		if let lastError {
+			throw lastError
+		}
+		throw NSError(
+			domain: "AudioRecorderViewModel.Mac",
+			code: -10,
+			userInfo: [NSLocalizedDescriptionKey: "No alternate microphone is available."]
 		)
 	}
 
 	#if os(macOS)
 	func sealNativeMacScratchSegment() {
 		sealMacScratchSegment()
-	}
-
-	func startNativeMacContinuation(at finalURL: URL) throws {
-		try startMacContinuation(at: finalURL)
 	}
 	#endif
 

--- a/BisonNotes AI/BisonNotes AI/ViewModels/AudioRecorderViewModel+MacFinalization.swift
+++ b/BisonNotes AI/BisonNotes AI/ViewModels/AudioRecorderViewModel+MacFinalization.swift
@@ -195,6 +195,7 @@ extension AudioRecorderViewModel {
         macScratchSegmentURLs = []
         macSystemAudioURL = nil
         macMicrophoneStartOffset = 0
+        macInputDeviceID = nil
         resetRecordingAttemptArtifacts()
     }
 

--- a/BisonNotes AI/BisonNotes AI/ViewModels/AudioRecorderViewModel+MicrophoneReconnection.swift
+++ b/BisonNotes AI/BisonNotes AI/ViewModels/AudioRecorderViewModel+MicrophoneReconnection.swift
@@ -60,6 +60,7 @@ extension AudioRecorderViewModel {
 			guard enhancedAudioSessionManager.recordingInputNeedsRecovery() else { return }
 			await recoverNativeMacInput(keepPaused: isPaused)
 		case .waitingForMicrophone:
+			guard !macAwaitingRecoveryBuffer else { return }
 			guard enhancedAudioSessionManager.resolvedInputDeviceID() != nil else { return }
 			await recoverNativeMacInput(keepPaused: false)
 		default:
@@ -93,13 +94,11 @@ extension AudioRecorderViewModel {
 			sealNativeMacScratchSegment()
 		}
 
-		guard enhancedAudioSessionManager.resolvedInputDeviceID() != nil else {
-			await waitForNativeMacInput(disconnectedAt: disconnectedAt, notify: !wasAlreadyWaiting)
-			return
-		}
-
 		do {
-			try startNativeMacContinuation(at: finalURL)
+			try startMacContinuationWithAutomaticInputFallback(
+				at: finalURL,
+				excluding: macInputDeviceID
+			)
 			macAwaitingRecoveryBuffer = true
 			pendingMacInputRecovery = PendingMacInputRecovery(
 				keepPaused: keepPaused,
@@ -109,10 +108,12 @@ extension AudioRecorderViewModel {
 			recordingState = .waitingForMicrophone(disconnectedAt: disconnectedAt)
 			errorMessage = "Microphone connected. Confirming that audio is being received…"
 		} catch {
-			discardFailedMacCaptureState()
 			pendingMacInputRecovery = nil
 			macAwaitingRecoveryBuffer = false
 			AppLog.shared.audioSession("Mac input recovery failed: \(error.localizedDescription)", level: .error)
+			if !keepPaused, continueMacSystemAudioWithoutMicrophone(after: error) {
+				return
+			}
 			recordingState = .waitingForMicrophone(disconnectedAt: disconnectedAt)
 			errorMessage = "Could not use the available microphone: \(error.localizedDescription)"
 			startNativeMacInputRecoveryMonitoring()

--- a/BisonNotes AI/BisonNotes AI/ViewModels/AudioRecorderViewModel+MicrophoneReconnection.swift
+++ b/BisonNotes AI/BisonNotes AI/ViewModels/AudioRecorderViewModel+MicrophoneReconnection.swift
@@ -62,14 +62,22 @@ extension AudioRecorderViewModel {
 		case .waitingForMicrophone:
 			guard !macAwaitingRecoveryBuffer else { return }
 			guard enhancedAudioSessionManager.resolvedInputDeviceID() != nil else { return }
-			await recoverNativeMacInput(keepPaused: false)
+			// A device became available while we were waiting, so the input we were
+			// last bound to is no longer evidence of a bad device — Core Audio may
+			// have handed the reconnected microphone the same ID. See
+			// `MacRecordingInputSelection.excludedDeviceID`.
+			await recoverNativeMacInput(keepPaused: false, trigger: .deviceBecameAvailable)
 		default:
 			break
 		}
 	}
 
 	@MainActor
-	func recoverNativeMacInput(keepPaused: Bool, forceRestart: Bool = false) async {
+	func recoverNativeMacInput(
+		keepPaused: Bool,
+		forceRestart: Bool = false,
+		trigger: MacInputRecoveryTrigger = .currentInputFailed
+	) async {
 		guard !isRecoveringMacInput, isRecording, let finalURL = recordingURL else { return }
 		isRecoveringMacInput = true
 		defer { isRecoveringMacInput = false }
@@ -97,7 +105,10 @@ extension AudioRecorderViewModel {
 		do {
 			try startMacContinuationWithAutomaticInputFallback(
 				at: finalURL,
-				excluding: macInputDeviceID
+				excluding: MacRecordingInputSelection.excludedDeviceID(
+					currentInputDeviceID: macInputDeviceID,
+					trigger: trigger
+				)
 			)
 			macAwaitingRecoveryBuffer = true
 			pendingMacInputRecovery = PendingMacInputRecovery(

--- a/BisonNotes AI/BisonNotes AI/ViewModels/AudioRecorderViewModel+Recovery.swift
+++ b/BisonNotes AI/BisonNotes AI/ViewModels/AudioRecorderViewModel+Recovery.swift
@@ -294,14 +294,9 @@ extension AudioRecorderViewModel {
 			if failure.category == .mediaServicesReset {
 				enhancedAudioSessionManager.resetPreparedSessionAfterMediaServicesReset()
 			}
-			guard failure.attempt < AudioActivationFailure.maximumActivationAttempts else {
-				_ = await terminateAudioRecovery(
-					request,
-					reason: failure.errorDescription ?? "Audio session activation failed",
-					notify: true
-				)
-				return .stopped
-			}
+			// No budget check here: `AudioActivationFailure.disposition` is the
+			// single owner of the bound and only answers `.retry` while the
+			// attempt is under it — an exhausted budget arrives as `.fail`.
 			do {
 				try await recoverySleeper.sleep(for: min(Double(failure.attempt) * 0.5, 2.0))
 				return .retry

--- a/BisonNotes AI/BisonNotes AI/ViewModels/AudioRecorderViewModel.swift
+++ b/BisonNotes AI/BisonNotes AI/ViewModels/AudioRecorderViewModel.swift
@@ -11,6 +11,9 @@ import SwiftUI
 import Combine
 import CoreLocation
 import UserNotifications
+#if os(macOS)
+import CoreAudio
+#endif
 #if canImport(CallKit) && os(iOS)
 import CallKit
 #endif
@@ -141,6 +144,10 @@ class AudioRecorderViewModel: NSObject, ObservableObject {
 	var macCaptureHealthTimer: Timer?
 	var macAutomaticRecoveryAttempts = 0
 	var macAwaitingRecoveryBuffer = false
+	/// The Core Audio input used by the current/last Mac capture segment. Keep
+	/// this across a failed restart so the next recovery can exclude that route
+	/// and try a newly registered virtual meeting input instead.
+	var macInputDeviceID: AudioDeviceID?
 	#if os(macOS)
 	var macInputDeviceChangeTask: Task<Void, Never>?
 	var isRecoveringMacInput = false

--- a/BisonNotes AI/BisonNotes AI/Views/RecordingsView.swift
+++ b/BisonNotes AI/BisonNotes AI/Views/RecordingsView.swift
@@ -15,8 +15,8 @@ struct RecordingsView: View {
     @EnvironmentObject var importManager: FileImportManager
     @EnvironmentObject var transcriptImportManager: TranscriptImportManager
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var showingAudioImporter = false
-    @State private var showingTranscriptImporter = false
+    @State private var showingFileImporter = false
+    @State private var fileImportKind: FileImportKind = .audio
     @StateObject private var webImportManager = WebImportManager()
     @ObservedObject private var processingManager = BackgroundProcessingManager.shared
     @State private var recordings: [AudioRecordingFile] = []
@@ -25,6 +25,11 @@ struct RecordingsView: View {
     @State private var showingWebImport = false
     @State private var showingRecorderError = false
     @State private var recorderErrorMessage = ""
+
+    private enum FileImportKind {
+        case audio
+        case transcript
+    }
 
     private struct RecordingActionConfig {
         let title: String
@@ -154,6 +159,34 @@ struct RecordingsView: View {
         }
     }
 
+    private var fileImportContentTypes: [UTType] {
+        switch fileImportKind {
+        case .audio:
+            return [.audio]
+        case .transcript:
+            return Self.transcriptContentTypes
+        }
+    }
+
+    private func beginFileImport(_ kind: FileImportKind) {
+        fileImportKind = kind
+        showingFileImporter = true
+    }
+
+    private func handleFileImport(_ result: Result<[URL], Error>) {
+        let importKind = fileImportKind
+        switch importKind {
+        case .audio:
+            handleImport(result) { urls in
+                await importManager.importAudioFiles(from: urls)
+            }
+        case .transcript:
+            handleImport(result) { urls in
+                await transcriptImportManager.importTranscriptFiles(from: urls)
+            }
+        }
+    }
+
     private static let transcriptContentTypes: [UTType] = {
         var types: [UTType] = [.plainText, .text, .pdf]
         types.append(UTType(importedAs: "org.openxmlformats.wordprocessingml.document"))
@@ -269,7 +302,7 @@ struct RecordingsView: View {
                                     accessibilityIdentifier: BisonNotesAccessibilityID.importAudioButton
                                 )
                             ) {
-                                showingAudioImporter = true
+                                beginFileImport(.audio)
                             }
 
                             homeActionButton(
@@ -295,7 +328,7 @@ struct RecordingsView: View {
                                     accessibilityIdentifier: BisonNotesAccessibilityID.importTranscriptButton
                                 )
                             ) {
-                                showingTranscriptImporter = true
+                                beginFileImport(.transcript)
                             }
                         }
 
@@ -316,22 +349,11 @@ struct RecordingsView: View {
             .scrollIndicators(.hidden)
             .background(Color(.systemGroupedBackground))
             .fileImporter(
-                isPresented: $showingAudioImporter,
-                allowedContentTypes: [.audio],
+                isPresented: $showingFileImporter,
+                allowedContentTypes: fileImportContentTypes,
                 allowsMultipleSelection: true
             ) { result in
-                handleImport(result) { urls in
-                    await importManager.importAudioFiles(from: urls)
-                }
-            }
-            .fileImporter(
-                isPresented: $showingTranscriptImporter,
-                allowedContentTypes: Self.transcriptContentTypes,
-                allowsMultipleSelection: true
-            ) { result in
-                handleImport(result) { urls in
-                    await transcriptImportManager.importTranscriptFiles(from: urls)
-                }
+                handleFileImport(result)
             }
             .sheet(isPresented: $showingWebImport) {
                 WebImportSheet(
@@ -370,10 +392,10 @@ struct RecordingsView: View {
                 }
             }
             .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("ImportAudioFromMenu"))) { _ in
-                showingAudioImporter = true
+                beginFileImport(.audio)
             }
             .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("ImportTranscriptFromMenu"))) { _ in
-                showingTranscriptImporter = true
+                beginFileImport(.transcript)
             }
             .onReceive(
                 NotificationCenter.default.publisher(for: NSNotification.Name("ImportFromLinkFromMenu"))

--- a/BisonNotes AI/BisonNotes AI/Views/TranscriptViews.swift
+++ b/BisonNotes AI/BisonNotes AI/Views/TranscriptViews.swift
@@ -1467,24 +1467,19 @@ struct TranscriptsView: View {
             if shouldDeleteImportedRecording {
                 appCoordinator.deleteRecording(id: request.recordingId)
                 AppLog.shared.transcription("Deleted imported transcript and its recording entry")
-            } else if let transcriptId = request.transcriptId {
-                try await appCoordinator.deleteTranscript(id: transcriptId)
-                if request.imported {
-                    recording.recordingURL = nil
-                    recording.lastModified = Date()
-                    try? appCoordinator.coreDataManager.saveContext()
+            } else if request.imported {
+                try await appCoordinator.deleteImportedTranscriptPreservingSummary(
+                    recordingId: request.recordingId,
+                    transcriptId: request.transcriptId
+                )
+                if request.transcriptId != nil {
                     AppLog.shared.transcription("Deleted imported transcript, preserved summary")
                 } else {
-                    AppLog.shared.transcription("Deleted transcript, preserved recording and summary")
+                    AppLog.shared.transcription("Removed unavailable imported transcript, preserved summary")
                 }
-            } else if request.imported {
-                // There is no transcript row to delete, but a summary may still be
-                // anchored to this imported recording. Preserve that summary while
-                // removing the temporary audio relationship.
-                recording.recordingURL = nil
-                recording.lastModified = Date()
-                try? appCoordinator.coreDataManager.saveContext()
-                AppLog.shared.transcription("Removed unavailable imported transcript, preserved summary")
+            } else if let transcriptId = request.transcriptId {
+                try await appCoordinator.deleteTranscript(id: transcriptId)
+                AppLog.shared.transcription("Deleted transcript, preserved recording and summary")
             } else {
                 AppLog.shared.transcription("Cannot delete transcript: no transcript ID", level: .error)
             }

--- a/BisonNotes AI/BisonNotes AI/iCloudStorageManager.swift
+++ b/BisonNotes AI/BisonNotes AI/iCloudStorageManager.swift
@@ -3482,7 +3482,6 @@ extension iCloudStorageManager {
             // it, because the tag we hold is the one that edit produced. Arbitrate
             // once more against what actually came back.
             if let refetched = recordingRecordsToWrite[entry.recordID],
-               !hasPendingImportedAudioRemoval,
                !Self.shouldUploadLocalVersion(
                    localTimestamp: localRecordingContentTimestamp(entry.recording),
                    cloudTimestamp: backupRecordContentTimestamp(
@@ -3490,6 +3489,25 @@ extension iCloudStorageManager {
                        keys: Self.recordingContentTimestampKeys
                    )
                ) {
+                // A queued audio removal is an explicit user deletion, so it still has
+                // to land even though the other device's metadata wins. Clear the audio
+                // on *their* record rather than falling through to `applyRecordingFields`,
+                // which would put this device's stale name, dates, location, and
+                // processing state over the newer edit merely to drop the audio.
+                if hasPendingImportedAudioRemoval {
+                    var changed = false
+                    clearAudioBackupFields(on: refetched, changed: &changed)
+                    if changed {
+                        AppLog.shared.iCloudSync(
+                            "Another device wrote this recording while the run was in flight; "
+                            + "keeping its version and clearing only the removed audio",
+                            level: .debug
+                        )
+                        recordsToSave.append(refetched)
+                        continue
+                    }
+                }
+
                 AppLog.shared.iCloudSync(
                     "Another device wrote this recording while the run was in flight; keeping its version",
                     level: .debug

--- a/BisonNotes AI/BisonNotes AI/iCloudStorageManager.swift
+++ b/BisonNotes AI/BisonNotes AI/iCloudStorageManager.swift
@@ -2776,6 +2776,7 @@ extension iCloudStorageManager {
     private static let pendingLocalOnlyRemovalsKey = "iCloudPendingLocalOnlyRemovalsV1"
     private static let pendingSummaryRemovalsKey = "iCloudPendingSummaryRemovalsV1"
     private static let pendingTranscriptRemovalsKey = "iCloudPendingTranscriptRemovalsV1"
+    private static let pendingImportedAudioRemovalsKey = "iCloudPendingImportedAudioRemovalsV1"
     private static let backupRecordingRecordPrefix = "backup_recording_"
     private static let backupTranscriptRecordPrefix = "backup_transcript_"
     private static let backupSummaryRecordPrefix = "backup_summary_"
@@ -2804,6 +2805,11 @@ extension iCloudStorageManager {
     private struct PendingSummaryCloudRemoval: Codable, Equatable {
         let summaryId: UUID
         var recordingId: UUID?
+        let requestedAt: Date
+    }
+
+    private struct PendingImportedAudioRemoval: Codable, Equatable {
+        let recordingId: UUID
         let requestedAt: Date
     }
 
@@ -3242,6 +3248,7 @@ extension iCloudStorageManager {
             options: options
         )
         if activeManifestMigrationCompleted,
+           pendingImportedAudioRemovals.isEmpty,
            UserDefaults.standard.string(forKey: Self.backupStateSignatureKey) == currentBackupStateSignature {
             let hasCloudContentBackup = try await cloudHasAnyContentBackupRecord()
             if hasCloudContentBackup {
@@ -3318,8 +3325,12 @@ extension iCloudStorageManager {
                 recordName: makeBackupRecordName(prefix: Self.backupRecordingRecordPrefix, id: recordingId)
             )
             let existingRecord = snapshot.recordings[recordID]
+            let hasPendingImportedAudioRemoval = pendingImportedAudioRemovals.contains {
+                $0.recordingId == recordingId
+            }
 
             if let existingRecord,
+               !hasPendingImportedAudioRemoval,
                !Self.shouldUploadLocalVersion(
                    localTimestamp: localRecordingContentTimestamp(recording),
                    cloudTimestamp: backupRecordContentTimestamp(
@@ -3348,6 +3359,9 @@ extension iCloudStorageManager {
             let probe = existingRecord
                 ?? CKRecord(recordType: Self.backupRecordingRecordType, recordID: recordID)
             applyRecordingFields(recording, to: probe, changed: &changed)
+            if hasPendingImportedAudioRemoval {
+                clearAudioBackupFields(on: probe, changed: &changed)
+            }
             if changed {
                 recordingsNeedingUpload.append((recording, recordID))
             } else if options.includeAudioFiles, existingRecord?[Self.fieldAudioSignature] == nil {
@@ -3456,6 +3470,9 @@ extension iCloudStorageManager {
         var remoteWinnersFoundWhileWriting: [CKRecord] = []
 
         for entry in recordingsNeedingUpload {
+            let hasPendingImportedAudioRemoval = entry.recording.id.map { recordingId in
+                pendingImportedAudioRemovals.contains { $0.recordingId == recordingId }
+            } ?? false
             let record = recordingRecordsToWrite[entry.recordID]
                 ?? CKRecord(recordType: Self.backupRecordingRecordType, recordID: entry.recordID)
 
@@ -3465,6 +3482,7 @@ extension iCloudStorageManager {
             // it, because the tag we hold is the one that edit produced. Arbitrate
             // once more against what actually came back.
             if let refetched = recordingRecordsToWrite[entry.recordID],
+               !hasPendingImportedAudioRemoval,
                !Self.shouldUploadLocalVersion(
                    localTimestamp: localRecordingContentTimestamp(entry.recording),
                    cloudTimestamp: backupRecordContentTimestamp(
@@ -3496,6 +3514,9 @@ extension iCloudStorageManager {
                     result.audioFilesBackedUp += 1
                 }
             }
+            if hasPendingImportedAudioRemoval {
+                clearAudioBackupFields(on: record, changed: &changed)
+            }
             recordsToSave.append(record)
         }
 
@@ -3513,6 +3534,10 @@ extension iCloudStorageManager {
                 changed: &changed
             ) {
                 result.audioFilesBackedUp += 1
+            }
+            if let recordingId = entry.recording.id,
+               pendingImportedAudioRemovals.contains(where: { $0.recordingId == recordingId }) {
+                clearAudioBackupFields(on: record, changed: &changed)
             }
             if changed {
                 recordsToSave.append(record)
@@ -3586,6 +3611,19 @@ extension iCloudStorageManager {
         // record that failed to upload, and never keeps one that was deleted.
         let settledManifest = try await applyManifestDelta(manifestDelta)
         recorder?.endPhase()
+
+        let settledRecordsByID = Dictionary(uniqueKeysWithValues: settledRecords.map { ($0.recordID, $0) })
+        for pendingRemoval in pendingImportedAudioRemovals {
+            let recordID = CKRecord.ID(
+                recordName: makeBackupRecordName(
+                    prefix: Self.backupRecordingRecordPrefix,
+                    id: pendingRemoval.recordingId
+                )
+            )
+            guard let settledRecord = settledRecordsByID[recordID],
+                  !hasAudioBackupFields(settledRecord) else { continue }
+            clearPendingImportedAudioRemoval(recordingId: pendingRemoval.recordingId)
+        }
 
         // The settled manifest, not this run's arithmetic on a snapshot that may
         // already be stale: where another device added or removed an entry while
@@ -5500,6 +5538,11 @@ extension iCloudStorageManager {
         set { Self.storePendingCloudMutations(newValue, key: Self.pendingTranscriptRemovalsKey) }
     }
 
+    private var pendingImportedAudioRemovals: [PendingImportedAudioRemoval] {
+        get { Self.decodePendingCloudMutations(PendingImportedAudioRemoval.self, key: Self.pendingImportedAudioRemovalsKey) }
+        set { Self.storePendingCloudMutations(newValue, key: Self.pendingImportedAudioRemovalsKey) }
+    }
+
     private static func decodePendingCloudMutations<T: Decodable>(_ type: T.Type, key: String) -> [T] {
         guard let data = UserDefaults.standard.data(forKey: key) else {
             return []
@@ -5545,6 +5588,7 @@ extension iCloudStorageManager {
             ))
         }
         pendingCloudDeletionMarkers = queue
+        pendingImportedAudioRemovals.removeAll { $0.recordingId == recordingId }
         let deletedSummaryIds = Set(summaryIds)
         pendingSyncQueue.removeAll { summary in
             summary.recordingId == recordingId || deletedSummaryIds.contains(summary.id)
@@ -5607,6 +5651,22 @@ extension iCloudStorageManager {
         publishMaintenanceMessage("Deleted transcripts will be removed from iCloud sync records when iCloud sync is available.")
     }
 
+    /// Records an explicit user request to remove an imported recording's temporary
+    /// audio while retaining its summary. A missing local file is otherwise treated
+    /// as an environmental condition and must not clear a healthy cloud asset.
+    func enqueueImportedAudioRemovalFromiCloud(
+        recordingId: UUID,
+        requestedAt: Date = Date()
+    ) {
+        var queue = pendingImportedAudioRemovals
+        if !queue.contains(where: { $0.recordingId == recordingId }) {
+            queue.append(PendingImportedAudioRemoval(recordingId: recordingId, requestedAt: requestedAt))
+            pendingImportedAudioRemovals = queue
+        }
+        UserDefaults.standard.removeObject(forKey: Self.backupStateSignatureKey)
+        publishMaintenanceMessage("Deleted imported audio will be removed from iCloud sync records when iCloud sync is available.")
+    }
+
     func clearPendingLocalOnlyCloudRemoval(recordingId: UUID) {
         pendingLocalOnlyCloudRemovals.removeAll { $0.recordingId == recordingId }
     }
@@ -5619,8 +5679,75 @@ extension iCloudStorageManager {
         pendingTranscriptCloudRemovals.removeAll { $0.transcriptId == transcriptId }
     }
 
+    func clearPendingImportedAudioRemoval(recordingId: UUID) {
+        pendingImportedAudioRemovals.removeAll { $0.recordingId == recordingId }
+    }
+
     func clearPendingRecordingDeletion(recordingId: UUID) {
         pendingCloudDeletionMarkers.removeAll { $0.recordingId == recordingId }
+    }
+
+    /// Removes the cloud audio and placeholder relationships for an imported item
+    /// after the user explicitly deleted its temporary audio. This is deliberately
+    /// separate from `CloudAudioAssetPolicy.skippedMissingSource`: an absent file
+    /// can be an ordinary device condition, while this queue is an intentional
+    /// destructive action that must survive an offline period.
+    private func markImportedAudioRemovedInCloud(
+        _ pendingRemoval: PendingImportedAudioRemoval
+    ) async throws {
+        let recordID = CKRecord.ID(
+            recordName: makeBackupRecordName(
+                prefix: Self.backupRecordingRecordPrefix,
+                id: pendingRemoval.recordingId
+            )
+        )
+        let fetchOutcome = try await cloudExecutor.fetch([recordID])
+        recordMetrics(fetch: fetchOutcome)
+        try fetchOutcome.throwIfIncomplete()
+
+        guard let record = fetchOutcome.records[recordID] else {
+            // The recording was already removed from CloudKit. There is no asset
+            // left for this intent to clear, so the durable work is complete.
+            clearPendingImportedAudioRemoval(recordingId: pendingRemoval.recordingId)
+            return
+        }
+
+        var changed = false
+        clearAudioBackupFields(on: record, changed: &changed)
+        updateStringField(Self.fieldRecordingURL, value: nil, on: record, changed: &changed)
+        updateStringField(Self.fieldTranscriptId, value: nil, on: record, changed: &changed)
+        updateStringField(
+            Self.fieldTranscriptionStatus,
+            value: ProcessingStatus.notStarted.rawValue,
+            on: record,
+            changed: &changed
+        )
+        updateDateField(
+            Self.fieldLastModified,
+            value: pendingRemoval.requestedAt,
+            on: record,
+            changed: &changed
+        )
+        markBackupRecordActive(record, changed: &changed)
+
+        guard changed else {
+            clearPendingImportedAudioRemoval(recordingId: pendingRemoval.recordingId)
+            return
+        }
+
+        let saveOutcome = try await saveBackupRecords([record])
+        let settledRecord = saveOutcome.settledRecords.first { $0.recordID == recordID }
+        guard let settledRecord, !hasAudioBackupFields(settledRecord) else {
+            // Do not report completion until a server winner without the old asset
+            // has been observed. The next sync will retry the durable intent.
+            throw CloudSyncUnsettledRecordsError(recordCount: 1)
+        }
+
+        clearPendingImportedAudioRemoval(recordingId: pendingRemoval.recordingId)
+        AppLog.shared.iCloudSync(
+            "Recorded imported audio removal for \(pendingRemoval.recordingId.uuidString)",
+            level: .debug
+        )
     }
 
     private static func mergedUUIDs(_ lhs: [UUID], _ rhs: [UUID]) -> [UUID] {
@@ -5661,6 +5788,7 @@ extension iCloudStorageManager {
         var flushedLocalOnlyRemovals = 0
         var flushedSummaryRemovals = 0
         var flushedTranscriptRemovals = 0
+        var flushedImportedAudioRemovals = 0
 
         for pendingDeletion in pendingCloudDeletionMarkers {
             try await markRecordingDeletedIniCloud(
@@ -5707,13 +5835,20 @@ extension iCloudStorageManager {
             flushedLocalOnlyRemovals += 1
         }
 
+        for pendingRemoval in pendingImportedAudioRemovals {
+            try await markImportedAudioRemovedInCloud(pendingRemoval)
+            flushedImportedAudioRemovals += 1
+        }
+
         if flushedDeletions > 0 || flushedLocalOnlyRemovals > 0 ||
-            flushedTranscriptRemovals > 0 || flushedSummaryRemovals > 0 {
+            flushedTranscriptRemovals > 0 || flushedSummaryRemovals > 0 ||
+            flushedImportedAudioRemovals > 0 {
             AppLog.shared.iCloudSync(
                 "Flushed pending iCloud mutations - deletions: \(flushedDeletions), " +
                     "local-only removals: \(flushedLocalOnlyRemovals), " +
                     "transcript removals: \(flushedTranscriptRemovals), " +
-                    "summary removals: \(flushedSummaryRemovals)",
+                    "summary removals: \(flushedSummaryRemovals), " +
+                    "imported audio removals: \(flushedImportedAudioRemovals)",
                 level: .debug
             )
         }
@@ -5727,7 +5862,8 @@ extension iCloudStorageManager {
         pendingCloudDeletionMarkers.count +
             pendingTranscriptCloudRemovals.count +
             pendingSummaryCloudRemovals.count +
-            pendingLocalOnlyCloudRemovals.count
+            pendingLocalOnlyCloudRemovals.count +
+            pendingImportedAudioRemovals.count
     }
 
     #if DEBUG
@@ -5747,6 +5883,10 @@ extension iCloudStorageManager {
         pendingTranscriptCloudRemovals.count
     }
 
+    var pendingImportedAudioRemovalCountForTesting: Int {
+        pendingImportedAudioRemovals.count
+    }
+
     func pendingCloudDeletionRequestedAtForTesting(recordingId: UUID) -> Date? {
         pendingCloudDeletionMarkers.first { $0.recordingId == recordingId }?.requestedAt
     }
@@ -5756,6 +5896,7 @@ extension iCloudStorageManager {
         pendingLocalOnlyCloudRemovals = []
         pendingSummaryCloudRemovals = []
         pendingTranscriptCloudRemovals = []
+        pendingImportedAudioRemovals = []
     }
     #endif
 
@@ -6686,6 +6827,30 @@ extension iCloudStorageManager {
             record[key] = value as CKRecordValue?
             changed = true
         }
+    }
+
+    private func clearRecordField(
+        _ key: String,
+        on record: CKRecord,
+        changed: inout Bool
+    ) {
+        guard record[key] != nil else { return }
+        record[key] = nil
+        changed = true
+    }
+
+    private func clearAudioBackupFields(on record: CKRecord, changed: inout Bool) {
+        clearRecordField(Self.fieldAudioAsset, on: record, changed: &changed)
+        clearRecordField(Self.fieldAudioFileName, on: record, changed: &changed)
+        clearRecordField(Self.fieldAudioByteCount, on: record, changed: &changed)
+        clearRecordField(Self.fieldAudioSignature, on: record, changed: &changed)
+    }
+
+    private func hasAudioBackupFields(_ record: CKRecord) -> Bool {
+        record[Self.fieldAudioAsset] != nil ||
+            record[Self.fieldAudioFileName] != nil ||
+            record[Self.fieldAudioByteCount] != nil ||
+            record[Self.fieldAudioSignature] != nil
     }
 
     private func updateDateField(

--- a/BisonNotes AI/BisonNotes AI/iCloudStorageManager.swift
+++ b/BisonNotes AI/BisonNotes AI/iCloudStorageManager.swift
@@ -5732,20 +5732,42 @@ extension iCloudStorageManager {
 
         var changed = false
         clearAudioBackupFields(on: record, changed: &changed)
-        updateStringField(Self.fieldRecordingURL, value: nil, on: record, changed: &changed)
-        updateStringField(Self.fieldTranscriptId, value: nil, on: record, changed: &changed)
-        updateStringField(
-            Self.fieldTranscriptionStatus,
-            value: ProcessingStatus.notStarted.rawValue,
-            on: record,
-            changed: &changed
+
+        // The audio removal is an explicit destructive intent, but it must not
+        // turn a newer edit into an older record just because this device's
+        // deletion marker arrived late. Preserve newer metadata and only clear
+        // the audio fields in that case; the normal backup arbitration then keeps
+        // the newer cloud relationships and processing state as well.
+        let cloudTimestamp = backupRecordContentTimestamp(
+            record,
+            keys: Self.recordingContentTimestampKeys
         )
-        updateDateField(
-            Self.fieldLastModified,
-            value: pendingRemoval.requestedAt,
-            on: record,
-            changed: &changed
+        let shouldApplyRemovalMetadata = Self.shouldUploadLocalVersion(
+            localTimestamp: pendingRemoval.requestedAt,
+            cloudTimestamp: cloudTimestamp
         )
+        if shouldApplyRemovalMetadata {
+            updateStringField(Self.fieldRecordingURL, value: nil, on: record, changed: &changed)
+            updateStringField(Self.fieldTranscriptId, value: nil, on: record, changed: &changed)
+            updateStringField(
+                Self.fieldTranscriptionStatus,
+                value: ProcessingStatus.notStarted.rawValue,
+                on: record,
+                changed: &changed
+            )
+            updateDateField(
+                Self.fieldLastModified,
+                value: pendingRemoval.requestedAt,
+                on: record,
+                changed: &changed
+            )
+        } else {
+            AppLog.shared.iCloudSync(
+                "Preserved newer cloud metadata while removing imported audio for " +
+                    "\(pendingRemoval.recordingId.uuidString)",
+                level: .debug
+            )
+        }
         markBackupRecordActive(record, changed: &changed)
 
         guard changed else {

--- a/BisonNotes AI/BisonNotes AITests/CacheMaintenanceTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/CacheMaintenanceTests.swift
@@ -1,0 +1,219 @@
+//
+//  CacheMaintenanceTests.swift
+//  BisonNotes AITests
+//
+//  Covers the rules that bound the two caches which grew to 29 GB on macOS:
+//  the Hugging Face blob cache behind MLX model downloads, and the persisted
+//  log files. See `CacheMaintenanceService` and `LogTrimPolicy`.
+//
+
+import XCTest
+@testable import BisonNotes_AI
+
+final class CacheMaintenanceTests: XCTestCase {
+
+    // MARK: - Hub repository directory naming
+
+    func testHubRepoDirectoryNameMatchesHuggingFaceLayout() {
+        XCTAssertEqual(
+            CacheMaintenancePolicy.hubRepoDirectoryName(forModelID: "prism-ml/Ternary-Bonsai-27B-mlx-2bit"),
+            "models--prism-ml--Ternary-Bonsai-27B-mlx-2bit"
+        )
+    }
+
+    func testModelIDRoundTripsThroughDirectoryName() {
+        let modelID = "mlx-community/Qwen3-4B-4bit"
+        let directory = CacheMaintenancePolicy.hubRepoDirectoryName(forModelID: modelID)
+        XCTAssertEqual(CacheMaintenancePolicy.modelID(forHubRepoDirectoryName: directory), modelID)
+    }
+
+    /// A repository name may itself contain `--`; only the first separator after
+    /// the prefix divides namespace from name.
+    func testModelIDKeepsDoubleDashesInsideRepositoryName() {
+        XCTAssertEqual(
+            CacheMaintenancePolicy.modelID(forHubRepoDirectoryName: "models--org--name--with--dashes"),
+            "org/name--with--dashes"
+        )
+    }
+
+    func testModelIDRejectsNonModelDirectories() {
+        XCTAssertNil(CacheMaintenancePolicy.modelID(forHubRepoDirectoryName: ".metadata"))
+        XCTAssertNil(CacheMaintenancePolicy.modelID(forHubRepoDirectoryName: "datasets--org--name"))
+        XCTAssertNil(CacheMaintenancePolicy.modelID(forHubRepoDirectoryName: "models--org"))
+        XCTAssertNil(CacheMaintenancePolicy.modelID(forHubRepoDirectoryName: "models----name"))
+        XCTAssertNil(CacheMaintenancePolicy.modelID(forHubRepoDirectoryName: "random-file.txt"))
+    }
+
+    // MARK: - What may be pruned from the blob cache
+
+    /// The blobs of an installed model are a byte-for-byte second copy: the app
+    /// resolves models out of `downloadBase` and never reads the blob cache.
+    func testInstalledModelBlobsArePrunedAsDuplicates() {
+        XCTAssertEqual(
+            CacheMaintenancePolicy.hubPruneReason(
+                directoryName: "models--org--installed",
+                installedModelIDs: ["org/installed"],
+                isDownloadInFlight: false
+            ),
+            .duplicateOfInstalledModel
+        )
+    }
+
+    /// Blobs no installed model claims are what a "delete" in Settings used to
+    /// leave behind — 3.3 GB of them on the machine that prompted this.
+    func testUnclaimedBlobsArePrunedAsOrphans() {
+        XCTAssertEqual(
+            CacheMaintenancePolicy.hubPruneReason(
+                directoryName: "models--org--deleted",
+                installedModelIDs: ["org/installed"],
+                isDownloadInFlight: false
+            ),
+            .orphaned
+        )
+    }
+
+    /// The blob cache is also the resume state for an interrupted download, so a
+    /// sweep must never run while one is in flight.
+    func testNothingIsPrunedWhileADownloadIsInFlight() {
+        XCTAssertNil(
+            CacheMaintenancePolicy.hubPruneReason(
+                directoryName: "models--org--installed",
+                installedModelIDs: ["org/installed"],
+                isDownloadInFlight: true
+            )
+        )
+        XCTAssertNil(
+            CacheMaintenancePolicy.hubPruneReason(
+                directoryName: "models--org--deleted",
+                installedModelIDs: [],
+                isDownloadInFlight: true
+            )
+        )
+    }
+
+    func testNonModelDirectoriesAreNeverPruned() {
+        XCTAssertNil(
+            CacheMaintenancePolicy.hubPruneReason(
+                directoryName: ".metadata",
+                installedModelIDs: [],
+                isDownloadInFlight: false
+            )
+        )
+    }
+
+    // MARK: - CloudKit asset cache budget
+
+    private func entry(_ id: String, ageHours: Double, megabytes: Int64) -> CacheMaintenancePolicy.AssetEntry {
+        CacheMaintenancePolicy.AssetEntry(
+            identifier: id,
+            byteCount: megabytes * 1024 * 1024,
+            modifiedAt: Date().addingTimeInterval(-ageHours * 3600)
+        )
+    }
+
+    /// Nothing younger than the minimum age is touched, whatever the cache weighs:
+    /// that gate is what stands in for an in-flight check.
+    func testAssetsInsideTheMinimumAgeAreNeverPruned() {
+        let entries = (0..<10).map { entry("recent-\($0)", ageHours: 0.1, megabytes: 1_000) }
+        let doomed = CacheMaintenancePolicy.assetsToPrune(entries, now: Date())
+        XCTAssertTrue(doomed.isEmpty)
+    }
+
+    /// The defect this bounds: the cache was seen growing from 9.8 GB to 32 GB in
+    /// about an hour, so age alone does not hold it down — the budget does.
+    func testCacheOverBudgetIsPrunedOldestFirstUntilUnderBudget() {
+        // 6 GB eligible, well inside the maximum age, against a 2 GB budget.
+        let entries = (0..<6).map { entry("asset-\($0)", ageHours: Double(12 - $0), megabytes: 1_024) }
+        let doomed = CacheMaintenancePolicy.assetsToPrune(entries, now: Date())
+
+        XCTAssertEqual(doomed.count, 4, "should stop as soon as the cache is under budget")
+        XCTAssertEqual(doomed.map(\.identifier), ["asset-0", "asset-1", "asset-2", "asset-3"])
+    }
+
+    func testCacheUnderBudgetAndInsideMaximumAgeIsLeftAlone() {
+        let entries = [entry("a", ageHours: 5, megabytes: 100), entry("b", ageHours: 3, megabytes: 100)]
+        XCTAssertTrue(CacheMaintenancePolicy.assetsToPrune(entries, now: Date()).isEmpty)
+    }
+
+    /// Past the maximum age an asset goes even when the cache is tiny.
+    func testAssetsPastTheMaximumAgeArePrunedRegardlessOfBudget() {
+        let entries = [entry("stale", ageHours: 48, megabytes: 1), entry("fresh", ageHours: 2, megabytes: 1)]
+        let doomed = CacheMaintenancePolicy.assetsToPrune(entries, now: Date())
+        XCTAssertEqual(doomed.map(\.identifier), ["stale"])
+    }
+
+    /// An unknown age must not be read as "old enough to delete".
+    func testAssetWithNoTimestampIsKeptEvenOverBudget() {
+        let entries = [
+            CacheMaintenancePolicy.AssetEntry(identifier: "unknown", byteCount: 8 * 1024 * 1024 * 1024, modifiedAt: nil)
+        ]
+        XCTAssertTrue(CacheMaintenancePolicy.assetsToPrune(entries, now: Date()).isEmpty)
+    }
+
+    // MARK: - Persisted log budgets
+
+    /// The defect: 476 lines held 4.1 MB because one line was 354 KB.
+    func testOneHugeLineIsClampedToItsByteBudget() {
+        let line = String(repeating: "x", count: 400_000)
+        let clamped = LogTrimPolicy.clamp(line, maxBytes: 8 * 1024)
+        XCTAssertLessThanOrEqual(clamped.utf8.count, 8 * 1024)
+        XCTAssertTrue(clamped.hasSuffix("…[truncated]"))
+    }
+
+    func testShortLineIsLeftAlone() {
+        XCTAssertEqual(LogTrimPolicy.clamp("a short line", maxBytes: 8 * 1024), "a short line")
+    }
+
+    /// Clamping counts UTF-8 bytes, not characters, and must not split one.
+    func testClampNeverSplitsAMultiByteCharacter() {
+        let line = String(repeating: "é", count: 500)
+        let clamped = LogTrimPolicy.clamp(line, maxBytes: 64)
+        XCTAssertLessThanOrEqual(clamped.utf8.count, 64)
+        XCTAssertNotNil(clamped.range(of: "…[truncated]"))
+    }
+
+    /// A persisted line must stay on one line, or the line-count cap means nothing.
+    func testClampFlattensEmbeddedNewlines() {
+        let clamped = LogTrimPolicy.clamp("first\nsecond", maxBytes: 1024)
+        XCTAssertFalse(clamped.contains("\n"))
+    }
+
+    func testTrimDropsOldestLinesPastTheLineCount() {
+        let lines = (1...10).map { "line \($0)" }
+        let kept = LogTrimPolicy.trim(lines: lines, maxLines: 3, maxBytes: .max)
+        XCTAssertEqual(kept, ["line 8", "line 9", "line 10"])
+    }
+
+    func testTrimDropsOldestLinesPastTheByteBudget() {
+        let lines = (1...10).map { _ in String(repeating: "x", count: 100) }
+        let kept = LogTrimPolicy.trim(lines: lines, maxLines: .max, maxBytes: 350)
+        XCTAssertEqual(kept.count, 3)
+    }
+
+    /// Even a line that alone exceeds the budget is kept, so logging is never a no-op.
+    func testTrimAlwaysKeepsTheNewestLine() {
+        let kept = LogTrimPolicy.trim(
+            lines: ["old", String(repeating: "x", count: 5_000)],
+            maxLines: .max,
+            maxBytes: 100
+        )
+        XCTAssertEqual(kept.count, 1)
+        XCTAssertEqual(kept.first?.count, 5_000)
+    }
+
+    func testTrimLeavesAnUnderBudgetLogAlone() {
+        let lines = ["a", "b", "c"]
+        XCTAssertEqual(LogTrimPolicy.trim(lines: lines, maxLines: 100, maxBytes: 10_000), lines)
+    }
+
+    // MARK: - Diagnostic export naming
+
+    /// `TemporaryFileCleanupService` deletes by name, so the predicate has to be
+    /// exact: these exports sat in tmp at ~9 MB each until nothing removed them.
+    func testExportFileNameRecognition() {
+        XCTAssertTrue(LogExporter.isExportFileName("BisonNotes-Logs-2026-08-30T18-15-13.txt"))
+        XCTAssertFalse(LogExporter.isExportFileName("BisonNotes-Logs-2026-08-30T18-15-13.m4a"))
+        XCTAssertFalse(LogExporter.isExportFileName("recording.txt"))
+        XCTAssertFalse(LogExporter.isExportFileName("apprecording-1787583442.caf"))
+    }
+}

--- a/BisonNotes AI/BisonNotes AITests/CacheMaintenanceTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/CacheMaintenanceTests.swift
@@ -206,6 +206,120 @@ final class CacheMaintenanceTests: XCTestCase {
         XCTAssertEqual(LogTrimPolicy.trim(lines: lines, maxLines: 100, maxBytes: 10_000), lines)
     }
 
+    // MARK: - Blob sweep, against a real directory tree
+
+    /// Builds `<caches>/huggingface/hub/models--…` blobs and `<caches>/models/…`
+    /// materialized copies, the two layouts `defaultHubApi` writes.
+    private func makeCachesRoot(
+        hubRepos: [String],
+        installedModels: [String]
+    ) throws -> URL {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("SweepTests-\(UUID().uuidString)", isDirectory: true)
+        let hub = root.appendingPathComponent("huggingface/hub", isDirectory: true)
+        try FileManager.default.createDirectory(at: hub, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+
+        for repo in hubRepos {
+            let blobs = hub.appendingPathComponent(repo, isDirectory: true)
+                .appendingPathComponent("blobs", isDirectory: true)
+            try FileManager.default.createDirectory(at: blobs, withIntermediateDirectories: true)
+            try Data(repeating: 0x62, count: 1_024)
+                .write(to: blobs.appendingPathComponent("blob0"))
+        }
+
+        for model in installedModels {
+            let dir = root.appendingPathComponent("models", isDirectory: true)
+                .appendingPathComponent(model, isDirectory: true)
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            try Data("{}".utf8).write(to: dir.appendingPathComponent("config.json"))
+        }
+
+        return root
+    }
+
+    private func hubRepoExists(_ repo: String, in root: URL) -> Bool {
+        FileManager.default.fileExists(
+            atPath: root.appendingPathComponent("huggingface/hub/\(repo)").path
+        )
+    }
+
+    func testSweepRemovesDuplicateAndOrphanedBlobs() async throws {
+        let root = try makeCachesRoot(
+            hubRepos: ["models--org--installed", "models--org--deleted"],
+            installedModels: ["org/installed"]
+        )
+
+        let report = await CacheMaintenanceSweep(cachesRoot: root).run { false }
+
+        XCTAssertFalse(hubRepoExists("models--org--installed", in: root))
+        XCTAssertFalse(hubRepoExists("models--org--deleted", in: root))
+        XCTAssertEqual(report.removedDirectoryCount, 2)
+        XCTAssertGreaterThan(report.duplicateModelBlobBytes, 0)
+        XCTAssertGreaterThan(report.orphanedModelBlobBytes, 0)
+    }
+
+    /// The materialized copy is the one the app reads; the sweep must never touch it.
+    func testSweepLeavesTheMaterializedModelAlone() async throws {
+        let root = try makeCachesRoot(
+            hubRepos: ["models--org--installed"],
+            installedModels: ["org/installed"]
+        )
+
+        _ = await CacheMaintenanceSweep(cachesRoot: root).run { false }
+
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: root.appendingPathComponent("models/org/installed/config.json").path
+        ))
+    }
+
+    /// The blob cache is a running download's resume state.
+    func testSweepRemovesNothingWhileADownloadIsInFlight() async throws {
+        let root = try makeCachesRoot(
+            hubRepos: ["models--org--installed", "models--org--deleted"],
+            installedModels: ["org/installed"]
+        )
+
+        let report = await CacheMaintenanceSweep(cachesRoot: root).run { true }
+
+        XCTAssertTrue(hubRepoExists("models--org--installed", in: root))
+        XCTAssertTrue(hubRepoExists("models--org--deleted", in: root))
+        XCTAssertEqual(report.removedDirectoryCount, 0)
+    }
+
+    /// The check is re-read per directory rather than sampled once for the sweep: a
+    /// download starting mid-sweep must protect the repositories not yet reached.
+    /// A single sampled reading deleted the repository a download was writing.
+    func testDownloadCheckIsConsultedForEveryDirectory() async throws {
+        let root = try makeCachesRoot(
+            hubRepos: ["models--org--a", "models--org--b", "models--org--c"],
+            installedModels: []
+        )
+
+        let callCount = Counter()
+        let report = await CacheMaintenanceSweep(cachesRoot: root).run {
+            // Reports "a download started" from the second directory onward.
+            await callCount.increment() > 1
+        }
+
+        let surviving = ["models--org--a", "models--org--b", "models--org--c"]
+            .filter { hubRepoExists($0, in: root) }
+        let observedCalls = await callCount.value
+        XCTAssertEqual(observedCalls, 3, "every candidate must re-read the check")
+        XCTAssertEqual(report.removedDirectoryCount, 1)
+        XCTAssertEqual(surviving.count, 2, "directories reached after the download began must survive")
+    }
+
+    func testSweepIgnoresNonModelDirectories() async throws {
+        let root = try makeCachesRoot(hubRepos: [".metadata", "datasets--org--set"], installedModels: [])
+
+        let report = await CacheMaintenanceSweep(cachesRoot: root).run { false }
+
+        XCTAssertTrue(hubRepoExists(".metadata", in: root))
+        XCTAssertTrue(hubRepoExists("datasets--org--set", in: root))
+        XCTAssertEqual(report.removedDirectoryCount, 0)
+    }
+
     // MARK: - Rolling log file, against real files
 
     private func makeTempLogURL() -> URL {
@@ -292,5 +406,16 @@ final class CacheMaintenanceTests: XCTestCase {
         XCTAssertFalse(LogExporter.isExportFileName("BisonNotes-Logs-2026-08-30T18-15-13.m4a"))
         XCTAssertFalse(LogExporter.isExportFileName("recording.txt"))
         XCTAssertFalse(LogExporter.isExportFileName("apprecording-1787583442.caf"))
+    }
+}
+
+/// Actor so the sweep's `@Sendable` check closure can count its calls.
+private actor Counter {
+    private(set) var value = 0
+
+    @discardableResult
+    func increment() -> Int {
+        value += 1
+        return value
     }
 }

--- a/BisonNotes AI/BisonNotes AITests/CacheMaintenanceTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/CacheMaintenanceTests.swift
@@ -329,6 +329,87 @@ final class CacheMaintenanceTests: XCTestCase {
         XCTAssertEqual(report.removedDirectoryCount, 0)
     }
 
+    // MARK: - Sharded model completeness
+
+    /// A materialized model directory with a valid `config.json` and nothing else.
+    private func makeMaterializedModelDirectory() throws -> URL {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ModelDir-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        try Data("{}".utf8).write(to: directory.appendingPathComponent("config.json"))
+        return directory
+    }
+
+    private func writeShardIndex(in directory: URL, shards: [String]) throws {
+        var weightMap: [String: String] = [:]
+        for (index, shard) in shards.enumerated() {
+            weightMap["layer.\(index).weight"] = shard
+        }
+        try JSONSerialization
+            .data(withJSONObject: ["weight_map": weightMap])
+            .write(to: directory.appendingPathComponent("model.safetensors.index.json"))
+    }
+
+    private func writeShard(_ name: String, in directory: URL, byteCount: Int = 128) throws {
+        try Data(repeating: 0x64, count: byteCount)
+            .write(to: directory.appendingPathComponent(name))
+    }
+
+    /// One landed shard used to be enough. A relaunch mid-download then read the
+    /// model as installed, so the sweep deleted the blob cache the interrupted
+    /// download needed to resume and Settings offered the model as ready.
+    func testShardedModelIsIncompleteUntilEveryShardLands() throws {
+        let directory = try makeMaterializedModelDirectory()
+        let shards = [
+            "model-00001-of-00003.safetensors",
+            "model-00002-of-00003.safetensors",
+            "model-00003-of-00003.safetensors"
+        ]
+        try writeShardIndex(in: directory, shards: shards)
+        try writeShard(shards[0], in: directory)
+
+        XCTAssertFalse(CacheMaintenancePolicy.isMaterializedModelComplete(at: directory))
+
+        try writeShard(shards[1], in: directory)
+        try writeShard(shards[2], in: directory)
+
+        XCTAssertTrue(CacheMaintenancePolicy.isMaterializedModelComplete(at: directory))
+    }
+
+    /// A shard file that exists but holds nothing is a copy that was interrupted.
+    func testShardedModelWithAnEmptyShardIsIncomplete() throws {
+        let directory = try makeMaterializedModelDirectory()
+        let shards = ["model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors"]
+        try writeShardIndex(in: directory, shards: shards)
+        try writeShard(shards[0], in: directory)
+        try writeShard(shards[1], in: directory, byteCount: 0)
+
+        XCTAssertFalse(CacheMaintenancePolicy.isMaterializedModelComplete(at: directory))
+    }
+
+    /// The index itself can be half-copied. Falling back to "any one weight file"
+    /// there would call a partly downloaded sharded model complete.
+    func testShardedModelWithAnUnreadableIndexIsIncomplete() throws {
+        let directory = try makeMaterializedModelDirectory()
+        try Data("{ not json".utf8)
+            .write(to: directory.appendingPathComponent("model.safetensors.index.json"))
+        try writeShard("model-00001-of-00002.safetensors", in: directory)
+
+        XCTAssertFalse(CacheMaintenancePolicy.isMaterializedModelComplete(at: directory))
+    }
+
+    /// An unsharded model has no index, and its single weight file is the whole model.
+    func testUnshardedModelIsCompleteWithItsOneWeightFile() throws {
+        let directory = try makeMaterializedModelDirectory()
+
+        XCTAssertFalse(CacheMaintenancePolicy.isMaterializedModelComplete(at: directory))
+
+        try writeShard("model.safetensors", in: directory)
+
+        XCTAssertTrue(CacheMaintenancePolicy.isMaterializedModelComplete(at: directory))
+    }
+
     func testPersistedInFlightModelRetainsBlobCacheAfterRelaunch() async throws {
         let root = try makeCachesRoot(
             hubRepos: ["models--org--marked"],

--- a/BisonNotes AI/BisonNotes AITests/CacheMaintenanceTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/CacheMaintenanceTests.swift
@@ -12,6 +12,16 @@ import XCTest
 
 final class CacheMaintenanceTests: XCTestCase {
 
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        UserDefaults.standard.removeObject(forKey: MLXSwiftSettingsKeys.inFlightDownloadModelID)
+    }
+
+    override func tearDownWithError() throws {
+        UserDefaults.standard.removeObject(forKey: MLXSwiftSettingsKeys.inFlightDownloadModelID)
+        try super.tearDownWithError()
+    }
+
     // MARK: - Hub repository directory naming
 
     func testHubRepoDirectoryNameMatchesHuggingFaceLayout() {
@@ -212,7 +222,9 @@ final class CacheMaintenanceTests: XCTestCase {
     /// materialized copies, the two layouts `defaultHubApi` writes.
     private func makeCachesRoot(
         hubRepos: [String],
-        installedModels: [String]
+        installedModels: [String],
+        partialModels: [String] = [],
+        incompleteHubRepos: [String] = []
     ) throws -> URL {
         let root = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("SweepTests-\(UUID().uuidString)", isDirectory: true)
@@ -226,9 +238,22 @@ final class CacheMaintenanceTests: XCTestCase {
             try FileManager.default.createDirectory(at: blobs, withIntermediateDirectories: true)
             try Data(repeating: 0x62, count: 1_024)
                 .write(to: blobs.appendingPathComponent("blob0"))
+            if incompleteHubRepos.contains(repo) {
+                try Data(repeating: 0x63, count: 128)
+                    .write(to: blobs.appendingPathComponent("blob1.incomplete"))
+            }
         }
 
         for model in installedModels {
+            let dir = root.appendingPathComponent("models", isDirectory: true)
+                .appendingPathComponent(model, isDirectory: true)
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            try Data("{}".utf8).write(to: dir.appendingPathComponent("config.json"))
+            try Data(repeating: 0x64, count: 128)
+                .write(to: dir.appendingPathComponent("model.safetensors"))
+        }
+
+        for model in partialModels {
             let dir = root.appendingPathComponent("models", isDirectory: true)
                 .appendingPathComponent(model, isDirectory: true)
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -284,6 +309,39 @@ final class CacheMaintenanceTests: XCTestCase {
 
         XCTAssertTrue(hubRepoExists("models--org--installed", in: root))
         XCTAssertTrue(hubRepoExists("models--org--deleted", in: root))
+        XCTAssertEqual(report.removedDirectoryCount, 0)
+    }
+
+    func testIncompleteMaterializedModelRetainsItsResumeCache() async throws {
+        let root = try makeCachesRoot(
+            hubRepos: ["models--org--partial"],
+            installedModels: [],
+            partialModels: ["org/partial"],
+            incompleteHubRepos: ["models--org--partial"]
+        )
+        let partialDirectory = root.appendingPathComponent("models/org/partial", isDirectory: true)
+
+        XCTAssertFalse(CacheMaintenancePolicy.isMaterializedModelComplete(at: partialDirectory))
+
+        let report = await CacheMaintenanceSweep(cachesRoot: root).run { false }
+
+        XCTAssertTrue(hubRepoExists("models--org--partial", in: root))
+        XCTAssertEqual(report.removedDirectoryCount, 0)
+    }
+
+    func testPersistedInFlightModelRetainsBlobCacheAfterRelaunch() async throws {
+        let root = try makeCachesRoot(
+            hubRepos: ["models--org--marked"],
+            installedModels: []
+        )
+        UserDefaults.standard.set(
+            "org/marked",
+            forKey: MLXSwiftSettingsKeys.inFlightDownloadModelID
+        )
+
+        let report = await CacheMaintenanceSweep(cachesRoot: root).run { false }
+
+        XCTAssertTrue(hubRepoExists("models--org--marked", in: root))
         XCTAssertEqual(report.removedDirectoryCount, 0)
     }
 

--- a/BisonNotes AI/BisonNotes AITests/CacheMaintenanceTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/CacheMaintenanceTests.swift
@@ -206,6 +206,83 @@ final class CacheMaintenanceTests: XCTestCase {
         XCTAssertEqual(LogTrimPolicy.trim(lines: lines, maxLines: 100, maxBytes: 10_000), lines)
     }
 
+    // MARK: - Rolling log file, against real files
+
+    private func makeTempLogURL() -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("LogFileTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
+        return dir.appendingPathComponent("log.txt")
+    }
+
+    /// The regression that motivated splitting `PersistentLogFile` out of `AppLog`:
+    /// the append handle was opened write-only, so the separator check failed with
+    /// EBADF, the append reported failure, and the caller replaced the whole file
+    /// with the single newest line — losing all history on every log call.
+    func testAppendingKeepsEarlierLines() {
+        let url = makeTempLogURL()
+        let file = PersistentLogFile(url: url, maxLines: 100, maxBytes: 1_000_000)
+
+        file.append("first")
+        file.append("second")
+        file.append("third")
+
+        let contents = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+        let lines = contents.components(separatedBy: "\n").filter { !$0.isEmpty }
+        XCTAssertEqual(lines, ["first", "second", "third"])
+    }
+
+    func testAppendCreatesTheFileWhenMissing() {
+        let url = makeTempLogURL()
+        PersistentLogFile(url: url, maxLines: 100, maxBytes: 1_000_000).append("only")
+
+        XCTAssertEqual(
+            (try? String(contentsOf: url, encoding: .utf8))?.trimmingCharacters(in: .newlines),
+            "only"
+        )
+    }
+
+    /// Files written by earlier versions end without a trailing newline. Appending
+    /// must not run onto the end of the last line.
+    func testAppendAddsTheMissingSeparatorForALegacyFile() throws {
+        let url = makeTempLogURL()
+        try "old one\nold two".write(to: url, atomically: true, encoding: .utf8)
+
+        PersistentLogFile(url: url, maxLines: 100, maxBytes: 1_000_000).append("new")
+
+        let lines = (try String(contentsOf: url, encoding: .utf8))
+            .components(separatedBy: "\n").filter { !$0.isEmpty }
+        XCTAssertEqual(lines, ["old one", "old two", "new"])
+    }
+
+    /// Over the ceiling the file is compacted well under it, so the rewrite is
+    /// occasional rather than per-line — the other half of the 4 MB defect, where
+    /// every call read and rewrote the whole file.
+    func testFileIsCompactedOnceItExceedsItsByteCeiling() {
+        let url = makeTempLogURL()
+        let file = PersistentLogFile(url: url, maxLines: 10_000, maxBytes: 4_096)
+        let line = String(repeating: "x", count: 200)
+
+        for _ in 0..<100 { file.append(line) }
+
+        let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        XCTAssertLessThanOrEqual(size, 4_096)
+        XCTAssertGreaterThan(size, 0, "compaction must not empty the file")
+    }
+
+    /// Compaction keeps the newest entries, which are the ones a crash report needs.
+    func testCompactionKeepsTheNewestLines() {
+        let url = makeTempLogURL()
+        let file = PersistentLogFile(url: url, maxLines: 5, maxBytes: 200)
+
+        for index in 0..<40 { file.append("line \(index)") }
+
+        let contents = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+        XCTAssertTrue(contents.contains("line 39"))
+        XCTAssertFalse(contents.contains("line 0\n"))
+    }
+
     // MARK: - Diagnostic export naming
 
     /// `TemporaryFileCleanupService` deletes by name, so the predicate has to be

--- a/BisonNotes AI/BisonNotes AITests/ICloudBackupRegressionTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/ICloudBackupRegressionTests.swift
@@ -255,6 +255,54 @@ final class ICloudBackupRegressionTests: XCTestCase {
         XCTAssertEqual(iCloudManager.pendingImportedAudioRemovalCountForTesting, 1)
     }
 
+    func testDeletingImportedTranscriptRemovesEveryLinkedLocalTranscriptRow() async throws {
+        let recordingId = try createRecordingOnly(named: "Duplicate imported transcript")
+        let context = appCoordinator.coreDataManager.managedObjectContext
+        let recording = try XCTUnwrap(appCoordinator.getRecording(id: recordingId))
+        let currentTranscriptId = UUID()
+        let staleTranscriptId = UUID()
+
+        recording.audioQuality = "imported"
+        recording.transcriptId = currentTranscriptId
+        recording.transcriptionStatus = ProcessingStatus.completed.rawValue
+
+        let currentTranscript = TranscriptEntry(context: context)
+        currentTranscript.id = currentTranscriptId
+        currentTranscript.recording = recording
+        currentTranscript.recordingId = recordingId
+        currentTranscript.segments = "[]"
+        currentTranscript.createdAt = Date()
+        currentTranscript.lastModified = Date()
+
+        let staleTranscript = TranscriptEntry(context: context)
+        staleTranscript.id = staleTranscriptId
+        staleTranscript.recordingId = recordingId
+        staleTranscript.segments = "[]"
+        staleTranscript.createdAt = Date().addingTimeInterval(-60)
+        staleTranscript.lastModified = Date().addingTimeInterval(-60)
+
+        let summary = SummaryEntry(context: context)
+        summary.id = UUID()
+        summary.recording = recording
+        summary.recordingId = recordingId
+        summary.transcriptId = staleTranscriptId
+        summary.summary = "Retained summary"
+        summary.aiMethod = "fixture"
+        summary.generatedAt = Date()
+        recording.summary = summary
+        recording.summaryId = summary.id
+        try context.save()
+
+        try await appCoordinator.deleteImportedTranscriptPreservingSummary(
+            recordingId: recordingId,
+            transcriptId: currentTranscriptId
+        )
+
+        XCTAssertNil(appCoordinator.coreDataManager.getTranscript(id: currentTranscriptId))
+        XCTAssertNil(appCoordinator.coreDataManager.getTranscript(id: staleTranscriptId))
+        XCTAssertNotNil(appCoordinator.getSummary(for: recordingId))
+    }
+
     func testDeletionMarkerNamesRemainDistinctForEachContentKind() throws {
         let manager = iCloudStorageManager()
         let recordingId = UUID()

--- a/BisonNotes AI/BisonNotes AITests/ICloudBackupRegressionTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/ICloudBackupRegressionTests.swift
@@ -216,6 +216,45 @@ final class ICloudBackupRegressionTests: XCTestCase {
         XCTAssertEqual(iCloudManager.pendingTranscriptRemovalCountForTesting, 1)
     }
 
+    func testDeletingUnavailableImportedTranscriptClearsStaleLinksAndQueuesCloudCleanup() async throws {
+        let recordingId = try createRecordingOnly(named: "Unavailable Imported Transcript")
+        let context = appCoordinator.coreDataManager.managedObjectContext
+        let recording = try XCTUnwrap(appCoordinator.getRecording(id: recordingId))
+        let orphanedTranscriptId = UUID()
+        let summaryId = UUID()
+
+        recording.audioQuality = "imported"
+        recording.transcriptId = orphanedTranscriptId
+        recording.transcriptionStatus = ProcessingStatus.completed.rawValue
+
+        let summary = SummaryEntry(context: context)
+        summary.id = summaryId
+        summary.recording = recording
+        summary.recordingId = recordingId
+        summary.transcriptId = orphanedTranscriptId
+        summary.summary = "A retained summary for an imported item whose transcript row is gone."
+        summary.aiMethod = "fixture"
+        summary.generatedAt = Date()
+        recording.summary = summary
+        recording.summaryId = summaryId
+        try context.save()
+
+        let iCloudManager = SummaryManager.shared.getiCloudManager()
+        try await appCoordinator.deleteImportedTranscriptPreservingSummary(recordingId: recordingId)
+
+        let remainingRecording = try XCTUnwrap(appCoordinator.getRecording(id: recordingId))
+        let remainingSummary = try XCTUnwrap(appCoordinator.getSummary(for: recordingId))
+        XCTAssertNil(remainingRecording.recordingURL)
+        XCTAssertNil(remainingRecording.transcript)
+        XCTAssertNil(remainingRecording.transcriptId)
+        XCTAssertEqual(remainingRecording.transcriptionStatus, ProcessingStatus.notStarted.rawValue)
+        XCTAssertNil(remainingSummary.transcript)
+        XCTAssertNil(remainingSummary.transcriptId)
+        XCTAssertEqual(remainingSummary.id, summaryId)
+        XCTAssertEqual(iCloudManager.pendingTranscriptRemovalCountForTesting, 1)
+        XCTAssertEqual(iCloudManager.pendingImportedAudioRemovalCountForTesting, 1)
+    }
+
     func testDeletionMarkerNamesRemainDistinctForEachContentKind() throws {
         let manager = iCloudStorageManager()
         let recordingId = UUID()

--- a/BisonNotes AI/BisonNotes AITests/ICloudSyncOrchestrationTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/ICloudSyncOrchestrationTests.swift
@@ -499,6 +499,76 @@ final class ICloudSyncOrchestrationTests: XCTestCase {
         XCTAssertEqual(result.restoreResult.audioFilesRestored, 0)
     }
 
+    func testImportedAudioRemovalPreservesNewerCloudMetadata() async throws {
+        let (recordingId, summaryId) = try createImportedRecordingWithSummary(
+            named: "Imported metadata arbitration"
+        )
+        let recording = try XCTUnwrap(appCoordinator.getRecording(id: recordingId))
+        let localDeletionDate = Date().addingTimeInterval(-3_600)
+        let cloudEditDate = Date().addingTimeInterval(3_600)
+        let remoteTranscriptId = UUID()
+        recording.lastModified = localDeletionDate
+        try appCoordinator.coreDataManager.saveContext()
+
+        let cloudAudioURL = tempDirectory.appendingPathComponent("newer-cloud-audio.m4a")
+        try Data("newer cloud placeholder".utf8).write(to: cloudAudioURL)
+        let recordingRecordName = "backup_recording_\(recordingId.uuidString)"
+        let summaryRecordName = "backup_summary_\(summaryId.uuidString)"
+        transport.seed([
+            CloudKitTestRecords.record(
+                type: "CD_BackupRecording",
+                name: recordingRecordName,
+                fields: [
+                    "recordingName": "Edited on another device",
+                    "recordingDate": cloudEditDate,
+                    "createdAt": cloudEditDate,
+                    "lastModified": cloudEditDate,
+                    "recordingURL": "newer-cloud-audio.m4a",
+                    "audioQuality": "imported",
+                    "transcriptionStatus": ProcessingStatus.completed.rawValue,
+                    "transcriptId": remoteTranscriptId.uuidString,
+                    "summaryId": summaryId.uuidString,
+                    "audioAsset": CKAsset(fileURL: cloudAudioURL),
+                    "audioFileName": "newer-cloud-audio.m4a",
+                    "audioByteCount": Int64("newer cloud placeholder".utf8.count),
+                    "audioSignature": "newer-signature",
+                    "syncLifecycle": "active",
+                    "syncSchemaVersion": 2
+                ]
+            ),
+            CloudKitTestRecords.record(
+                type: "CD_BackupSummary",
+                name: summaryRecordName,
+                fields: [
+                    "recordingId": recordingId.uuidString,
+                    "summary": "Retained summary",
+                    "aiMethod": "fixture",
+                    "generatedAt": cloudEditDate,
+                    "lastModified": cloudEditDate,
+                    "syncLifecycle": "active",
+                    "syncSchemaVersion": 2
+                ]
+            )
+        ])
+        seedTrustedManifest()
+
+        manager.enqueueImportedAudioRemovalFromiCloud(
+            recordingId: recordingId,
+            requestedAt: localDeletionDate
+        )
+        _ = try await runReconcile()
+
+        let cloudRecording = try XCTUnwrap(transport.record(named: recordingRecordName))
+        XCTAssertNil(cloudRecording["audioAsset"])
+        XCTAssertEqual(cloudRecording["recordingName"] as? String, "Edited on another device")
+        XCTAssertEqual(cloudRecording["transcriptId"] as? String, remoteTranscriptId.uuidString)
+        XCTAssertEqual(
+            cloudRecording["transcriptionStatus"] as? String,
+            ProcessingStatus.completed.rawValue
+        )
+        XCTAssertEqual(cloudRecording["lastModified"] as? Date, cloudEditDate)
+    }
+
     func testABackoffStopsRoutineTriggersFromStartingWork() async throws {
         try createCompleteRecording(named: "Throttled")
         transport.fetchFailures = [CloudKitTestError.ckError(.requestRateLimited, retryAfter: 600)]

--- a/BisonNotes AI/BisonNotes AITests/ICloudSyncOrchestrationTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/ICloudSyncOrchestrationTests.swift
@@ -425,6 +425,80 @@ final class ICloudSyncOrchestrationTests: XCTestCase {
         XCTAssertEqual(manager.pendingCloudDeletionCount, 1)
     }
 
+    func testExplicitImportedAudioRemovalClearsExistingCloudAssetBeforeRestore() async throws {
+        let (recordingId, summaryId) = try createImportedRecordingWithSummary(
+            named: "Imported cleanup"
+        )
+        let cloudAudioURL = tempDirectory.appendingPathComponent("old-cloud-audio.m4a")
+        try Data("old cloud placeholder".utf8).write(to: cloudAudioURL)
+
+        let recordingRecordName = "backup_recording_\(recordingId.uuidString)"
+        let summaryRecordName = "backup_summary_\(summaryId.uuidString)"
+        let cloudTimestamp = Date().addingTimeInterval(-3_600)
+        transport.seed([
+            CloudKitTestRecords.record(
+                type: "CD_BackupRecording",
+                name: recordingRecordName,
+                fields: [
+                    "recordingName": "Imported cleanup",
+                    "recordingDate": cloudTimestamp,
+                    "createdAt": cloudTimestamp,
+                    "lastModified": cloudTimestamp,
+                    "recordingURL": "old-cloud-audio.m4a",
+                    "audioQuality": "imported",
+                    "transcriptionStatus": ProcessingStatus.completed.rawValue,
+                    "summaryStatus": ProcessingStatus.completed.rawValue,
+                    "summaryId": summaryId.uuidString,
+                    "audioAsset": CKAsset(fileURL: cloudAudioURL),
+                    "audioFileName": "old-cloud-audio.m4a",
+                    "audioByteCount": Int64("old cloud placeholder".utf8.count),
+                    "audioSignature": "old-signature",
+                    "syncLifecycle": "active",
+                    "syncSchemaVersion": 2
+                ]
+            ),
+            CloudKitTestRecords.record(
+                type: "CD_BackupSummary",
+                name: summaryRecordName,
+                fields: [
+                    "recordingId": recordingId.uuidString,
+                    "summary": "Retained summary",
+                    "aiMethod": "fixture",
+                    "generatedAt": cloudTimestamp,
+                    "lastModified": cloudTimestamp,
+                    "syncLifecycle": "active",
+                    "syncSchemaVersion": 2
+                ]
+            )
+        ])
+        seedTrustedManifest()
+
+        let previousAudioSetting = UserDefaults.standard.object(forKey: "iCloudBackupIncludeAudioFiles")
+        UserDefaults.standard.set(true, forKey: "iCloudBackupIncludeAudioFiles")
+        defer {
+            if let previousAudioSetting {
+                UserDefaults.standard.set(previousAudioSetting, forKey: "iCloudBackupIncludeAudioFiles")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "iCloudBackupIncludeAudioFiles")
+            }
+        }
+
+        manager.enqueueImportedAudioRemovalFromiCloud(recordingId: recordingId)
+        let result = try await runReconcile()
+
+        let cloudRecording = try XCTUnwrap(transport.record(named: recordingRecordName))
+        XCTAssertNil(cloudRecording["audioAsset"])
+        XCTAssertNil(cloudRecording["audioFileName"])
+        XCTAssertNil(cloudRecording["audioByteCount"])
+        XCTAssertNil(cloudRecording["audioSignature"])
+        XCTAssertNil(cloudRecording["recordingURL"])
+        XCTAssertNil(cloudRecording["transcriptId"])
+        XCTAssertEqual(manager.pendingImportedAudioRemovalCountForTesting, 0)
+        XCTAssertNil(appCoordinator.getRecording(id: recordingId)?.recordingURL)
+        XCTAssertNotNil(appCoordinator.getSummary(for: recordingId))
+        XCTAssertEqual(result.restoreResult.audioFilesRestored, 0)
+    }
+
     func testABackoffStopsRoutineTriggersFromStartingWork() async throws {
         try createCompleteRecording(named: "Throttled")
         transport.fetchFailures = [CloudKitTestError.ckError(.requestRateLimited, retryAfter: 600)]
@@ -614,6 +688,30 @@ final class ICloudSyncOrchestrationTests: XCTestCase {
             duration: 30,
             quality: .whisperOptimized
         )
+    }
+
+    private func createImportedRecordingWithSummary(named name: String) throws -> (recordingId: UUID, summaryId: UUID) {
+        let recordingId = try createRecordingOnlyForConflict(named: name)
+        let context = appCoordinator.coreDataManager.managedObjectContext
+        let recording = try XCTUnwrap(appCoordinator.getRecording(id: recordingId))
+        let summaryId = UUID()
+
+        recording.audioQuality = "imported"
+        recording.recordingURL = nil
+        recording.transcriptionStatus = ProcessingStatus.notStarted.rawValue
+
+        let summary = SummaryEntry(context: context)
+        summary.id = summaryId
+        summary.recording = recording
+        summary.recordingId = recordingId
+        summary.summary = "Retained summary for \(name)"
+        summary.aiMethod = "fixture"
+        summary.generatedAt = Date()
+        recording.summary = summary
+        recording.summaryId = summaryId
+        try context.save()
+
+        return (recordingId, summaryId)
     }
 
     /// The refetch that pulls a recording's full record also pulls a fresh change

--- a/BisonNotes AI/BisonNotes AITests/MacRecordingReliabilityTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/MacRecordingReliabilityTests.swift
@@ -9,6 +9,34 @@ import XCTest
 @testable import BisonNotes_AI
 
 final class MacRecordingReliabilityTests: XCTestCase {
+	func testRecordingInputSelectionPreservesPreferenceThenTriesMeetingBridge() {
+		let candidates = [
+			MacRecordingInputCandidate(deviceID: 7, name: "MacBook Microphone"),
+			MacRecordingInputCandidate(deviceID: 9, name: "ZoomAudioDevice"),
+			MacRecordingInputCandidate(deviceID: 5, name: "Poly Sync 10")
+		]
+
+		XCTAssertEqual(
+			MacRecordingInputSelection.orderedDeviceIDs(
+				preferredDeviceID: 7,
+				defaultDeviceID: 5,
+				available: candidates
+			),
+			[7, 5, 9]
+		)
+	}
+
+	func testRecordingInputSelectionRetainsDefaultWhenDiscoveryIsTemporarilyBehind() {
+		XCTAssertEqual(
+			MacRecordingInputSelection.orderedDeviceIDs(
+				preferredDeviceID: 11,
+				defaultDeviceID: 13,
+				available: []
+			),
+			[13]
+		)
+	}
+
 	func testSystemAudioStartupGateReleasesExactlyOnceForMicrophoneWrite() {
 		var gate = MacSystemAudioStartupGate()
 		let sessionID = UUID()

--- a/BisonNotes AI/BisonNotes AITests/MacRecordingReliabilityTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/MacRecordingReliabilityTests.swift
@@ -37,6 +37,48 @@ final class MacRecordingReliabilityTests: XCTestCase {
 		)
 	}
 
+	/// A microphone that just stopped producing audio must not be retried, or the
+	/// fallback would keep picking the device that is already failing.
+	func testFailedInputIsExcludedFromItsOwnRetry() {
+		XCTAssertEqual(
+			MacRecordingInputSelection.excludedDeviceID(
+				currentInputDeviceID: 7,
+				trigger: .currentInputFailed
+			),
+			7
+		)
+	}
+
+	/// Core Audio can reuse a device ID when a microphone is plugged back in, and
+	/// the failure path never clears the ID the recording was bound to. Carrying
+	/// the exclusion into the reconnection filtered the returning microphone out of
+	/// its own recovery, leaving a recording with no other input stuck in
+	/// `waitingForMicrophone` for the rest of the session.
+	func testReconnectedInputIsNotExcludedFromRecovery() {
+		XCTAssertNil(
+			MacRecordingInputSelection.excludedDeviceID(
+				currentInputDeviceID: 7,
+				trigger: .deviceBecameAvailable
+			)
+		)
+	}
+
+	/// With nothing excluded, a returning microphone is a candidate again even when
+	/// it is the only input present — the case that used to strand the recording.
+	func testSoleReconnectedMicrophoneRemainsACandidate() {
+		let excluded = MacRecordingInputSelection.excludedDeviceID(
+			currentInputDeviceID: 7,
+			trigger: .deviceBecameAvailable
+		)
+		let candidates = MacRecordingInputSelection.orderedDeviceIDs(
+			preferredDeviceID: 7,
+			defaultDeviceID: 7,
+			available: [MacRecordingInputCandidate(deviceID: 7, name: "MacBook Microphone")]
+		)
+
+		XCTAssertEqual(candidates.filter { $0 != excluded }, [7])
+	}
+
 	func testSystemAudioStartupGateReleasesExactlyOnceForMicrophoneWrite() {
 		var gate = MacSystemAudioStartupGate()
 		let sessionID = UUID()


### PR DESCRIPTION
Four bugfixes on top of `v2.4`. Following the pattern of #122, this targets `v2.4` rather than `main` — `main` is still at #118 (v2.3).

## Bound the caches and logs that grew without limit (79e1dc4e)

The app container's `Library/Caches` reached **51 GB** on macOS and had to be cleared by hand. The persistent error log reached 4.1 MB holding only 476 lines. Neither had anything that removed old entries.

**Three separate cache leaks:**

- **Every MLX model was stored twice.** `defaultHubApi` is `HubApi(downloadBase: Caches)` with the blob cache left on, so swift-transformers downloads into `Caches/huggingface/hub/…/blobs` and then *copies* into `Caches/models/<repo>`. A 7.9 GB model occupied 15.8 GB.
- **Deleting a model reclaimed only half of it.** `removeModelFiles` removed the materialized copy and left the blobs behind, so two models already deleted through Settings were still costing 3.3 GB.
- **CloudKit never reclaims its asset cache.** It keeps a copy of every `CKAsset` it moves, leaving a second full copy of the audio library. This one is actively growing — observed going from 9.8 GB to 32 GB in about an hour of syncing.

`CacheMaintenanceService` sweeps all three, at launch and on activation, throttled to 6 hours.

**Reviewer notes on the safety gates**, since two of these touch directories the app doesn't own:

- Model blobs are **never** touched while a download is in flight — that cache is also the download's resume state.
- CloudKit assets are bounded by **size**, not age alone; age alone does not hold down something growing that fast. Nothing under an hour old is ever removed, and nothing whose timestamp can't be read. Past a 2 GB budget or 24 hours, oldest go first. This is an undocumented directory, so the gates are deliberately conservative — it is a `Caches` directory the OS may purge under pressure anyway, so CloudKit has to tolerate re-fetching.
- The sweep runs **off the main actor**. A first pass has tens of gigabytes to delete and would otherwise hang launch.

**Logs:**

- The persisted-log cap counted lines, not bytes, so one 354 KB message blew the budget. Lines are now clamped (8 KB) and each file has a byte ceiling (512 KB error / 256 KB breadcrumb).
- `persistLine` read and rewrote the whole file on **every** call — at 4 MB that's a 4 MB read plus a 4 MB write per logged line. It now appends via `FileHandle` and compacts only once the file crosses its ceiling. Files written by earlier versions have no trailing newline, so the first append after upgrading adds the separator; existing oversized logs self-heal on the next log call.
- Diagnostic exports accumulated in `tmp` at ~9 MB each. An export now clears its predecessors, and `TemporaryFileCleanupService` catches what a crash leaves behind.

That service also now sweeps `iCloudAudioStaging`, which leaks a full copy of every staged recording when a sync run is killed mid-upload.

Prune rules are pure static functions on `CacheMaintenancePolicy` / `LogTrimPolicy`, covered by `CacheMaintenanceTests` (22 tests). All shared code, so iOS gets the same bounds.

## Drop a model's blobs as soon as its download materializes (f73a9a61)

Follow-up to the above, closing the duplication at the source instead of only sweeping it after.

The obvious fix here is `cache: nil` on `HubApi`, which is what an earlier revision of this description proposed. That turns out to be the **wrong** fix: the entire resumable-download path in `HubClient+Files.swift:519-676` sits inside `if let cache`, so disabling the blob cache would make a dropped connection restart a 7.9 GB model download from zero.

Instead the blobs are kept for the download that needs them and dropped the moment the materialized copy is confirmed complete. Steady-state disk matches what `cache: nil` would have given; the 2x is transient and only while downloading. The `checkModelExists` gate is load-bearing — if the download did not materialize, the blobs are what a retry resumes from and must survive.

The sweep in `CacheMaintenanceService` stays as the backstop for what a killed download leaves behind and what earlier versions already accumulated.

## Other commits

- **b2f81c0c** — Fix resurrection of deleted imported transcripts (`iCloudStorageManager`, with regression tests in `ICloudBackupRegressionTests` / `ICloudSyncOrchestrationTests`).
- **0896895a** — Fix macOS audio import picker; consolidates the two file importers in `RecordingsView` into one with a kind discriminator.
- **b9fde78a** — Add automatic meeting microphone fallback on macOS.

## Verification

`BisonNotes AI macOS` builds clean. iOS unit target (`BisonNotes AITests`): **444 passed, 0 failed**. An earlier full-scheme run including UI tests was **455 passed, 2 failed** — both failures are accessibility audits in the UI test target (`testRecordScreenAccessibilityAudit` "Text clipped", `testSetupAccessibilityAudit` "Contrast nearly passed"), pre-existing and unrelated to these changes.

That run predates the last two commits, so the build and test verification above covers the cache/log work; the macOS import picker and mic fallback commits were authored separately and are not covered by a run I made.
