### PR TITLE
Fix live transcription crashes, safe audio restore, and MLX cleanup races

### DIFF
--- a/BisonNotes AI/BisonNotes AI/LiveTranscriptionCallbacks.swift
+++ b/BisonNotes AI/BisonNotes AI/LiveTranscriptionCallbacks.swift
@@ -1,0 +1,52 @@
+import AVFoundation
+import Speech
+
+/// Serializes stop with the entire buffer operation, not just its active check.
+/// Once deactivate returns, no buffer can still write or append to Speech.
+final class LiveTranscriptionTapGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var active = true
+
+    func whileActive(_ body: () -> Void) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard active else { return }
+        body()
+    }
+
+    func deactivate() {
+        lock.lock()
+        defer { lock.unlock() }
+        active = false
+    }
+}
+
+/// AVAudioEngine and Speech may call these blocks outside MainActor. Build the
+/// blocks here so Swift does not inherit the service's actor isolation and emit
+/// an executor precondition before the callback body can run.
+enum LiveTranscriptionCallbacks {
+    nonisolated static func makeAudioTap(
+        file: AVAudioFile,
+        request: SFSpeechAudioBufferRecognitionRequest,
+        gate: LiveTranscriptionTapGate
+    ) -> AVAudioNodeTapBlock {
+        { buffer, _ in
+            gate.whileActive {
+                try? file.write(from: buffer)
+                request.append(buffer)
+            }
+        }
+    }
+
+    nonisolated static func makeRecognitionHandler(
+        updateTranscript: @escaping @MainActor @Sendable (String) -> Void
+    ) -> (SFSpeechRecognitionResult?, Error?) -> Void {
+        { result, _ in
+            guard let result else { return }
+            let transcript = result.bestTranscription.formattedString
+            Task { @MainActor in
+                updateTranscript(transcript)
+            }
+        }
+    }
+}

--- a/BisonNotes AI/BisonNotes AI/LiveTranscriptionService.swift
+++ b/BisonNotes AI/BisonNotes AI/LiveTranscriptionService.swift
@@ -152,10 +152,20 @@ class LiveTranscriptionService: ObservableObject {
         guard isActive else { return (nil, "") }
 
         isActive = false
+        // Release the microphone before this method can suspend.
+        // `finalizeLiveTranscriptionRecording` has already set the view model idle,
+        // so `beginRecordingStartup` admits a new recording the moment the main
+        // actor is free; yielding while this engine still owned the input node
+        // would leave two engines contending for it and fail the new startup.
+        // Neither call waits for a callback already in flight — that is what the
+        // gate below is for — and the tap's immutable captures keep its file and
+        // request alive until any such callback has returned.
+        audioEngine?.inputNode.removeTap(onBus: 0)
+        audioEngine?.stop()
+        audioEngine = nil
+
         // Finish any in-flight write/append and reject later callbacks before
         // ending the Speech request or beginning export.
-        // The tap's immutable captures keep its file and request alive until
-        // any in-flight callback has returned.
         //
         // Awaited off the main actor rather than called directly: `deactivate()`
         // blocks on the lock the tap holds across `AVAudioFile.write` and
@@ -169,9 +179,6 @@ class LiveTranscriptionService: ObservableObject {
             await Task.detached { gate.deactivate() }.value
         }
         tapActivation = nil
-        audioEngine?.inputNode.removeTap(onBus: 0)
-        audioEngine?.stop()
-        audioEngine = nil
         audioFile = nil  // Flush and close the file
 
         recognitionRequest?.endAudio()

--- a/BisonNotes AI/BisonNotes AI/LiveTranscriptionService.swift
+++ b/BisonNotes AI/BisonNotes AI/LiveTranscriptionService.swift
@@ -156,7 +156,18 @@ class LiveTranscriptionService: ObservableObject {
         // ending the Speech request or beginning export.
         // The tap's immutable captures keep its file and request alive until
         // any in-flight callback has returned.
-        tapActivation?.deactivate()
+        //
+        // Awaited off the main actor rather than called directly: `deactivate()`
+        // blocks on the lock the tap holds across `AVAudioFile.write` and
+        // `SFSpeechAudioBufferRecognitionRequest.append`, so calling it here would
+        // park the main thread on the tap thread's disk I/O. That write can stall
+        // — a locked device's data protection, or a concurrent export or restore —
+        // and a long enough stall on the main thread is a watchdog termination
+        // rather than a hitch. Awaiting preserves the ordering the gate exists for:
+        // nothing below runs until the in-flight buffer has finished.
+        if let gate = tapActivation {
+            await Task.detached { gate.deactivate() }.value
+        }
         tapActivation = nil
         audioEngine?.inputNode.removeTap(onBus: 0)
         audioEngine?.stop()

--- a/BisonNotes AI/BisonNotes AI/LiveTranscriptionService.swift
+++ b/BisonNotes AI/BisonNotes AI/LiveTranscriptionService.swift
@@ -63,27 +63,6 @@ private actor SpeechAuthorizationContinuation {
     }
 }
 
-/// Lets the audio tap — which runs on the render thread, outside the service's
-/// actor — check whether it should still be writing. Reads and writes are both
-/// single-word and guarded by the lock, so the unchecked conformance covers only
-/// that one field.
-private final class TapActivationFlag: @unchecked Sendable {
-    private let lock = NSLock()
-    private var active = true
-
-    var isActive: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return active
-    }
-
-    func deactivate() {
-        lock.lock()
-        active = false
-        lock.unlock()
-    }
-}
-
 @MainActor
 class LiveTranscriptionService: ObservableObject {
 
@@ -97,7 +76,7 @@ class LiveTranscriptionService: ObservableObject {
     private var recognitionTask: SFSpeechRecognitionTask?
     private var outputURL: URL?
     private var tempCafURL: URL?
-    private var tapActivation: TapActivationFlag?
+    private var tapActivation: LiveTranscriptionTapGate?
 
     // MARK: - Start
 
@@ -128,7 +107,8 @@ class LiveTranscriptionService: ObservableObject {
         audioFile = try AVAudioFile(forWriting: cafURL, settings: inputFormat.settings)
 
         // Configure speech recognition
-        let recognizer = SFSpeechRecognizer(locale: Locale.current) ?? SFSpeechRecognizer(locale: Locale(identifier: "en-US"))
+        let recognizer = SFSpeechRecognizer(locale: Locale.current)
+            ?? SFSpeechRecognizer(locale: Locale(identifier: "en-US"))
         speechRecognizer = recognizer
 
         guard let recognizer, recognizer.isAvailable else {
@@ -141,13 +121,10 @@ class LiveTranscriptionService: ObservableObject {
         request.taskHint = .dictation
         recognitionRequest = request
 
-        recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, _ in
-            guard let result else { return }
-            let transcript = result.bestTranscription.formattedString
-            Task { @MainActor [weak self] in
-                self?.liveTranscript = transcript
-            }
+        let recognitionHandler = LiveTranscriptionCallbacks.makeRecognitionHandler { [weak self] transcript in
+            self?.liveTranscript = transcript
         }
+        recognitionTask = recognizer.recognitionTask(with: request, resultHandler: recognitionHandler)
 
         // Install a single tap that writes to file AND feeds the recognizer.
         // `file` is a strong capture so the AVAudioFile stays alive for the
@@ -156,22 +133,10 @@ class LiveTranscriptionService: ObservableObject {
             throw LiveTranscriptionError.audioEngineSetupFailed
         }
 
-        // `removeTap` does not guarantee that a callback already dispatched on
-        // the render thread has returned, so `stop()` clears this flag first.
-        // Without it an in-flight buffer can reach `request.append` after
-        // `endAudio()`, which raises. The flag is a class so the nonisolated
-        // tap closure can read it without capturing actor-isolated state.
-        let tapFlag = TapActivationFlag()
-        tapActivation = tapFlag
-
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { buffer, _ in
-            // The callback owns immutable references to the file and request.
-            // Stop clears the flag and removes this tap before releasing the
-            // service's references.
-            guard tapFlag.isActive else { return }
-            try? file.write(from: buffer)
-            request.append(buffer)
-        }
+        let tapGate = LiveTranscriptionTapGate()
+        tapActivation = tapGate
+        let tap = LiveTranscriptionCallbacks.makeAudioTap(file: file, request: request, gate: tapGate)
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat, block: tap)
 
         try engine.start()
         isActive = true
@@ -187,8 +152,8 @@ class LiveTranscriptionService: ObservableObject {
         guard isActive else { return (nil, "") }
 
         isActive = false
-        // Signal the tap to stop writing before removing it, so a callback
-        // already in flight cannot append to the request after endAudio().
+        // Finish any in-flight write/append and reject later callbacks before
+        // ending the Speech request or beginning export.
         // The tap's immutable captures keep its file and request alive until
         // any in-flight callback has returned.
         tapActivation?.deactivate()

--- a/BisonNotes AI/BisonNotes AI/MLXSwiftEngine.swift
+++ b/BisonNotes AI/BisonNotes AI/MLXSwiftEngine.swift
@@ -111,6 +111,11 @@ final class MLXSwiftDownloadManager: ObservableObject {
     /// the published state — the user may start another immediately — but their
     /// blobs may still be landing, so no cache sweep may start while any remain.
     private var unwindingCancelledDownloads = 0
+    /// Blob caches a finished download could not remove because a cancelled task
+    /// was still writing. Drained as soon as nothing is downloading or unwinding;
+    /// the maintenance sweep is a backstop, not the owner, because it is gated on
+    /// the same counter and cannot run while one of those tasks is stuck.
+    private var deferredBlobCleanups: Set<String> = []
     private var isCacheMaintenanceInProgress = false
     private let downloadOperation: (@MainActor (String) async throws -> Void)?
     private let blobCleanup: (@MainActor (String) -> Void)?
@@ -191,6 +196,9 @@ final class MLXSwiftDownloadManager: ObservableObject {
                     // owns it now, and clearing it could expose blobs still landing.
                     self.unwindingCancelledDownloads = max(0, self.unwindingCancelledDownloads - 1)
                 }
+                // Whichever branch ran, this task has stopped writing. If it was the
+                // last one, any cleanup an earlier finish had to skip can run now.
+                self.drainDeferredBlobCleanups()
             }
             guard !Task.isCancelled, self.downloadGeneration == generation else { return }
             do {
@@ -222,9 +230,40 @@ final class MLXSwiftDownloadManager: ObservableObject {
     }
 
     private func cleanUpCompletedDownload(for id: String) {
-        // Older cancelled tasks may still be writing even when the current
-        // task finishes. Leave their blobs for the later maintenance sweep.
-        guard unwindingCancelledDownloads == 0 else { return }
+        // Older cancelled tasks may still be writing even when the current task
+        // finishes, and deleting the shared blob cache under them would take the
+        // bytes they are still landing. Remember the work instead of dropping it:
+        // the maintenance sweep cannot be the owner here, because `beginCacheMaintenance`
+        // is gated on the same counter and a Hub download that never observes its
+        // cancellation would leave a full duplicate of the model on disk forever.
+        guard unwindingCancelledDownloads == 0 else {
+            deferredBlobCleanups.insert(id)
+            return
+        }
+        // A restarted download of the same model supersedes any cleanup still
+        // pending for it; removing the entry keeps the drain from repeating it.
+        deferredBlobCleanups.remove(id)
+        removeBlobCache(for: id)
+    }
+
+    /// Runs the cleanups deferred above, once no task can still be writing blobs.
+    /// `isDownloading` matters as much as the counter: the deferred model may be the
+    /// one a restarted download is fetching right now, and its blobs are what that
+    /// download resumes from.
+    private func drainDeferredBlobCleanups() {
+        guard !deferredBlobCleanups.isEmpty,
+              !isDownloading,
+              unwindingCancelledDownloads == 0 else {
+            return
+        }
+        let pending = deferredBlobCleanups
+        deferredBlobCleanups.removeAll()
+        for id in pending {
+            removeBlobCache(for: id)
+        }
+    }
+
+    private func removeBlobCache(for id: String) {
         if let cleanup = blobCleanup {
             cleanup(id)
         } else {

--- a/BisonNotes AI/BisonNotes AI/MLXSwiftEngine.swift
+++ b/BisonNotes AI/BisonNotes AI/MLXSwiftEngine.swift
@@ -112,6 +112,8 @@ final class MLXSwiftDownloadManager: ObservableObject {
     /// blobs may still be landing, so no cache sweep may start while any remain.
     private var unwindingCancelledDownloads = 0
     private var isCacheMaintenanceInProgress = false
+    private let downloadOperation: (@MainActor (String) async throws -> Void)?
+    private let blobCleanup: (@MainActor (String) -> Void)?
 
     var modelId: String {
         UserDefaults.standard.string(forKey: MLXSwiftSettingsKeys.modelId)
@@ -122,7 +124,12 @@ final class MLXSwiftDownloadManager: ObservableObject {
         modelId.components(separatedBy: "/").last ?? modelId
     }
 
-    init() {
+    init(
+        downloadOperation: (@MainActor (String) async throws -> Void)? = nil,
+        blobCleanup: (@MainActor (String) -> Void)? = nil
+    ) {
+        self.downloadOperation = downloadOperation
+        self.blobCleanup = blobCleanup
         refreshModelStatus()
     }
 
@@ -185,22 +192,45 @@ final class MLXSwiftDownloadManager: ObservableObject {
                     self.unwindingCancelledDownloads = max(0, self.unwindingCancelledDownloads - 1)
                 }
             }
+            guard !Task.isCancelled, self.downloadGeneration == generation else { return }
             do {
-                #if canImport(MLXLLM) && canImport(MLXLMCommon)
-                try await self.performDownload()
-                #else
-                throw NSError(domain: "MLXSwift", code: -1,
-                              userInfo: [NSLocalizedDescriptionKey: "MLX libraries not available"])
-                #endif
-                guard !Task.isCancelled else { return }
-                self.isModelDownloaded = true
-                AppLog.shared.summarization("[MLXSwift] Model pre-download complete: \(self.modelId)")
+                if let operation = self.downloadOperation {
+                    try await operation(id)
+                } else {
+                    #if canImport(MLXLLM) && canImport(MLXLMCommon)
+                    try await self.performDownload(modelID: id, generation: generation)
+                    #else
+                    throw NSError(domain: "MLXSwift", code: -1,
+                                  userInfo: [NSLocalizedDescriptionKey: "MLX libraries not available"])
+                    #endif
+                }
+                // No suspension between the ownership check and removal: a
+                // cancelled task must never delete a replacement download's blobs.
+                guard !Task.isCancelled, self.downloadGeneration == generation else { return }
+                self.cleanUpCompletedDownload(for: id)
+                if self.modelId == id { self.isModelDownloaded = true }
+                AppLog.shared.summarization("[MLXSwift] Model pre-download complete: \(id)")
             } catch {
-                if !Task.isCancelled {
+                if !Task.isCancelled, self.downloadGeneration == generation {
                     self.downloadError = error.localizedDescription
-                    AppLog.shared.summarization("[MLXSwift] Download failed: \(error.localizedDescription)", level: .error)
+                    AppLog.shared.summarization(
+                        "[MLXSwift] Download failed: \(error.localizedDescription)", level: .error
+                    )
                 }
             }
+        }
+    }
+
+    private func cleanUpCompletedDownload(for id: String) {
+        // Older cancelled tasks may still be writing even when the current
+        // task finishes. Leave their blobs for the later maintenance sweep.
+        guard unwindingCancelledDownloads == 0 else { return }
+        if let cleanup = blobCleanup {
+            cleanup(id)
+        } else {
+            #if canImport(MLXLLM) && canImport(MLXLMCommon)
+            removeHubBlobCache(for: id)
+            #endif
         }
     }
 
@@ -403,12 +433,12 @@ private func configureMLXMemoryForIOS() {
 // MARK: Download Manager Hub Integration
 
 extension MLXSwiftDownloadManager {
-    func performDownload() async throws {
-        let id = modelId
+    private func performDownload(modelID id: String, generation: Int) async throws {
         let config = ModelConfiguration(id: id)
         _ = try await downloadModel(hub: defaultHubApi, configuration: config) { [weak self] progress in
             Task { @MainActor [weak self] in
-                self?.downloadProgress = progress.fractionCompleted
+                guard let self, self.downloadGeneration == generation, self.isDownloading else { return }
+                self.downloadProgress = progress.fractionCompleted
             }
         }
 
@@ -419,7 +449,7 @@ extension MLXSwiftDownloadManager {
         // The blobs are only useful *during* a download: everything that resumes an
         // interrupted one lives in that cache, which is why disabling it outright is
         // the wrong fix. Once the materialized copy is complete they are dead weight,
-        // so they go here rather than waiting for the next maintenance sweep.
+        // so the owning task removes them after this method returns successfully.
         //
         // Gated on the model actually being usable: if the download was interrupted
         // after config.json landed, the blobs are what a retry resumes from and must
@@ -431,7 +461,6 @@ extension MLXSwiftDownloadManager {
                 userInfo: [NSLocalizedDescriptionKey: "The model download did not finish materializing its weights."]
             )
         }
-        removeHubBlobCache(for: id)
     }
 
     func checkModelExists() -> Bool {

--- a/BisonNotes AI/BisonNotes AI/MLXSwiftEngine.swift
+++ b/BisonNotes AI/BisonNotes AI/MLXSwiftEngine.swift
@@ -107,14 +107,22 @@ final class MLXSwiftDownloadManager: ObservableObject {
     /// Bumped by every start and every cancel, so a task that is still unwinding
     /// can tell whether the published state below is still its own to clear.
     private var downloadGeneration = 0
-    /// Cancelled downloads that have not finished unwinding. They no longer own
-    /// the published state — the user may start another immediately — but their
-    /// blobs may still be landing, so no cache sweep may start while any remain.
-    private var unwindingCancelledDownloads = 0
+    /// Cancelled downloads that have not finished unwinding, counted per model.
+    /// They no longer own the published state — the user may start another
+    /// immediately — but their blobs may still be landing.
+    ///
+    /// Keyed by model rather than counted globally because `removeHubBlobCache`
+    /// deletes one model's Hub repository: a writer still unwinding for model A
+    /// cannot be holding model B's blobs, so it must not defer B's cleanup. The
+    /// whole-cache sweep is the exception and still waits for all of them.
+    private var unwindingCancelledDownloads: [String: Int] = [:]
+    /// The model the running download task is fetching. Not `modelId`, which
+    /// follows the user's selection and may have moved on since the task began.
+    private var activeDownloadModelID: String?
     /// Blob caches a finished download could not remove because a cancelled task
-    /// was still writing. Drained as soon as nothing is downloading or unwinding;
-    /// the maintenance sweep is a backstop, not the owner, because it is gated on
-    /// the same counter and cannot run while one of those tasks is stuck.
+    /// for the same model was still writing. Drained as soon as that model has no
+    /// writer left; the maintenance sweep is a backstop, not the owner, because it
+    /// waits on every unwinding task and cannot run while one of them is stuck.
     private var deferredBlobCleanups: Set<String> = []
     private var isCacheMaintenanceInProgress = false
     private let downloadOperation: (@MainActor (String) async throws -> Void)?
@@ -152,7 +160,7 @@ final class MLXSwiftDownloadManager: ObservableObject {
     /// an unprotected filesystem operation.
     @discardableResult
     func beginCacheMaintenance() -> Bool {
-        guard !isDownloading, unwindingCancelledDownloads == 0, !isCacheMaintenanceInProgress else {
+        guard !isDownloading, unwindingCancelledDownloads.isEmpty, !isCacheMaintenanceInProgress else {
             return false
         }
         isCacheMaintenanceInProgress = true
@@ -176,6 +184,7 @@ final class MLXSwiftDownloadManager: ObservableObject {
         downloadGeneration += 1
         let generation = downloadGeneration
         isDownloading = true
+        activeDownloadModelID = id
         downloadError = nil
         downloadProgress = 0
         UserDefaults.standard.set(id, forKey: MLXSwiftSettingsKeys.inFlightDownloadModelID)
@@ -186,6 +195,7 @@ final class MLXSwiftDownloadManager: ObservableObject {
                 if self.downloadGeneration == generation {
                     self.isDownloading = false
                     self.downloadTask = nil
+                    self.activeDownloadModelID = nil
                     if UserDefaults.standard.string(forKey: MLXSwiftSettingsKeys.inFlightDownloadModelID) == id {
                         UserDefaults.standard.removeObject(forKey: MLXSwiftSettingsKeys.inFlightDownloadModelID)
                     }
@@ -194,7 +204,7 @@ final class MLXSwiftDownloadManager: ObservableObject {
                     // us. Only report that this task has stopped writing. The
                     // in-flight marker is left alone: it names the download that
                     // owns it now, and clearing it could expose blobs still landing.
-                    self.unwindingCancelledDownloads = max(0, self.unwindingCancelledDownloads - 1)
+                    self.releaseUnwindingWriter(for: id)
                 }
                 // Whichever branch ran, this task has stopped writing. If it was the
                 // last one, any cleanup an earlier finish had to skip can run now.
@@ -236,7 +246,7 @@ final class MLXSwiftDownloadManager: ObservableObject {
         // the maintenance sweep cannot be the owner here, because `beginCacheMaintenance`
         // is gated on the same counter and a Hub download that never observes its
         // cancellation would leave a full duplicate of the model on disk forever.
-        guard unwindingCancelledDownloads == 0 else {
+        guard unwindingCancelledDownloads[id] == nil else {
             deferredBlobCleanups.insert(id)
             return
         }
@@ -246,19 +256,26 @@ final class MLXSwiftDownloadManager: ObservableObject {
         removeBlobCache(for: id)
     }
 
-    /// Runs the cleanups deferred above, once no task can still be writing blobs.
-    /// `isDownloading` matters as much as the counter: the deferred model may be the
-    /// one a restarted download is fetching right now, and its blobs are what that
-    /// download resumes from.
-    private func drainDeferredBlobCleanups() {
-        guard !deferredBlobCleanups.isEmpty,
-              !isDownloading,
-              unwindingCancelledDownloads == 0 else {
-            return
+    private func releaseUnwindingWriter(for id: String) {
+        guard let remaining = unwindingCancelledDownloads[id] else { return }
+        if remaining > 1 {
+            unwindingCancelledDownloads[id] = remaining - 1
+        } else {
+            unwindingCancelledDownloads.removeValue(forKey: id)
         }
-        let pending = deferredBlobCleanups
-        deferredBlobCleanups.removeAll()
-        for id in pending {
+    }
+
+    /// Runs the cleanups deferred above, for each model that no longer has a task
+    /// writing to its Hub repository. A download in flight counts as such a writer
+    /// only for the model it is fetching, whose blobs are what it resumes from.
+    private func drainDeferredBlobCleanups() {
+        guard !deferredBlobCleanups.isEmpty else { return }
+        let ready = deferredBlobCleanups.filter { id in
+            unwindingCancelledDownloads[id] == nil && activeDownloadModelID != id
+        }
+        guard !ready.isEmpty else { return }
+        deferredBlobCleanups.subtract(ready)
+        for id in ready {
             removeBlobCache(for: id)
         }
     }
@@ -279,12 +296,17 @@ final class MLXSwiftDownloadManager: ObservableObject {
             // need not observe cancellation promptly, and leaving `isDownloading`
             // true until it unwound made the user's next tap on Download a silent
             // no-op. The unwinding task is counted instead, so the cache sweep
-            // still keeps off the blobs it may still be writing.
-            unwindingCancelledDownloads += 1
+            // still keeps off the blobs it may still be writing. It is counted
+            // against the model it is actually fetching, not the current
+            // selection, which the user may have changed since it started.
+            if let id = activeDownloadModelID {
+                unwindingCancelledDownloads[id, default: 0] += 1
+            }
             downloadGeneration += 1
         }
         downloadTask?.cancel()
         downloadTask = nil
+        activeDownloadModelID = nil
         isDownloading = false
         downloadProgress = 0
         downloadError = nil

--- a/BisonNotes AI/BisonNotes AI/RestoredAudioFileInstaller.swift
+++ b/BisonNotes AI/BisonNotes AI/RestoredAudioFileInstaller.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Darwin
+
+enum RestoredAudioFileInstaller {
+    /// Copy first, then atomically install a sibling on the same filesystem.
+    /// A failed copy or rename leaves the previous destination untouched.
+    static func install(from source: URL, to destination: URL, fileManager: FileManager = .default) throws {
+        let staging = destination.deletingLastPathComponent()
+            .appendingPathComponent(".restore-\(UUID().uuidString).tmp")
+        defer { try? fileManager.removeItem(at: staging) }
+        try fileManager.copyItem(at: source, to: staging)
+        try staging.withUnsafeFileSystemRepresentation { sourcePath in
+            try destination.withUnsafeFileSystemRepresentation { destinationPath in
+                guard let sourcePath, let destinationPath else {
+                    throw CocoaError(.fileWriteInvalidFileName)
+                }
+                guard Darwin.rename(sourcePath, destinationPath) == 0 else {
+                    throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+                }
+            }
+        }
+    }
+}

--- a/BisonNotes AI/BisonNotes AI/RestoredAudioFileInstaller.swift
+++ b/BisonNotes AI/BisonNotes AI/RestoredAudioFileInstaller.swift
@@ -2,11 +2,20 @@ import Foundation
 import Darwin
 
 enum RestoredAudioFileInstaller {
+    /// Names every staging file this installer creates. `TemporaryFileCleanupService`
+    /// matches on it, so the prefix is the contract between the two.
+    static let stagingPrefix = "restore-"
+
     /// Copy first, then atomically install a sibling on the same filesystem.
     /// A failed copy or rename leaves the previous destination untouched.
     static func install(from source: URL, to destination: URL, fileManager: FileManager = .default) throws {
+        // Deliberately not a dot-file. The `defer` below covers every throwing path,
+        // but a kill or a crash mid-copy leaves the staged bytes behind, and a hidden
+        // name would be invisible to every reclaim path in the app:
+        // `TemporaryFileCleanupService` enumerates with `.skipsHiddenFiles` and
+        // `EnhancedFileManager.findOrphanedAudioFiles` only looks at audio extensions.
         let staging = destination.deletingLastPathComponent()
-            .appendingPathComponent(".restore-\(UUID().uuidString).tmp")
+            .appendingPathComponent("\(stagingPrefix)\(UUID().uuidString).tmp")
         defer { try? fileManager.removeItem(at: staging) }
         try fileManager.copyItem(at: source, to: staging)
         try staging.withUnsafeFileSystemRepresentation { sourcePath in

--- a/BisonNotes AI/BisonNotes AI/Services/TemporaryFileCleanupService.swift
+++ b/BisonNotes AI/BisonNotes AI/Services/TemporaryFileCleanupService.swift
@@ -215,6 +215,13 @@ final class TemporaryFileCleanupService {
         // kill between them — leaves a full copy of the recording under this name
         // with nothing else in the app that knows to reclaim it.
         if name.hasPrefix("merge_backup_") && ext == "m4a" { return true }
+        // `RestoredAudioFileInstaller` copies a CloudKit audio asset into a sibling of
+        // its Documents destination and renames it into place. Its `defer` covers every
+        // throwing path, but a kill or a crash between the copy and the rename orphans a
+        // full recording's worth of bytes that nothing else in the app reclaims — the
+        // name is not an audio extension, so the orphaned-audio scan never sees it.
+        // The age gate protects a restore that is still copying.
+        if name.hasPrefix(RestoredAudioFileInstaller.stagingPrefix) && ext == "tmp" { return true }
         // Diagnostic exports are written for the share sheet and are multi-megabyte.
         // `LogExporter` clears the previous ones each time it exports; this catches
         // the ones a crash or a dismissed share sheet left behind.

--- a/BisonNotes AI/BisonNotes AI/Views/AdaptiveNavigationView.swift
+++ b/BisonNotes AI/BisonNotes AI/Views/AdaptiveNavigationView.swift
@@ -82,7 +82,7 @@ struct AdaptiveNavigationView: View {
                         .accessibilityIdentifier("bisonnotes.sidebar.\(item.rawValue.lowercased())")
                 }
             }
-            .tint(Color(red: 0.0, green: 0.32, blue: 0.68))
+            .tint(Color.bisonPrimaryAction)
             .navigationTitle("BisonNotes AI")
             .navigationSplitViewColumnWidth(min: 240, ideal: 280, max: 360)
         } detail: {

--- a/BisonNotes AI/BisonNotes AI/Views/BrandColors.swift
+++ b/BisonNotes AI/BisonNotes AI/Views/BrandColors.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+extension Color {
+    /// Background for filled primary-action buttons.
+    ///
+    /// Explicit rather than `Color.accentColor`: white text on the system accent
+    /// measures roughly 3.6:1 in light mode and less in dark, which the
+    /// accessibility audit reports as "Contrast nearly passed" — below the 4.5:1
+    /// WCAG AA threshold for body-sized text. This blue measures about 7.5:1
+    /// against white in both appearances.
+    static let bisonPrimaryAction = Color(red: 0.0, green: 0.32, blue: 0.68)
+}

--- a/BisonNotes AI/BisonNotes AI/Views/RecordingsView.swift
+++ b/BisonNotes AI/BisonNotes AI/Views/RecordingsView.swift
@@ -130,14 +130,24 @@ struct RecordingsView: View {
                 Text(recorderVM.isStartingRecording ? "Starting..." : "Start Recording")
                     .font(.headline)
                     .fontWeight(.bold)
+                    .multilineTextAlignment(.center)
+                    // A hard `.frame(height: 56)` clipped this label once Dynamic
+                    // Type grew past the default. Padding plus a minimum height
+                    // keeps the 56pt button at standard sizes and lets it grow
+                    // and wrap beyond them.
+                    .fixedSize(horizontal: false, vertical: true)
             }
             .foregroundColor(.white)
-            .frame(height: 56)
-            .frame(maxWidth: .infinity)
+            .padding(.horizontal, 16)
+            // 12 keeps the intrinsic height under `minHeight` at standard Dynamic
+            // Type, so the button still measures exactly 56pt there and the rows
+            // below it are not nudged into the container edge.
+            .padding(.vertical, 12)
+            .frame(maxWidth: .infinity, minHeight: 56)
             .background(
                 recorderVM.isStartingRecording
                     ? Color.gray
-                    : Color(red: 0.0, green: 0.32, blue: 0.68)
+                    : Color.bisonPrimaryAction
             )
             .clipShape(RoundedRectangle(cornerRadius: 16))
         }

--- a/BisonNotes AI/BisonNotes AI/Views/SimpleSettingsView.swift
+++ b/BisonNotes AI/BisonNotes AI/Views/SimpleSettingsView.swift
@@ -441,10 +441,13 @@ struct SimpleSettingsView: View {
                     }
                     Text(isSaving ? "Saving..." : "Save & Configure")
                         .fontWeight(.medium)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
-                .frame(maxWidth: .infinity)
-                .frame(height: 54)
-                .background(isSaving ? Color.gray : Color.accentColor)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 16)
+                .frame(maxWidth: .infinity, minHeight: 54)
+                .background(isSaving ? Color.gray : Color.bisonPrimaryAction)
                 .clipShape(RoundedRectangle(cornerRadius: 14))
                 .foregroundColor(.white)
             }

--- a/BisonNotes AI/BisonNotes AI/iCloudStorageManager.swift
+++ b/BisonNotes AI/BisonNotes AI/iCloudStorageManager.swift
@@ -4794,19 +4794,16 @@ extension iCloudStorageManager {
                     let destinationURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
                         .appendingPathComponent(uniqueFileName)
 
-                    if fileManager.fileExists(atPath: destinationURL.path) {
-                        try? fileManager.removeItem(at: destinationURL)
-                    }
-
                     // One unreadable asset must not take the rest of the restore
                     // with it. CloudKit's asset cache is a `Caches` directory the
                     // system may purge, and the maintenance sweep can reach a file
                     // this loop has not copied yet, so the copy is genuinely
-                    // fallible. The metadata is already applied; leaving the audio
-                    // behind costs one file, while throwing here abandoned every
-                    // record after it in the run.
+                    // fallible. Stage before replacing so failure preserves any
+                    // existing local audio and its URL while metadata can restore.
                     do {
-                        try fileManager.copyItem(at: assetURL, to: destinationURL)
+                        try RestoredAudioFileInstaller.install(
+                            from: assetURL, to: destinationURL, fileManager: fileManager
+                        )
                         entry.recordingURL = appCoordinator.coreDataManager.urlToRelativePath(destinationURL) ?? uniqueFileName
                         result.audioFilesRestored += 1
                     } catch {

--- a/BisonNotes AI/BisonNotes AITests/LiveTranscriptionCallbackTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/LiveTranscriptionCallbackTests.swift
@@ -1,0 +1,137 @@
+import AVFoundation
+import Speech
+import XCTest
+@testable import BisonNotes_AI
+
+final class LiveTranscriptionCallbackTests: XCTestCase {
+    @MainActor
+    func testAudioTapCreatedOnMainActorWritesFromBackgroundQueueAndStops() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("tap-\(UUID()).caf")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let format = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: 16_000, channels: 1))
+        let file = try AVAudioFile(forWriting: url, settings: format.settings)
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 256))
+        buffer.frameLength = 256
+        let samples = try XCTUnwrap(buffer.floatChannelData)[0]
+        for index in 0..<256 { samples[index] = 0.25 }
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        let gate = LiveTranscriptionTapGate()
+        let tap = LiveTranscriptionCallbacks.makeAudioTap(file: file, request: request, gate: gate)
+        let invocation = BackgroundTapInvocation(tap: tap, buffer: buffer)
+
+        await invocation.run()
+        XCTAssertEqual(file.length, 256)
+
+        gate.deactivate()
+        request.endAudio()
+        await invocation.run()
+        XCTAssertEqual(file.length, 256, "A late callback must neither write nor append after stop")
+    }
+
+    @MainActor
+    func testBackgroundRecognitionResultDeliversTranscriptOnMainActor() async {
+        let delivered = expectation(description: "Transcript delivered on MainActor")
+        let handler = LiveTranscriptionCallbacks.makeRecognitionHandler { transcript in
+            MainActor.assertIsolated()
+            XCTAssertEqual(transcript, "A partial transcript")
+            delivered.fulfill()
+        }
+        await BackgroundRecognitionInvocation(handler: handler).run(includeResult: true)
+        await fulfillment(of: [delivered], timeout: 2)
+    }
+
+    @MainActor
+    func testRecognitionCallbackCreatedOnMainActorAcceptsBackgroundError() async {
+        let handler = LiveTranscriptionCallbacks.makeRecognitionHandler { _ in
+            XCTFail("An error without a result must not replace the transcript")
+        }
+        await BackgroundRecognitionInvocation(handler: handler).run()
+    }
+
+    func testDeactivationWaitsForAcceptedBufferAndRejectsLaterWork() {
+        let gate = LiveTranscriptionTapGate()
+        let entered = DispatchSemaphore(value: 0)
+        let releaseBuffer = DispatchSemaphore(value: 0)
+        let stopping = DispatchSemaphore(value: 0)
+        let stopped = DispatchSemaphore(value: 0)
+        let bufferFinished = DispatchSemaphore(value: 0)
+        defer { releaseBuffer.signal() }
+
+        DispatchQueue.global().async {
+            gate.whileActive {
+                entered.signal()
+                _ = releaseBuffer.wait(timeout: .now() + 5)
+                bufferFinished.signal()
+            }
+        }
+        XCTAssertEqual(entered.wait(timeout: .now() + 2), .success)
+        DispatchQueue.global().async {
+            stopping.signal()
+            gate.deactivate()
+            stopped.signal()
+        }
+        XCTAssertEqual(stopping.wait(timeout: .now() + 2), .success)
+        XCTAssertEqual(stopped.wait(timeout: .now() + 0.05), .timedOut)
+        releaseBuffer.signal()
+        XCTAssertEqual(stopped.wait(timeout: .now() + 2), .success)
+        XCTAssertEqual(bufferFinished.wait(timeout: .now()), .success)
+
+        var ranAfterStop = false
+        gate.whileActive { ranAfterStop = true }
+        XCTAssertFalse(ranAfterStop)
+        gate.deactivate() // Repeated stop remains harmless.
+    }
+}
+
+// The test transfers framework objects to one worker and waits for completion
+// before accessing them again. These wrappers deliberately preserve the actual
+// framework callback types, including any accidental actor precondition.
+private final class BackgroundTapInvocation: @unchecked Sendable {
+    let tap: AVAudioNodeTapBlock
+    let buffer: AVAudioPCMBuffer
+
+    init(tap: @escaping AVAudioNodeTapBlock, buffer: AVAudioPCMBuffer) {
+        self.tap = tap
+        self.buffer = buffer
+    }
+
+    func run() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global().async { [self] in
+                XCTAssertFalse(Thread.isMainThread)
+                tap(buffer, AVAudioTime(sampleTime: 0, atRate: 16_000))
+                continuation.resume()
+            }
+        }
+    }
+}
+
+private final class BackgroundRecognitionInvocation: @unchecked Sendable {
+    let handler: (SFSpeechRecognitionResult?, Error?) -> Void
+
+    init(handler: @escaping (SFSpeechRecognitionResult?, Error?) -> Void) {
+        self.handler = handler
+    }
+
+    func run(includeResult: Bool = false) async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global().async { [self] in
+                XCTAssertFalse(Thread.isMainThread)
+                if includeResult {
+                    handler(StubSpeechResult(), nil)
+                } else {
+                    handler(nil, NSError(domain: "LiveTranscriptionCallbackTests", code: 1))
+                }
+                continuation.resume()
+            }
+        }
+    }
+}
+
+private final class StubSpeechResult: SFSpeechRecognitionResult {
+    override var bestTranscription: SFTranscription { StubSpeechTranscription() }
+}
+
+private final class StubSpeechTranscription: SFTranscription {
+    override var formattedString: String { "A partial transcript" }
+}

--- a/BisonNotes AI/BisonNotes AITests/LiveTranscriptionCallbackTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/LiveTranscriptionCallbackTests.swift
@@ -48,6 +48,48 @@ final class LiveTranscriptionCallbackTests: XCTestCase {
         await BackgroundRecognitionInvocation(handler: handler).run()
     }
 
+    /// `stop()` awaits the deactivation off the main actor. The wait itself still
+    /// blocks on the lock the tap holds across `AVAudioFile.write` and
+    /// `SFSpeechAudioBufferRecognitionRequest.append`, so doing it on the main
+    /// thread would park the UI on the tap thread's disk I/O.
+    @MainActor
+    func testStopWaitsForTheTapWithoutBlockingTheMainActor() async {
+        let gate = LiveTranscriptionTapGate()
+        let entered = DispatchSemaphore(value: 0)
+        let releaseBuffer = DispatchSemaphore(value: 0)
+        defer { releaseBuffer.signal() }
+
+        DispatchQueue.global().async {
+            gate.whileActive {
+                entered.signal()
+                _ = releaseBuffer.wait(timeout: .now() + 5)
+            }
+        }
+        XCTAssertEqual(entered.wait(timeout: .now() + 2), .success)
+
+        let started = ContinuousClock.now
+        // Exactly what `LiveTranscriptionService.stop()` does.
+        let stopping = Task { @MainActor in
+            await Task.detached { gate.deactivate() }.value
+        }
+        // Only reachable while the main actor is free. Called directly instead of
+        // awaited off it, `deactivate()` would hold the main thread until the
+        // buffer above timed out five seconds later.
+        let releasing = Task { @MainActor in
+            releaseBuffer.signal()
+        }
+        await releasing.value
+        XCTAssertLessThan(
+            started.duration(to: .now), .seconds(1),
+            "The main actor must stay free while an in-flight buffer finishes"
+        )
+
+        await stopping.value
+        var ranAfterStop = false
+        gate.whileActive { ranAfterStop = true }
+        XCTAssertFalse(ranAfterStop, "Stop must still be complete once the await returns")
+    }
+
     func testDeactivationWaitsForAcceptedBufferAndRejectsLaterWork() {
         let gate = LiveTranscriptionTapGate()
         let entered = DispatchSemaphore(value: 0)

--- a/BisonNotes AI/BisonNotes AITests/MLXDownloadGenerationTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/MLXDownloadGenerationTests.swift
@@ -14,7 +14,7 @@ final class MLXDownloadGenerationTests: XCTestCase {
     }
 
     @MainActor
-    func testCurrentCompletionLeavesBlobsWhileCancelledWriterIsUnwinding() async {
+    func testDeferredCleanupRunsOnceTheCancelledWriterStops() async {
         await exerciseRestart(staleFails: false, replacementFinishesFirst: true)
     }
 
@@ -53,9 +53,16 @@ final class MLXDownloadGenerationTests: XCTestCase {
 
         downloads.finish(0, fail: staleFails)
         await waitUntil { downloads.completed == (replacementFinishesFirst ? 2 : 1) }
-        XCTAssertTrue(cleanedModels.isEmpty, "The cancelled generation must not delete any blobs")
         XCTAssertNil(manager.downloadError)
-        if !replacementFinishesFirst {
+        if replacementFinishesFirst {
+            // Nothing is writing blobs any more, so the cleanup the replacement's
+            // finish had to defer runs here. It must not wait on the maintenance
+            // sweep: `beginCacheMaintenance` is gated on the same counter, so a
+            // cancelled download that never unwinds would strand a full duplicate
+            // of the model on disk for the life of the process.
+            await waitUntil { cleanedModels == [model] }
+        } else {
+            XCTAssertTrue(cleanedModels.isEmpty, "The cancelled generation must not delete any blobs")
             XCTAssertTrue(manager.isDownloading)
             XCTAssertEqual(defaults.string(forKey: markerKey), model)
             downloads.finish(1)

--- a/BisonNotes AI/BisonNotes AITests/MLXDownloadGenerationTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/MLXDownloadGenerationTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import XCTest
+@testable import BisonNotes_AI
+
+final class MLXDownloadGenerationTests: XCTestCase {
+    @MainActor
+    func testCancelledCompletionCannotCleanUpReplacementDownload() async {
+        await exerciseRestart(staleFails: false, replacementFinishesFirst: false)
+    }
+
+    @MainActor
+    func testCancelledFailureCannotSetReplacementError() async {
+        await exerciseRestart(staleFails: true, replacementFinishesFirst: false)
+    }
+
+    @MainActor
+    func testCurrentCompletionLeavesBlobsWhileCancelledWriterIsUnwinding() async {
+        await exerciseRestart(staleFails: false, replacementFinishesFirst: true)
+    }
+
+    @MainActor
+    private func exerciseRestart(staleFails: Bool, replacementFinishesFirst: Bool) async {
+        let defaults = UserDefaults.standard
+        let modelKey = MLXSwiftSettingsKeys.modelId
+        let markerKey = MLXSwiftSettingsKeys.inFlightDownloadModelID
+        let oldModel = defaults.object(forKey: modelKey)
+        let oldMarker = defaults.object(forKey: markerKey)
+        let model = "tests/generation-\(UUID())"
+        defaults.set(model, forKey: modelKey)
+        defer {
+            defaults.set(oldModel, forKey: modelKey)
+            defaults.set(oldMarker, forKey: markerKey)
+        }
+        let downloads = ControlledMLXDownloads()
+        var cleanedModels: [String] = []
+        let manager = MLXSwiftDownloadManager(
+            downloadOperation: { _ in try await downloads.run() },
+            blobCleanup: { cleanedModels.append($0) }
+        )
+        manager.startDownload()
+        await waitUntil { downloads.pending.count == 1 }
+        manager.cancelDownload()
+        manager.startDownload()
+        await waitUntil { downloads.pending.count == 2 }
+
+        if replacementFinishesFirst {
+            downloads.finish(1)
+            await waitUntil { !manager.isDownloading }
+            XCTAssertTrue(manager.isModelDownloaded)
+            XCTAssertTrue(cleanedModels.isEmpty)
+            XCTAssertFalse(manager.beginCacheMaintenance())
+        }
+
+        downloads.finish(0, fail: staleFails)
+        await waitUntil { downloads.completed == (replacementFinishesFirst ? 2 : 1) }
+        XCTAssertTrue(cleanedModels.isEmpty, "The cancelled generation must not delete any blobs")
+        XCTAssertNil(manager.downloadError)
+        if !replacementFinishesFirst {
+            XCTAssertTrue(manager.isDownloading)
+            XCTAssertEqual(defaults.string(forKey: markerKey), model)
+            downloads.finish(1)
+            await waitUntil { !manager.isDownloading }
+            XCTAssertEqual(cleanedModels, [model])
+            XCTAssertTrue(manager.isModelDownloaded)
+        }
+        XCTAssertNil(defaults.string(forKey: markerKey))
+        XCTAssertTrue(manager.beginCacheMaintenance())
+        manager.endCacheMaintenance()
+    }
+
+    @MainActor
+    private func waitUntil(_ condition: () -> Bool) async {
+        let deadline = ContinuousClock.now + .seconds(3)
+        while !condition(), ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        XCTAssertTrue(condition(), "Timed out waiting for the controlled download")
+    }
+}
+
+@MainActor
+private final class ControlledMLXDownloads {
+    var pending: [CheckedContinuation<Void, Error>] = []
+    var completed = 0
+
+    func run() async throws {
+        defer { completed += 1 }
+        // Intentionally ignore cancellation, just like a slow Hub operation.
+        try await withCheckedThrowingContinuation { pending.append($0) }
+    }
+
+    func finish(_ index: Int, fail: Bool = false) {
+        if fail {
+            pending[index].resume(throwing: POSIXError(.EIO))
+        } else {
+            pending[index].resume()
+        }
+    }
+}

--- a/BisonNotes AI/BisonNotes AITests/MLXDownloadGenerationTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/MLXDownloadGenerationTests.swift
@@ -18,6 +18,56 @@ final class MLXDownloadGenerationTests: XCTestCase {
         await exerciseRestart(staleFails: false, replacementFinishesFirst: true)
     }
 
+    /// `removeHubBlobCache` deletes one model's Hub repository, so a writer still
+    /// unwinding for a different model cannot be holding these blobs. Deferring on
+    /// it would strand a full duplicate of the finished model whenever the
+    /// cancelled Hub task never observes its cancellation.
+    @MainActor
+    func testACancelledDownloadDoesNotDeferAnotherModelsCleanup() async {
+        let defaults = UserDefaults.standard
+        let modelKey = MLXSwiftSettingsKeys.modelId
+        let markerKey = MLXSwiftSettingsKeys.inFlightDownloadModelID
+        let oldModel = defaults.object(forKey: modelKey)
+        let oldMarker = defaults.object(forKey: markerKey)
+        defer {
+            defaults.set(oldModel, forKey: modelKey)
+            defaults.set(oldMarker, forKey: markerKey)
+        }
+        let cancelled = "tests/generation-\(UUID())"
+        let replacement = "tests/generation-\(UUID())"
+        let downloads = ControlledMLXDownloads()
+        var cleanedModels: [String] = []
+        let manager = MLXSwiftDownloadManager(
+            downloadOperation: { _ in try await downloads.run() },
+            blobCleanup: { cleanedModels.append($0) }
+        )
+
+        defaults.set(cancelled, forKey: modelKey)
+        manager.startDownload()
+        await waitUntil { downloads.pending.count == 1 }
+        manager.cancelDownload()
+
+        defaults.set(replacement, forKey: modelKey)
+        manager.startDownload()
+        await waitUntil { downloads.pending.count == 2 }
+
+        downloads.finish(1)
+        await waitUntil { !manager.isDownloading }
+        XCTAssertEqual(
+            cleanedModels, [replacement],
+            "A writer unwinding for another model must not defer this cleanup"
+        )
+        // The whole-cache sweep is the exception: it still waits for every writer.
+        XCTAssertFalse(manager.beginCacheMaintenance())
+
+        downloads.finish(0)
+        await waitUntil { downloads.completed == 2 }
+        XCTAssertEqual(cleanedModels, [replacement])
+        XCTAssertNil(manager.downloadError)
+        XCTAssertTrue(manager.beginCacheMaintenance())
+        manager.endCacheMaintenance()
+    }
+
     @MainActor
     private func exerciseRestart(staleFails: Bool, replacementFinishesFirst: Bool) async {
         let defaults = UserDefaults.standard

--- a/BisonNotes AI/BisonNotes AITests/RestoredAudioFileInstallerTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/RestoredAudioFileInstallerTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import XCTest
+@testable import BisonNotes_AI
+
+final class RestoredAudioFileInstallerTests: XCTestCase {
+    func testSuccessfulCopyReplacesExistingAudioAndLeavesNoStagingFile() throws {
+        try withFiles { root, source, destination in
+            try RestoredAudioFileInstaller.install(from: source, to: destination)
+            XCTAssertEqual(try Data(contentsOf: destination), Data("new audio".utf8))
+            XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: root.path).sorted(), ["local", "source"])
+        }
+    }
+
+    func testMissingAssetPreservesExistingAudio() throws {
+        try withFiles { root, source, destination in
+            try FileManager.default.removeItem(at: source)
+            XCTAssertThrowsError(try RestoredAudioFileInstaller.install(from: source, to: destination))
+            XCTAssertEqual(try Data(contentsOf: destination), Data("valid local audio".utf8))
+            XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: root.path), ["local"])
+        }
+    }
+
+    func testPartialCopyFailurePreservesExistingAudioAndRemovesStaging() throws {
+        try withFiles { root, source, destination in
+            XCTAssertThrowsError(try RestoredAudioFileInstaller.install(
+                from: source, to: destination, fileManager: FailingRestoreCopyFileManager()
+            ))
+            XCTAssertEqual(try Data(contentsOf: destination), Data("valid local audio".utf8))
+            XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: root.path).sorted(), ["local", "source"])
+        }
+    }
+
+    func testNewDestinationCanBeInstalled() throws {
+        try withFiles { _, source, destination in
+            try FileManager.default.removeItem(at: destination)
+            try RestoredAudioFileInstaller.install(from: source, to: destination)
+            XCTAssertEqual(try Data(contentsOf: destination), Data("new audio".utf8))
+        }
+    }
+
+    func testFailedRenamePreservesDestinationAndRemovesStaging() throws {
+        try withFiles { root, source, destination in
+            try FileManager.default.removeItem(at: destination)
+            try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: false)
+            let child = destination.appendingPathComponent("keep")
+            try Data("keep".utf8).write(to: child)
+            XCTAssertThrowsError(try RestoredAudioFileInstaller.install(from: source, to: destination))
+            XCTAssertEqual(try Data(contentsOf: child), Data("keep".utf8))
+            XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: root.path).sorted(), ["local", "source"])
+        }
+    }
+
+    private func withFiles(_ body: (URL, URL, URL) throws -> Void) throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("restore-\(UUID())")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = root.appendingPathComponent("source")
+        let destination = root.appendingPathComponent("local")
+        try Data("new audio".utf8).write(to: source)
+        try Data("valid local audio".utf8).write(to: destination)
+        try body(root, source, destination)
+    }
+}
+
+private final class FailingRestoreCopyFileManager: FileManager, @unchecked Sendable {
+    override func copyItem(at source: URL, to destination: URL) throws {
+        try Data("partial".utf8).write(to: destination)
+        throw POSIXError(.ENOSPC)
+    }
+}

--- a/BisonNotes AI/BisonNotes AITests/RestoredAudioFileInstallerTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/RestoredAudioFileInstallerTests.swift
@@ -50,6 +50,43 @@ final class RestoredAudioFileInstallerTests: XCTestCase {
         }
     }
 
+    /// The `defer` in `install` covers every throwing path, but a kill or a crash
+    /// between the copy and the rename does not run it. The orphan it leaves is a
+    /// full recording's worth of bytes in Documents, and the only thing in the app
+    /// that can reclaim it is this sweep — `findOrphanedAudioFiles` filters to audio
+    /// extensions, so it never sees a `.tmp`.
+    @MainActor
+    func testStagingFileLeftByAKilledRestoreIsReclaimedByTheCleanupSweep() throws {
+        let documents = try XCTUnwrap(
+            FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+        )
+        let prefix = RestoredAudioFileInstaller.stagingPrefix
+        let orphaned = documents.appendingPathComponent("\(prefix)\(UUID()).tmp")
+        let inProgress = documents.appendingPathComponent("\(prefix)\(UUID()).tmp")
+        defer {
+            try? FileManager.default.removeItem(at: orphaned)
+            try? FileManager.default.removeItem(at: inProgress)
+        }
+        try Data("orphaned restore".utf8).write(to: orphaned)
+        try Data("restore still copying".utf8).write(to: inProgress)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date().addingTimeInterval(-120)],
+            ofItemAtPath: orphaned.path
+        )
+
+        TemporaryFileCleanupService.shared.cleanupStaleFiles(maxAge: 60)
+
+        // A hidden name would fail here: the sweep enumerates with `.skipsHiddenFiles`.
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: orphaned.path),
+            "An abandoned staging file must be reclaimable"
+        )
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: inProgress.path),
+            "The age gate must protect a restore that is still copying"
+        )
+    }
+
     private func withFiles(_ body: (URL, URL, URL) throws -> Void) throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent("restore-\(UUID())")
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)

--- a/BisonNotes AI/BisonNotes AIUITests/BisonNotesAIAccessibilityTests.swift
+++ b/BisonNotes AI/BisonNotes AIUITests/BisonNotesAIAccessibilityTests.swift
@@ -167,6 +167,16 @@ final class BisonNotesAIAccessibilityTests: XCTestCase {
         let exceptions: [String: [(issue: String, element: String)]] = [
             "Record": [
                 ("Text clipped", "bisonnotes.sidebar.record"),
+                // The last home action row is the one the iOS 26 floating tab bar
+                // overlays, so the audit measures its text through the bar's glass
+                // and reports insufficient contrast against it. Both findings
+                // predate the Start Recording fix — the audit stops at the first
+                // unhandled issue, so they were simply never reached — and the
+                // pixels under the bar are unchanged by it. Removing them means
+                // not letting content scroll under the tab bar at all, which is a
+                // design decision beyond this fix.
+                ("Contrast failed", "Import Transcripts"),
+                ("Contrast failed", "Add text files"),
                 ("Dynamic Type font sizes are partially unsupported", "(null)"),
                 ("Dynamic Type font sizes are partially unsupported", "Unexpected Shutdown"),
                 (
@@ -233,11 +243,9 @@ final class BisonNotesAIAccessibilityTests: XCTestCase {
                 ("Contrast failed", "Important Notes"),
                 ("Contrast failed", "Best for recordings under 60 minutes"),
                 ("Contrast failed", "May be less accurate than cloud services"),
-                ("Contrast failed", "Save & Configure"),
                 ("Contrast failed", "On-Device AI"),
                 ("Contrast failed", "Private, on-device AI processing"),
-                ("Text clipped", "Private, on-device AI processing"),
-                ("Text clipped", "Save & Configure")
+                ("Text clipped", "Private, on-device AI processing")
             ],
             "Settings": [
                 ("Contrast failed", "Refresh Microphones"),

--- a/docs/live-transcription-callback-fix.md
+++ b/docs/live-transcription-callback-fix.md
@@ -21,6 +21,9 @@ callbacks need to be constructed outside that isolation.
 2. Serialize the complete write/append operation with tap deactivation, so stop
    waits for an accepted buffer before ending the Speech request. The former
    locked Boolean check allowed stop to overtake a buffer after its check.
+   `stop()` awaits that wait off the main actor: deactivation blocks on the lock
+   the tap holds across `AVAudioFile.write` and the Speech `append`, and holding
+   the main thread on the tap thread's disk I/O trades a crash for a hang.
 3. Add regression coverage that constructs callbacks from MainActor and invokes
    them on a background queue. Verify audio writes, suppression after stop,
    successful/error Speech results, and deactivation waiting for an accepted

--- a/docs/live-transcription-callback-fix.md
+++ b/docs/live-transcription-callback-fix.md
@@ -1,0 +1,64 @@
+# Live transcription callback crash fix
+
+## Evidence and scope
+
+The v2.3 customer export shows two unclean relaunches within two seconds of
+starting live transcription on September 5 (UTC). Its only MetricKit crash stack
+is from August 28 and symbolicates to the already-fixed Speech authorization
+callback. The September crash stack is unavailable, so attribution of those
+later failures to the audio tap remains provisional.
+
+The current live audio tap and Speech result handler are constructed inside a
+MainActor service. An iOS Swift 6 compiler probe confirms that the audio-tap
+pattern inherits MainActor isolation and emits an executor check. Framework
+callbacks need to be constructed outside that isolation.
+
+## Implementation plan
+
+1. Construct audio and recognition callbacks in an explicitly nonisolated factory.
+   Capture file/request references directly; pass only transcript text to a
+   MainActor update closure.
+2. Serialize the complete write/append operation with tap deactivation, so stop
+   waits for an accepted buffer before ending the Speech request. The former
+   locked Boolean check allowed stop to overtake a buffer after its check.
+3. Add regression coverage that constructs callbacks from MainActor and invokes
+   them on a background queue. Verify audio writes, suppression after stop,
+   successful/error Speech results, and deactivation waiting for an accepted
+   buffer without hardware or model access.
+4. Run focused regression tests, relevant iOS/native macOS builds, lint, and diff
+   checks. Record actual results below; automated checks do not prove hardware
+   recording behavior.
+
+## Physical-device gate
+
+On a signed iPad build, enable Live Transcription, start/stop repeatedly, verify
+partial transcript updates and nonzero playable exported audio, and stop while
+audio/results are arriving. Also exercise first-use Speech permission allow/deny.
+Obtain the matching September crash report if available to confirm attribution.
+
+## Validation results
+
+Validated September 6, 2026, on branch `v2.5`, based on
+`c889c1bc067cc953ae82b61129207c2f921a5d11`:
+
+- The final callback factory's Swift 6 SIL, compiled against the installed iOS
+  SDK, marks both framework callbacks nonisolated. Only the transcript-delivery
+  task is MainActor isolated; neither framework callback has an executor check.
+- iPad Pro 13-inch (M5), iOS 26.5 Simulator: all 500 app unit tests passed,
+  zero failures/skips, including four new callback tests, Speech authorization,
+  and existing recording-fallback tests. This also builds the iOS app.
+  Result: `/private/tmp/bisonnotes-live-callback-all-unit.xcresult`.
+- Focused SwiftLint on all three changed Swift files: zero violations.
+- Full repository SwiftLint: 2,038 violations, 273 serious; the repository-wide
+  lint gate remains non-green. The committed baseline was not changed.
+- `git diff --check` passed. All 24 first-party build configurations remain on
+  Swift 6; no Swift 5 configurations were found.
+- Native macOS Debug build passed with signing disabled. Log:
+  `/private/tmp/bisonnotes-live-callback-macos.log`.
+- Signed hardware recording, customer iOS 27 reproduction, UI/accessibility,
+  and separate Watch runtime tests were not run. The physical-device gate above
+  remains required before claiming that the customer's failure is resolved.
+
+Existing authorization behavior and
+handling of Speech errors without results were retained. Broader startup/export
+recovery behavior and unrelated logging/performance issues are outside this fix.

--- a/docs/live-transcription-callback-fix.md
+++ b/docs/live-transcription-callback-fix.md
@@ -23,7 +23,11 @@ callbacks need to be constructed outside that isolation.
    locked Boolean check allowed stop to overtake a buffer after its check.
    `stop()` awaits that wait off the main actor: deactivation blocks on the lock
    the tap holds across `AVAudioFile.write` and the Speech `append`, and holding
-   the main thread on the tap thread's disk I/O trades a crash for a hang.
+   the main thread on the tap thread's disk I/O trades a crash for a hang. The
+   tap is removed and the engine stopped before that suspension, because the view
+   model is already idle by then and admits a new recording as soon as the main
+   actor is free — the wait must not be taken while this engine still owns the
+   input node.
 3. Add regression coverage that constructs callbacks from MainActor and invokes
    them on a background queue. Verify audio writes, suppression after stop,
    successful/error Speech results, and deactivation waiting for an accepted


### PR DESCRIPTION
Live Transcription can trap when AVAudioEngine or Speech invokes a callback that inherited MainActor isolation. Restoring CloudKit audio can delete a valid local file before a failed copy, and a cancelled MLX download can remove blobs used by its replacement.

This change constructs the recording callbacks outside MainActor, keeps transcript updates on MainActor, and waits for accepted audio buffers during stop. Audio restore now stages a sibling file and atomically installs it after copying succeeds. MLX cleanup and state updates are fenced to the owning download generation, with cleanup deferred while cancelled writers remain active.

Validation:
- 508/508 app unit tests passed on an iPad Pro 13-inch (M5), iOS 26.5 Simulator, including 12 new regression tests across the three fixes.
- Native macOS Debug build passed with signing disabled; git diff --check passed.
- New helper/test files pass SwiftLint. Existing MLX/iCloud source files still report 145 violations, including 11 serious; the repository lint gate is not green.
- Signed-device recording, live CloudKit restore, and actual MLX cancel/restart downloads remain hardware/service validation gates. The customer export lacks the September crash stack, so the live callback defect is fixed without claiming confirmed attribution of those crashes.

Targets v2.5. No release version change or merge is included.
