### PR TITLE
Implement v2.5 follow-up reliability plan

### DIFF
--- a/BisonNotes AI/BisonNotes AI/BisonNotes_AI.xcdatamodeld/.xccurrentversion
+++ b/BisonNotes AI/BisonNotes AI/BisonNotes_AI.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>BisonNotes_AI.xcdatamodel</string>
+	<string>BisonNotes_AI_v2.xcdatamodel</string>
 </dict>
 </plist>

--- a/BisonNotes AI/BisonNotes AI/BisonNotes_AI.xcdatamodeld/BisonNotes_AI_v2.xcdatamodel/contents
+++ b/BisonNotes AI/BisonNotes AI/BisonNotes_AI.xcdatamodeld/BisonNotes_AI_v2.xcdatamodel/contents
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="true" userDefinedModelVersionIdentifier="">
+    <entity name="RecordingEntry" representedClassName="RecordingEntry" syncable="YES" codeGenerationType="class">
+        <attribute name="audioQuality" optional="YES" attributeType="String"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="duration" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="fileSize" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isCloudSyncDisabled" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="lastModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="locationAccuracy" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
+        <attribute name="locationAddress" optional="YES" attributeType="String"/>
+        <attribute name="locationLatitude" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
+        <attribute name="locationLongitude" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
+        <attribute name="locationTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="recordingDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="recordingName" optional="YES" attributeType="String"/>
+        <attribute name="recordingURL" optional="YES" attributeType="String"/>
+        <attribute name="summaryId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="summaryStatus" optional="YES" attributeType="String"/>
+        <attribute name="transcriptId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="transcriptionStatus" optional="YES" attributeType="String"/>
+        <attribute name="isArchived" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="archivedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="archiveNote" optional="YES" attributeType="String"/>
+        <relationship name="summary" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="SummaryEntry" inverseName="recording" inverseEntity="SummaryEntry"/>
+        <relationship name="transcript" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="TranscriptEntry" inverseName="recording" inverseEntity="TranscriptEntry"/>
+        <relationship name="processingJobs" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProcessingJobEntry" inverseName="recording" inverseEntity="ProcessingJobEntry"/>
+    </entity>
+    <entity name="SummaryEntry" representedClassName="SummaryEntry" syncable="YES" codeGenerationType="class">
+        <attribute name="aiMethod" optional="YES" attributeType="String"/>
+        <attribute name="compressionRatio" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="confidence" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="contentType" optional="YES" attributeType="String"/>
+        <attribute name="generatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="originalLength" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="processingTime" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="recordingId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="reminders" optional="YES" attributeType="String"/>
+        <attribute name="summary" optional="YES" attributeType="String"/>
+        <attribute name="tasks" optional="YES" attributeType="String"/>
+        <attribute name="titles" optional="YES" attributeType="String"/>
+        <attribute name="transcriptId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="version" optional="YES" attributeType="Integer 32" defaultValueString="1" usesScalarValueType="YES"/>
+        <attribute name="wordCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="recording" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="RecordingEntry" inverseName="summary" inverseEntity="RecordingEntry"/>
+        <relationship name="transcript" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TranscriptEntry" inverseName="summaries" inverseEntity="TranscriptEntry"/>
+    </entity>
+    <entity name="TranscriptEntry" representedClassName="TranscriptEntry" syncable="YES" codeGenerationType="class">
+        <attribute name="confidence" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="engine" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="lastModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="processingTime" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="recordingId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="segments" optional="YES" attributeType="String"/>
+        <attribute name="speakerMappings" optional="YES" attributeType="String"/>
+        <relationship name="recording" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="RecordingEntry" inverseName="transcript" inverseEntity="RecordingEntry"/>
+        <relationship name="summaries" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SummaryEntry" inverseName="transcript" inverseEntity="SummaryEntry"/>
+    </entity>
+    <entity name="ProcessingJobEntry" representedClassName="ProcessingJobEntry" syncable="YES" codeGenerationType="class">
+        <attribute name="completionTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="engine" optional="YES" attributeType="String"/>
+        <attribute name="error" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="jobType" optional="YES" attributeType="String"/>
+        <attribute name="lastModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="modelName" optional="YES" attributeType="String"/>
+        <attribute name="progress" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="recordingName" optional="YES" attributeType="String"/>
+        <attribute name="recordingURL" optional="YES" attributeType="String"/>
+        <attribute name="startTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="status" optional="YES" attributeType="String"/>
+        <relationship name="recording" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="RecordingEntry" inverseName="processingJobs" inverseEntity="RecordingEntry"/>
+    </entity>
+    <entity name="RecordingArchiveLocationEntry" representedClassName="RecordingArchiveLocationEntry" syncable="YES" codeGenerationType="class">
+        <attribute name="bookmarkData" optional="YES" attributeType="Binary"/>
+        <attribute name="destinationURLString" optional="YES" attributeType="String"/>
+        <attribute name="displayName" optional="YES" attributeType="String"/>
+        <attribute name="exportedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="exportedFilename" optional="YES" attributeType="String"/>
+        <attribute name="fileSize" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="lastVerifiedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="providerDisplayName" optional="YES" attributeType="String"/>
+        <attribute name="recordingId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="status" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="PendingCloudMutation" representedClassName="PendingCloudMutationManagedObject" syncable="NO" codeGenerationType="class">
+        <attribute name="kind" optional="NO" attributeType="String" defaultValueString="recordingDeletion"/>
+        <attribute name="payload" optional="YES" attributeType="Binary"/>
+        <attribute name="recordingId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="requestedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="targetId" optional="NO" attributeType="UUID" defaultValueString="00000000-0000-0000-0000-000000000000" usesScalarValueType="NO"/>
+        <attribute name="version" optional="NO" attributeType="Integer 32" defaultValueString="1" usesScalarValueType="YES"/>
+    </entity>
+    <elements>
+        <element name="RecordingEntry" positionX="-63" positionY="-18" width="128" height="269"/>
+        <element name="SummaryEntry" positionX="144" positionY="72" width="128" height="284"/>
+        <element name="TranscriptEntry" positionX="144" positionY="-117" width="128" height="194"/>
+        <element name="ProcessingJobEntry" positionX="144" positionY="180" width="128" height="194"/>
+        <element name="RecordingArchiveLocationEntry" positionX="342" positionY="180" width="128" height="209"/>
+        <element name="PendingCloudMutation" positionX="540" positionY="180" width="128" height="180"/>
+    </elements>
+</model>

--- a/BisonNotes AI/BisonNotes AI/MLXSwiftEngine.swift
+++ b/BisonNotes AI/BisonNotes AI/MLXSwiftEngine.swift
@@ -136,8 +136,11 @@ final class MLXSwiftDownloadManager: ObservableObject {
     private var queuedModelDeletionIDs: [String] = []
     @Published private(set) var isDownloadQueued = false
     /// What the manager is waiting on, for the settings UI to show. A queued
-    /// download reports no progress and is not `isDownloading`, so without this the
-    /// user's tap on Download looked like a dead button for as long as the sweep ran.
+    /// download reports no progress and is not `isDownloading`, and a queued
+    /// deletion sets no flag at all, so without this the user's tap looked like a
+    /// dead button for as long as the sweep ran. Always recomputed from the queued
+    /// state by `updateDeferredMaintenanceNotice` rather than assigned ad hoc, so
+    /// it cannot outlive or contradict what is actually pending.
     @Published private(set) var deferredMaintenanceNotice: String?
     private let downloadOperation: (@MainActor (String) async throws -> Void)?
     private let blobCleanup: (@MainActor (String) -> Void)?
@@ -187,10 +190,10 @@ final class MLXSwiftDownloadManager: ObservableObject {
     func endCacheMaintenance() {
         isCacheMaintenanceInProgress = false
         cacheMaintenanceYieldRequested = false
-        deferredMaintenanceNotice = nil
 
         let deletionIDs = queuedModelDeletionIDs
         queuedModelDeletionIDs = []
+        updateDeferredMaintenanceNotice()
         for deletionID in deletionIDs {
             deleteModelNow(for: deletionID)
         }
@@ -204,6 +207,22 @@ final class MLXSwiftDownloadManager: ObservableObject {
 
     var shouldYieldCacheMaintenance: Bool {
         cacheMaintenanceYieldRequested
+    }
+
+    private func updateDeferredMaintenanceNotice() {
+        let pendingDeletions = queuedModelDeletionIDs.count
+        switch (isDownloadQueued, pendingDeletions) {
+        case (false, 0):
+            deferredMaintenanceNotice = nil
+        case (true, 0):
+            deferredMaintenanceNotice = "Waiting for cache maintenance to finish before downloading."
+        case (false, 1):
+            deferredMaintenanceNotice = "Model deletion will run after cache maintenance finishes."
+        case (false, let count):
+            deferredMaintenanceNotice = "\(count) model deletions will run after cache maintenance finishes."
+        case (true, _):
+            deferredMaintenanceNotice = "A model download and deletion will run after cache maintenance finishes."
+        }
     }
 
     func startDownload() {
@@ -221,10 +240,10 @@ final class MLXSwiftDownloadManager: ObservableObject {
             downloadProgress = 0
             // Queuing is only acceptable while the user can see it happening.
             // `MLXSwiftSettingsView` renders this alongside a cancel button.
-            deferredMaintenanceNotice = "Waiting for cache maintenance to finish before downloading."
+            updateDeferredMaintenanceNotice()
             return
         }
-        deferredMaintenanceNotice = nil
+        updateDeferredMaintenanceNotice()
 
         downloadGeneration += 1
         let generation = downloadGeneration
@@ -342,11 +361,9 @@ final class MLXSwiftDownloadManager: ObservableObject {
             // already cancelled.
             queuedDownloadModelID = nil
             isDownloadQueued = false
-            // Any queued deletion still stands, so only drop the notice when this
-            // was the last thing waiting on the sweep.
-            if queuedModelDeletionIDs.isEmpty {
-                deferredMaintenanceNotice = nil
-            }
+            // Any queued deletion still stands; the notice re-derives itself so it
+            // describes what is actually left rather than the cancelled download.
+            updateDeferredMaintenanceNotice()
         }
         if downloadTask != nil {
             // Cleared here rather than only in the task's `defer`: a Hub download
@@ -380,7 +397,7 @@ final class MLXSwiftDownloadManager: ObservableObject {
             SummaryManager.shared.getiCloudManager().operationCoordinator.requestCacheMaintenanceYield()
             // Not `downloadError`: this is not a failure, and a download queued
             // afterwards used to clear it, hiding the pending deletion entirely.
-            deferredMaintenanceNotice = "Model deletion will run after cache maintenance finishes."
+            updateDeferredMaintenanceNotice()
             return
         }
         deleteModelNow(for: id)

--- a/BisonNotes AI/BisonNotes AI/MLXSwiftEngine.swift
+++ b/BisonNotes AI/BisonNotes AI/MLXSwiftEngine.swift
@@ -126,9 +126,19 @@ final class MLXSwiftDownloadManager: ObservableObject {
     private var deferredBlobCleanups: Set<String> = []
     private var isCacheMaintenanceInProgress = false
     private var cacheMaintenanceYieldRequested = false
+    /// Only one model downloads at a time, so a second request while one is queued
+    /// deliberately replaces it — the user changed their mind about which model to
+    /// fetch, and the earlier request never started writing anything.
     private var queuedDownloadModelID: String?
-    private var queuedModelDeletionID: String?
+    /// Deletions are not interchangeable: each one frees a different model's files.
+    /// A single slot silently dropped the first of two deletes requested during the
+    /// same sweep, leaving gigabytes the user asked to reclaim on disk.
+    private var queuedModelDeletionIDs: [String] = []
     @Published private(set) var isDownloadQueued = false
+    /// What the manager is waiting on, for the settings UI to show. A queued
+    /// download reports no progress and is not `isDownloading`, so without this the
+    /// user's tap on Download looked like a dead button for as long as the sweep ran.
+    @Published private(set) var deferredMaintenanceNotice: String?
     private let downloadOperation: (@MainActor (String) async throws -> Void)?
     private let blobCleanup: (@MainActor (String) -> Void)?
 
@@ -177,9 +187,11 @@ final class MLXSwiftDownloadManager: ObservableObject {
     func endCacheMaintenance() {
         isCacheMaintenanceInProgress = false
         cacheMaintenanceYieldRequested = false
+        deferredMaintenanceNotice = nil
 
-        if let deletionID = queuedModelDeletionID {
-            queuedModelDeletionID = nil
+        let deletionIDs = queuedModelDeletionIDs
+        queuedModelDeletionIDs = []
+        for deletionID in deletionIDs {
             deleteModelNow(for: deletionID)
         }
 
@@ -207,8 +219,12 @@ final class MLXSwiftDownloadManager: ObservableObject {
             SummaryManager.shared.getiCloudManager().operationCoordinator.requestCacheMaintenanceYield()
             downloadError = nil
             downloadProgress = 0
+            // Queuing is only acceptable while the user can see it happening.
+            // `MLXSwiftSettingsView` renders this alongside a cancel button.
+            deferredMaintenanceNotice = "Waiting for cache maintenance to finish before downloading."
             return
         }
+        deferredMaintenanceNotice = nil
 
         downloadGeneration += 1
         let generation = downloadGeneration
@@ -326,6 +342,11 @@ final class MLXSwiftDownloadManager: ObservableObject {
             // already cancelled.
             queuedDownloadModelID = nil
             isDownloadQueued = false
+            // Any queued deletion still stands, so only drop the notice when this
+            // was the last thing waiting on the sweep.
+            if queuedModelDeletionIDs.isEmpty {
+                deferredMaintenanceNotice = nil
+            }
         }
         if downloadTask != nil {
             // Cleared here rather than only in the task's `defer`: a Hub download
@@ -352,10 +373,14 @@ final class MLXSwiftDownloadManager: ObservableObject {
         #if canImport(MLXLLM) && canImport(MLXLMCommon)
         let id = modelId
         if isCacheMaintenanceInProgress {
-            queuedModelDeletionID = id
+            if !queuedModelDeletionIDs.contains(id) {
+                queuedModelDeletionIDs.append(id)
+            }
             cacheMaintenanceYieldRequested = true
             SummaryManager.shared.getiCloudManager().operationCoordinator.requestCacheMaintenanceYield()
-            downloadError = "Model deletion will run after cache maintenance finishes."
+            // Not `downloadError`: this is not a failure, and a download queued
+            // afterwards used to clear it, hiding the pending deletion entirely.
+            deferredMaintenanceNotice = "Model deletion will run after cache maintenance finishes."
             return
         }
         deleteModelNow(for: id)

--- a/BisonNotes AI/BisonNotes AI/MLXSwiftEngine.swift
+++ b/BisonNotes AI/BisonNotes AI/MLXSwiftEngine.swift
@@ -125,6 +125,10 @@ final class MLXSwiftDownloadManager: ObservableObject {
     /// waits on every unwinding task and cannot run while one of them is stuck.
     private var deferredBlobCleanups: Set<String> = []
     private var isCacheMaintenanceInProgress = false
+    private var cacheMaintenanceYieldRequested = false
+    private var queuedDownloadModelID: String?
+    private var queuedModelDeletionID: String?
+    @Published private(set) var isDownloadQueued = false
     private let downloadOperation: (@MainActor (String) async throws -> Void)?
     private let blobCleanup: (@MainActor (String) -> Void)?
 
@@ -164,6 +168,7 @@ final class MLXSwiftDownloadManager: ObservableObject {
             return false
         }
         isCacheMaintenanceInProgress = true
+        cacheMaintenanceYieldRequested = false
         return true
     }
 
@@ -171,16 +176,40 @@ final class MLXSwiftDownloadManager: ObservableObject {
     /// finished.
     func endCacheMaintenance() {
         isCacheMaintenanceInProgress = false
+        cacheMaintenanceYieldRequested = false
+
+        if let deletionID = queuedModelDeletionID {
+            queuedModelDeletionID = nil
+            deleteModelNow(for: deletionID)
+        }
+
+        if let downloadID = queuedDownloadModelID {
+            queuedDownloadModelID = nil
+            isDownloadQueued = false
+            startDownload(for: downloadID)
+        }
+    }
+
+    var shouldYieldCacheMaintenance: Bool {
+        cacheMaintenanceYieldRequested
     }
 
     func startDownload() {
+        startDownload(for: modelId)
+    }
+
+    private func startDownload(for id: String) {
         guard !isDownloading else { return }
-        // Deliberately not held behind a running sweep. What actually protects a
-        // download's blobs is the sweep re-reading `isDownloading` immediately
-        // before every removal; queuing the request instead was invisible — no
-        // progress, no message, nothing for minutes while gigabytes were swept —
-        // and became permanent whenever the sweep's release never ran.
-        let id = modelId
+        if isCacheMaintenanceInProgress {
+            queuedDownloadModelID = id
+            isDownloadQueued = true
+            cacheMaintenanceYieldRequested = true
+            SummaryManager.shared.getiCloudManager().operationCoordinator.requestCacheMaintenanceYield()
+            downloadError = nil
+            downloadProgress = 0
+            return
+        }
+
         downloadGeneration += 1
         let generation = downloadGeneration
         isDownloading = true
@@ -291,6 +320,13 @@ final class MLXSwiftDownloadManager: ObservableObject {
     }
 
     func cancelDownload() {
+        if downloadTask == nil, queuedDownloadModelID != nil {
+            // A queued request has not started writing yet. Clear it here rather
+            // than letting cache maintenance release start a download the user
+            // already cancelled.
+            queuedDownloadModelID = nil
+            isDownloadQueued = false
+        }
         if downloadTask != nil {
             // Cleared here rather than only in the task's `defer`: a Hub download
             // need not observe cancellation promptly, and leaving `isDownloading`
@@ -314,10 +350,26 @@ final class MLXSwiftDownloadManager: ObservableObject {
 
     func deleteModel() {
         #if canImport(MLXLLM) && canImport(MLXLMCommon)
+        let id = modelId
+        if isCacheMaintenanceInProgress {
+            queuedModelDeletionID = id
+            cacheMaintenanceYieldRequested = true
+            SummaryManager.shared.getiCloudManager().operationCoordinator.requestCacheMaintenanceYield()
+            downloadError = "Model deletion will run after cache maintenance finishes."
+            return
+        }
+        deleteModelNow(for: id)
+        #endif
+    }
+
+    private func deleteModelNow(for id: String) {
+        #if canImport(MLXLLM) && canImport(MLXLMCommon)
         do {
-            try removeModelFiles()
-            isModelDownloaded = false
-            AppLog.shared.summarization("[MLXSwift] Model deleted: \(modelId)")
+            try removeModelFiles(for: id)
+            if modelId == id {
+                isModelDownloaded = false
+            }
+            AppLog.shared.summarization("[MLXSwift] Model deleted: \(id)")
         } catch {
             downloadError = "Failed to delete: \(error.localizedDescription)"
             AppLog.shared.summarization("[MLXSwift] Delete failed: \(error.localizedDescription)", level: .error)
@@ -535,7 +587,11 @@ extension MLXSwiftDownloadManager {
     }
 
     func removeModelFiles() throws {
-        let config = ModelConfiguration(id: modelId)
+        try removeModelFiles(for: modelId)
+    }
+
+    func removeModelFiles(for modelID: String) throws {
+        let config = ModelConfiguration(id: modelID)
         let dir = config.modelDirectory(hub: defaultHubApi)
         if FileManager.default.fileExists(atPath: dir.path) {
             try FileManager.default.removeItem(at: dir)
@@ -545,7 +601,7 @@ extension MLXSwiftDownloadManager {
         // the model occupies. Removing just it left a full second copy behind — two
         // "deleted" models were still costing 3.3 GB. `CacheMaintenanceService` also
         // sweeps these, but a delete the user asked for should free the space now.
-        removeHubBlobCache(for: modelId)
+        removeHubBlobCache(for: modelID)
     }
 
     private func removeHubBlobCache(for modelId: String) {

--- a/BisonNotes AI/BisonNotes AI/MLXSwiftSettingsView.swift
+++ b/BisonNotes AI/BisonNotes AI/MLXSwiftSettingsView.swift
@@ -447,13 +447,6 @@ struct MLXSwiftSettingsView: View {
                     .foregroundColor(.secondary)
             }
 
-            if let notice = downloadManager.deferredMaintenanceNotice {
-                Text(notice)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .multilineTextAlignment(.center)
-            }
-
             if let error = downloadManager.downloadError {
                 Text(error)
                     .font(.caption)
@@ -469,8 +462,27 @@ struct MLXSwiftSettingsView: View {
 
     // MARK: - Model Status View
 
+    /// Shown wherever the status is, not inside the download-progress section:
+    /// a queued deletion sets neither `isDownloading` nor `isDownloadQueued`, so
+    /// gating this on those flags hid it entirely and the model could vanish when
+    /// maintenance finished with no prior indication.
+    @ViewBuilder
+    private var deferredMaintenanceNoticeView: some View {
+        if let notice = downloadManager.deferredMaintenanceNotice {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "clock")
+                    .foregroundColor(.orange)
+                Text(notice)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
     @ViewBuilder
     private var modelStatusView: some View {
+        deferredMaintenanceNoticeView
         if downloadManager.isModelDownloaded {
             HStack {
                 Image(systemName: "checkmark.circle.fill")

--- a/BisonNotes AI/BisonNotes AI/MLXSwiftSettingsView.swift
+++ b/BisonNotes AI/BisonNotes AI/MLXSwiftSettingsView.swift
@@ -129,8 +129,8 @@ struct MLXSwiftSettingsView: View {
                 }
             }
 
-            // Download Progress (if downloading)
-            if downloadManager.isDownloading {
+            // Download Progress (if downloading or waiting for a cache sweep)
+            if downloadManager.isDownloading || downloadManager.isDownloadQueued {
                 Section("Download Progress") {
                     downloadProgressView
                 }
@@ -233,7 +233,7 @@ struct MLXSwiftSettingsView: View {
                     }
                 }
 
-                if downloadManager.isDownloading {
+                if downloadManager.isDownloading || downloadManager.isDownloadQueued {
                     nativeSettingsCard(title: "Download Progress", systemImage: "arrow.down.circle", tint: .blue) {
                         downloadProgressView
                     }
@@ -382,7 +382,10 @@ struct MLXSwiftSettingsView: View {
                     .font(.title2)
                     .foregroundColor(.blue)
             }
-        } else if downloadManager.isDownloading && downloadManager.modelId == model.id {
+        } else if (downloadManager.isDownloading || downloadManager.isDownloadQueued)
+                    && downloadManager.modelId == model.id {
+            // A queued download is cancellable too, and showing the arrow for it
+            // made the row look untouched while the request sat waiting.
             Button {
                 downloadManager.cancelDownload()
             } label: {
@@ -400,7 +403,7 @@ struct MLXSwiftSettingsView: View {
                     .font(.title2)
                     .foregroundColor(.blue)
             }
-            .disabled(downloadManager.isDownloading)
+            .disabled(downloadManager.isDownloading || downloadManager.isDownloadQueued)
         }
     }
 
@@ -423,16 +426,33 @@ struct MLXSwiftSettingsView: View {
     @ViewBuilder
     private var downloadProgressView: some View {
         VStack(spacing: 12) {
-            Text("Downloading \(downloadManager.modelDisplayName)")
+            // A download requested during a cache sweep is queued rather than
+            // started. It has no progress to report, so say what it is waiting on
+            // instead of showing a 0% bar that never moves.
+            Text(downloadManager.isDownloadQueued
+                 ? "Queued: \(downloadManager.modelDisplayName)"
+                 : "Downloading \(downloadManager.modelDisplayName)")
                 .font(.subheadline)
                 .fontWeight(.medium)
 
-            ProgressView(value: downloadManager.downloadProgress)
-                .progressViewStyle(.linear)
+            if downloadManager.isDownloadQueued {
+                ProgressView()
+                    .progressViewStyle(.linear)
+            } else {
+                ProgressView(value: downloadManager.downloadProgress)
+                    .progressViewStyle(.linear)
 
-            Text("\(Int(downloadManager.downloadProgress * 100))%")
-                .font(.caption)
-                .foregroundColor(.secondary)
+                Text("\(Int(downloadManager.downloadProgress * 100))%")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            if let notice = downloadManager.deferredMaintenanceNotice {
+                Text(notice)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+            }
 
             if let error = downloadManager.downloadError {
                 Text(error)
@@ -440,7 +460,7 @@ struct MLXSwiftSettingsView: View {
                     .foregroundColor(.red)
             }
 
-            Button("Cancel Download") {
+            Button(downloadManager.isDownloadQueued ? "Cancel" : "Cancel Download") {
                 downloadManager.cancelDownload()
             }
             .foregroundColor(.red)

--- a/BisonNotes AI/BisonNotes AI/Models/AppDataCoordinator.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/AppDataCoordinator.swift
@@ -263,11 +263,24 @@ class AppDataCoordinator: ObservableObject {
                 // Remove every identity collected above, including stale ids from
                 // the recording and summary relationships. Otherwise backup can
                 // select an older remaining row and recreate the deleted transcript.
-                _ = try coreDataManager.stageTranscriptDeletion(
+                let removedLocalRow = try coreDataManager.stageTranscriptDeletion(
                     id: transcriptId,
                     effects: &effects,
                     requestedAt: deletionDate
                 )
+                if !removedLocalRow {
+                    // An id with no local row is the case this method exists for:
+                    // an imported placeholder whose transcript is already gone
+                    // here but still live in iCloud. Staging the deletion alone
+                    // would tombstone nothing, and the next reconcile would pull
+                    // the transcript back down — the resurrection this method is
+                    // meant to prevent.
+                    effects.stageTranscript(
+                        id: transcriptId,
+                        recordingId: recordingId,
+                        requestedAt: deletionDate
+                    )
+                }
             }
 
             guard let recording = coreDataManager.getRecording(id: recordingId) else {

--- a/BisonNotes AI/BisonNotes AI/Models/AppDataCoordinator.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/AppDataCoordinator.swift
@@ -34,6 +34,9 @@ class AppDataCoordinator: ObservableObject {
         // Set up the circular reference after initialization
         self.workflowManager.setAppCoordinator(self)
         SummaryManager.shared.configure(with: self)
+        SummaryManager.shared.getiCloudManager().bindPendingMutationContext(
+            to: coreDataManager.managedObjectContext
+        )
 
         Task {
             await initializeSystem()
@@ -196,23 +199,11 @@ class AppDataCoordinator: ObservableObject {
 
 
     func deleteRecording(id: UUID) {
-        let transcriptIds = coreDataManager.getTranscript(for: id).flatMap { $0.id }.map { [$0] } ?? []
-        let summaryIds = coreDataManager.getSummary(for: id).flatMap { $0.id }.map { [$0] } ?? []
         let iCloudManager = SummaryManager.shared.getiCloudManager()
-        // Persist the deletion intent first so a crash after the local save
-        // still tells other devices. Withdraw it if the local delete rolls back.
-        iCloudManager.enqueueRecordingDeletionForiCloud(
-            recordingId: id,
-            transcriptIds: transcriptIds,
-            summaryIds: summaryIds
-        )
         do {
             try coreDataManager.deleteRecording(id: id)
         } catch {
-            // Covers the not-found case too: nothing was deleted here, so the
-            // marker queued a moment ago must not go on to delete it elsewhere.
-            iCloudManager.clearPendingRecordingDeletion(recordingId: id)
-            AppLog.shared.coreData("Failed to delete recording \(id); withdrew the iCloud deletion marker: \(error)", level: .error)
+            AppLog.shared.coreData("Failed to delete recording \(id): \(error)", level: .error)
             return
         }
 
@@ -228,26 +219,8 @@ class AppDataCoordinator: ObservableObject {
     /// Deletes only a transcript. The recording, audio, and any summary remain, while
     /// the transcript's cloud tombstone is retained until iCloud accepts it.
     func deleteTranscript(id: UUID) async throws {
-        let transcript = coreDataManager.getTranscript(id: id)
-        let recordingId = transcript?.recordingId ?? transcript?.recording?.id
         let iCloudManager = SummaryManager.shared.getiCloudManager()
-        iCloudManager.enqueueTranscriptRemovalFromiCloud(
-            transcriptId: id,
-            recordingId: recordingId
-        )
-
-        do {
-            try coreDataManager.deleteTranscript(id: id)
-            guard coreDataManager.getTranscript(id: id) == nil else {
-                // Nothing was deleted — the row was not there. Withdraw the marker
-                // rather than tombstoning something this device never saw.
-                iCloudManager.clearPendingTranscriptRemoval(transcriptId: id)
-                return
-            }
-        } catch {
-            iCloudManager.clearPendingTranscriptRemoval(transcriptId: id)
-            throw error
-        }
+        try coreDataManager.deleteTranscript(id: id)
 
         do {
             try await iCloudManager.flushPendingiCloudDeletions(appCoordinator: self)
@@ -283,53 +256,18 @@ class AppDataCoordinator: ObservableObject {
             initialSummary?.transcript?.id
         ].compactMap { $0 })
 
-        // Persist both removal intents before touching anything locally, the same
-        // way `deleteSummary` and `setCloudSyncDisabled` do. Queuing them after the
-        // save left a window where a termination between the two would take the
-        // transcript and audio away locally with nothing durable telling the other
-        // devices — and the next sync would restore exactly what the user deleted,
-        // which is the resurrection this method exists to prevent. Withdrawn below
-        // if the local work does not commit.
-        //
-        // `deletionDate` is when the user asked, which is also what the markers must
-        // carry: a marker that reaches CloudKit days later must not erase newer work.
         let deletionDate = Date()
-        for transcriptId in transcriptIds {
-            iCloudManager.enqueueTranscriptRemovalFromiCloud(
-                transcriptId: transcriptId,
-                recordingId: recordingId,
-                requestedAt: deletionDate
-            )
-        }
-        iCloudManager.enqueueImportedAudioRemovalFromiCloud(
-            recordingId: recordingId,
-            requestedAt: deletionDate
-        )
-
-        // `deleteTranscript` commits a save of its own, so its rows can be durably
-        // gone even when the work below fails. Withdrawing a marker for one of those
-        // would leave the transcript deleted locally with nothing telling the other
-        // devices — the resurrection this method exists to prevent — so only intents
-        // whose mutation has not committed are taken back.
-        var committedTranscriptIds: Set<UUID> = []
-
-        func withdrawUncommittedRemovals() {
-            for transcriptId in transcriptIds where !committedTranscriptIds.contains(transcriptId) {
-                iCloudManager.clearPendingTranscriptRemoval(transcriptId: transcriptId)
-            }
-            // `recordingURL` is only cleared by the `saveContext()` below, so if that
-            // did not land the audio is still referenced locally and its intent goes.
-            iCloudManager.clearPendingImportedAudioRemoval(recordingId: recordingId)
-        }
-
+        var effects = DeferredDeletionEffects()
         do {
             for transcriptId in transcriptIds {
-                // The marker is already queued; this only removes the local row.
                 // Remove every identity collected above, including stale ids from
                 // the recording and summary relationships. Otherwise backup can
                 // select an older remaining row and recreate the deleted transcript.
-                try coreDataManager.deleteTranscript(id: transcriptId, enqueueCloudDeletion: false)
-                committedTranscriptIds.insert(transcriptId)
+                _ = try coreDataManager.stageTranscriptDeletion(
+                    id: transcriptId,
+                    effects: &effects,
+                    requestedAt: deletionDate
+                )
             }
 
             guard let recording = coreDataManager.getRecording(id: recordingId) else {
@@ -357,16 +295,12 @@ class AppDataCoordinator: ObservableObject {
 
             recording.recordingURL = nil
             recording.lastModified = deletionDate
-            try coreDataManager.saveContext()
+            effects.stageImportedAudioRemoval(recordingId: recordingId, requestedAt: deletionDate)
+            try coreDataManager.save(committing: effects)
         } catch {
-            // Roll back before withdrawing: `saveContext()` leaves a failed save's
-            // edits staged in the context, so the cleared `recordingURL` and
-            // transcript link would still be committed by the next unrelated save —
-            // with their removal intents already taken back. The recording would
-            // then have lost its audio and transcript locally with no tombstone,
-            // and the next sync would restore exactly what the user deleted.
+            // `save(committing:)` rolls back both local edits and outbox rows on
+            // failure. Nothing has been published or withdrawn outside the store.
             coreDataManager.rollbackContext()
-            withdrawUncommittedRemovals()
             throw error
         }
 
@@ -383,32 +317,11 @@ class AppDataCoordinator: ObservableObject {
 
     func deleteSummary(id: UUID) async throws {
         let iCloudManager = SummaryManager.shared.getiCloudManager()
-        let summary = coreDataManager.getSummary(id: id)
-        let recordingId = summary?.recordingId
-            ?? summary?.recording?.id
-            ?? coreDataManager.getRecording(forSummaryId: id)?.id
 
         // Attachment files are removed by deleteSummary once its save commits.
         // Doing it here destroyed the user's notes even when the delete below
         // threw and the marker was withdrawn.
-
-        // Persist the deletion intent before the local delete. This closes the crash window
-        // where a device could remove its local summary and never tell the other devices.
-        iCloudManager.enqueueSummaryRemovalFromiCloud(
-            summaryId: id,
-            recordingId: recordingId
-        )
-
-        do {
-            try coreDataManager.deleteSummary(id: id)
-            guard coreDataManager.getSummary(id: id) == nil else {
-                iCloudManager.clearPendingSummaryRemoval(summaryId: id)
-                return
-            }
-        } catch {
-            iCloudManager.clearPendingSummaryRemoval(summaryId: id)
-            throw error
-        }
+        try coreDataManager.deleteSummary(id: id)
 
         do {
             try await iCloudManager.flushPendingiCloudDeletions(appCoordinator: self)
@@ -423,18 +336,7 @@ class AppDataCoordinator: ObservableObject {
 
     func setCloudSyncDisabled(for recordingId: UUID, disabled: Bool) async throws {
         let iCloudManager = SummaryManager.shared.getiCloudManager()
-        if disabled {
-            iCloudManager.enqueueLocalOnlyCloudRemoval(recordingId: recordingId)
-        }
-
-        do {
-            try coreDataManager.updateCloudSyncDisabled(for: recordingId, disabled: disabled)
-        } catch {
-            if disabled {
-                iCloudManager.clearPendingLocalOnlyCloudRemoval(recordingId: recordingId)
-            }
-            throw error
-        }
+        try coreDataManager.updateCloudSyncDisabled(for: recordingId, disabled: disabled)
 
         if disabled {
             do {
@@ -443,7 +345,6 @@ class AppDataCoordinator: ObservableObject {
                 AppLog.shared.coreData("Marked recording local-only and queued iCloud removal for retry: \(error)", level: .error)
             }
         } else {
-            iCloudManager.clearPendingLocalOnlyCloudRemoval(recordingId: recordingId)
             scheduleAutoBackupIfEnabled()
         }
 

--- a/BisonNotes AI/BisonNotes AI/Models/CoreDataManager.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/CoreDataManager.swift
@@ -90,6 +90,18 @@ struct DeferredDeletionEffects {
         transcripts.append((transcriptId, transcript.recordingId ?? transcript.recording?.id, requestedAt))
     }
 
+    /// Stages a transcript tombstone by identity, for an id whose local row is
+    /// already gone. A missing row is not evidence that the cloud copy should
+    /// survive — for an imported placeholder it is the normal case, and without
+    /// this the next reconcile restores the transcript the user just deleted.
+    mutating func stageTranscript(
+        id transcriptId: UUID,
+        recordingId: UUID?,
+        requestedAt: Date = Date()
+    ) {
+        transcripts.append((transcriptId, recordingId, requestedAt))
+    }
+
     mutating func stage(recording: RecordingEntry, requestedAt: Date = Date()) {
         guard let recordingId = recording.id else { return }
         recordings.append((

--- a/BisonNotes AI/BisonNotes AI/Models/CoreDataManager.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/CoreDataManager.swift
@@ -44,73 +44,142 @@ enum CoreDataDeletionError: Error, Equatable {
     case recordingNotFound(UUID)
 }
 
-/// Side effects of a delete that must not run until Core Data has committed.
+/// Side effects of a delete that must be committed with the Core Data change.
 ///
-/// Two of them cannot be taken back. Attachment files are gone from disk once
-/// deleted, so a rollback returns rows pointing at notes the user can no longer
-/// open. A cloud deletion marker is durable and outlives the row it describes,
-/// so one queued for a row that then rolls back deletes a live copy from every
-/// other device. Callers stage the intent, save, and only then commit; if the
-/// save throws, nothing staged has happened.
+/// Cloud mutations are inserted into the same persistent store transaction as
+/// the deleted rows. Attachment folders remain post-commit filesystem effects:
+/// unlike an outbox row, they cannot be rolled back by SQLite.
 @MainActor
 struct DeferredDeletionEffects {
-    private var summaries: [(summaryId: UUID, recordingId: UUID?)] = []
-    private var transcripts: [(transcriptId: UUID, recordingId: UUID?)] = []
-    private var recordings: [(recordingId: UUID, transcriptIds: [UUID], summaryIds: [UUID])] = []
+    private var summaries: [(summaryId: UUID, recordingId: UUID?, requestedAt: Date, deleteAttachments: Bool)] = []
+    private var transcripts: [(transcriptId: UUID, recordingId: UUID?, requestedAt: Date)] = []
+    private var recordings: [(recordingId: UUID, transcriptIds: [UUID], summaryIds: [UUID], requestedAt: Date)] = []
+    private var localOnlyRemovals: [(recordingId: UUID, requestedAt: Date)] = []
+    private var importedAudioRemovals: [(recordingId: UUID, requestedAt: Date)] = []
 
     var isEmpty: Bool {
-        summaries.isEmpty && transcripts.isEmpty && recordings.isEmpty
+        summaries.isEmpty && transcripts.isEmpty && recordings.isEmpty &&
+            localOnlyRemovals.isEmpty && importedAudioRemovals.isEmpty
     }
 
-    /// Stages a summary. `deletesAttachments` is false for a row whose files are
-    /// being handed to another id rather than destroyed.
-    mutating func stage(summary: SummaryEntry) {
+    mutating func stage(
+        summary: SummaryEntry,
+        requestedAt: Date = Date(),
+        deleteAttachments: Bool = true
+    ) {
         guard let summaryId = summary.id else { return }
-        summaries.append((summaryId, summary.recordingId ?? summary.recording?.id))
+        summaries.append((
+            summaryId,
+            summary.recordingId ?? summary.recording?.id,
+            requestedAt,
+            deleteAttachments
+        ))
     }
 
-    mutating func stageSummary(id summaryId: UUID, recordingId: UUID?) {
-        summaries.append((summaryId, recordingId))
+    mutating func stageSummary(
+        id summaryId: UUID,
+        recordingId: UUID?,
+        requestedAt: Date = Date(),
+        deleteAttachments: Bool = true
+    ) {
+        summaries.append((summaryId, recordingId, requestedAt, deleteAttachments))
     }
 
-    mutating func stage(transcript: TranscriptEntry) {
+    mutating func stage(transcript: TranscriptEntry, requestedAt: Date = Date()) {
         guard let transcriptId = transcript.id else { return }
-        transcripts.append((transcriptId, transcript.recordingId ?? transcript.recording?.id))
+        transcripts.append((transcriptId, transcript.recordingId ?? transcript.recording?.id, requestedAt))
     }
 
-    mutating func stage(recording: RecordingEntry) {
+    mutating func stage(recording: RecordingEntry, requestedAt: Date = Date()) {
         guard let recordingId = recording.id else { return }
         recordings.append((
             recordingId,
             [recording.transcriptId ?? recording.transcript?.id].compactMap { $0 },
-            [recording.summaryId ?? recording.summary?.id].compactMap { $0 }
+            [recording.summaryId ?? recording.summary?.id].compactMap { $0 },
+            requestedAt
         ))
     }
 
-    /// Publishes the tombstones and removes the attachment files. Call only after
-    /// the save that removed these rows has succeeded.
-    func commit() {
-        guard !isEmpty else { return }
-        let iCloudManager = SummaryManager.shared.getiCloudManager()
+    mutating func stageLocalOnlyRemoval(recordingId: UUID, requestedAt: Date = Date()) {
+        localOnlyRemovals.append((recordingId, requestedAt))
+    }
 
+    mutating func stageImportedAudioRemoval(recordingId: UUID, requestedAt: Date = Date()) {
+        importedAudioRemovals.append((recordingId, requestedAt))
+    }
+
+    /// Inserts every outbound intent into the transaction that deletes the rows.
+    /// A thrown error leaves the caller's context free to roll back the whole
+    /// deletion, including any outbox rows inserted so far.
+    func stageCloudMutations(in context: NSManagedObjectContext) throws {
         for recording in recordings {
-            iCloudManager.enqueueRecordingDeletionForiCloud(
-                recordingId: recording.recordingId,
-                transcriptIds: recording.transcriptIds,
-                summaryIds: recording.summaryIds
+            // A whole-recording deletion supersedes an earlier explicit imported
+            // audio removal for the same target. Keep the old enqueue API's
+            // coalescing behavior inside this transaction too.
+            try PendingCloudMutationStore.remove(
+                kind: .importedAudioRemoval,
+                targetId: recording.recordingId,
+                from: context
+            )
+            try PendingCloudMutationStore.enqueue(
+                PendingCloudMutation(
+                    kind: .recordingDeletion,
+                    targetId: recording.recordingId,
+                    transcriptIds: recording.transcriptIds,
+                    summaryIds: recording.summaryIds,
+                    requestedAt: recording.requestedAt
+                ),
+                in: context
             )
         }
         for transcript in transcripts {
-            iCloudManager.enqueueTranscriptRemovalFromiCloud(
-                transcriptId: transcript.transcriptId,
-                recordingId: transcript.recordingId
+            try PendingCloudMutationStore.enqueue(
+                PendingCloudMutation(
+                    kind: .transcriptRemoval,
+                    targetId: transcript.transcriptId,
+                    recordingId: transcript.recordingId,
+                    requestedAt: transcript.requestedAt
+                ),
+                in: context
             )
         }
         for summary in summaries {
-            iCloudManager.enqueueSummaryRemovalFromiCloud(
-                summaryId: summary.summaryId,
-                recordingId: summary.recordingId
+            try PendingCloudMutationStore.enqueue(
+                PendingCloudMutation(
+                    kind: .summaryRemoval,
+                    targetId: summary.summaryId,
+                    recordingId: summary.recordingId,
+                    requestedAt: summary.requestedAt
+                ),
+                in: context
             )
+        }
+        for removal in localOnlyRemovals {
+            try PendingCloudMutationStore.enqueue(
+                PendingCloudMutation(
+                    kind: .localOnlyRemoval,
+                    targetId: removal.recordingId,
+                    requestedAt: removal.requestedAt
+                ),
+                in: context
+            )
+        }
+        for removal in importedAudioRemovals {
+            try PendingCloudMutationStore.enqueue(
+                PendingCloudMutation(
+                    kind: .importedAudioRemoval,
+                    targetId: removal.recordingId,
+                    requestedAt: removal.requestedAt
+                ),
+                in: context
+            )
+        }
+    }
+
+    /// Removes attachment files after a successful database commit. No cloud
+    /// publication happens here; the outbox row is already durable.
+    func commit() {
+        for summary in summaries where summary.deleteAttachments {
             try? SummaryAttachmentStore.shared.deleteAll(for: summary.summaryId)
         }
     }
@@ -118,7 +187,7 @@ struct DeferredDeletionEffects {
     /// Removes the attachment files without publishing any tombstone, for local
     /// cleanup that every device derives independently.
     func commitLocalOnly() {
-        for summary in summaries {
+        for summary in summaries where summary.deleteAttachments {
             try? SummaryAttachmentStore.shared.deleteAll(for: summary.summaryId)
         }
     }
@@ -147,6 +216,7 @@ class CoreDataManager: ObservableObject {
         let resolvedPersistenceController = persistenceController ?? PersistenceController.shared
         self.persistenceController = resolvedPersistenceController
         self.context = resolvedPersistenceController.container.viewContext
+        _ = PendingCloudMutationStore.migrateLegacyQueuesIfNeeded(in: context)
     }
 
     // MARK: - Context Management
@@ -486,54 +556,63 @@ class CoreDataManager: ObservableObject {
     /// `enqueueCloudDeletion` is false when applying a marker that came from
     /// another device — see `deleteRecording(id:enqueueCloudDeletion:)`.
     func deleteTranscript(id: UUID?, enqueueCloudDeletion: Bool = true) throws {
-        guard let id else { return }
-
         do {
-            let fetchRequest: NSFetchRequest<TranscriptEntry> = TranscriptEntry.fetchRequest()
-            fetchRequest.predicate = NSPredicate(format: "id == %@", id as CVarArg)
-            let transcripts = try context.fetch(fetchRequest)
-            guard !transcripts.isEmpty else {
-                AppLog.shared.coreData("No transcript found with ID: \(id)", level: .debug)
-                return
-            }
-
-            // Only rows that point at *this* transcript. Matching on the parent
-            // recording instead would clear the link on a recording that has since
-            // moved to a newer transcript, which is exactly the id an iCloud
-            // deletion marker for a superseded duplicate carries.
-            let recordings = fetchRecordings(
-                matching: NSPredicate(format: "transcriptId == %@ OR transcript.id == %@", id as CVarArg, id as CVarArg)
-            )
-            for recording in recordings {
-                recording.transcript = nil
-                recording.transcriptId = nil
-                recording.transcriptionStatus = ProcessingStatus.notStarted.rawValue
-                recording.lastModified = Date()
-            }
-
-            let summaryEntries = fetchSummaries(
-                matching: NSPredicate(format: "transcriptId == %@ OR transcript.id == %@", id as CVarArg, id as CVarArg)
-            )
-            for summary in summaryEntries {
-                summary.transcript = nil
-                summary.transcriptId = nil
-            }
-
-            // Capture before deleting, and enqueue only after the save lands:
-            // a rollback below would otherwise leave a queued cloud removal for a
-            // transcript that still exists locally, and the next sync would delete
-            // the cloud copy and then reconcile the local row away.
             var effects = DeferredDeletionEffects()
-            transcripts.forEach {
-                effects.stage(transcript: $0)
-                context.delete($0)
-            }
+            guard try stageTranscriptDeletion(id: id, effects: &effects) else { return }
             try save(committing: effects, localOnly: !enqueueCloudDeletion)
-            AppLog.shared.coreData("Deleted transcript with ID: \(id)")
+            AppLog.shared.coreData("Deleted transcript with ID: \(id?.uuidString ?? "nil")")
         } catch {
             AppLog.shared.coreData("Error deleting transcript: \(error)", level: .error)
             throw error
         }
+    }
+
+    /// Stages a transcript deletion without saving. Compound user actions use
+    /// this to put every local edit and every corresponding outbox row in one
+    /// persistent transaction.
+    @discardableResult
+    func stageTranscriptDeletion(
+        id: UUID?,
+        effects: inout DeferredDeletionEffects,
+        requestedAt: Date = Date()
+    ) throws -> Bool {
+        guard let id else { return false }
+
+        let fetchRequest: NSFetchRequest<TranscriptEntry> = TranscriptEntry.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+        let transcripts = try context.fetch(fetchRequest)
+        guard !transcripts.isEmpty else {
+            AppLog.shared.coreData("No transcript found with ID: \(id)", level: .debug)
+            return false
+        }
+
+        // Only rows that point at *this* transcript. Matching on the parent
+        // recording instead would clear the link on a recording that has since
+        // moved to a newer transcript, which is exactly the id an iCloud
+        // deletion marker for a superseded duplicate carries.
+        let recordings = fetchRecordings(
+            matching: NSPredicate(format: "transcriptId == %@ OR transcript.id == %@", id as CVarArg, id as CVarArg)
+        )
+        for recording in recordings {
+            recording.transcript = nil
+            recording.transcriptId = nil
+            recording.transcriptionStatus = ProcessingStatus.notStarted.rawValue
+            recording.lastModified = requestedAt
+        }
+
+        let summaryEntries = fetchSummaries(
+            matching: NSPredicate(format: "transcriptId == %@ OR transcript.id == %@", id as CVarArg, id as CVarArg)
+        )
+        for summary in summaryEntries {
+            summary.transcript = nil
+            summary.transcriptId = nil
+        }
+
+        for transcript in transcripts {
+            effects.stage(transcript: transcript, requestedAt: requestedAt)
+            context.delete(transcript)
+        }
+        return true
     }
 
     // MARK: - Repair Operations
@@ -1291,11 +1370,14 @@ class CoreDataManager: ObservableObject {
         context.rollback()
     }
 
-    /// Saves, then runs `effects`. On failure the context rolls back and the
-    /// error propagates with nothing staged having run — which is the whole
-    /// point of staging. Every delete path goes through here.
-    private func save(committing effects: DeferredDeletionEffects, localOnly: Bool = false) throws {
+    /// Saves the local mutation and its cloud outbox rows as one transaction,
+    /// then runs only irreversible filesystem effects after that transaction
+    /// succeeds. Every user deletion path goes through here.
+    func save(committing effects: DeferredDeletionEffects, localOnly: Bool = false) throws {
         do {
+            if !localOnly {
+                try effects.stageCloudMutations(in: context)
+            }
             try context.save()
         } catch {
             context.rollback()
@@ -1795,9 +1877,19 @@ class CoreDataManager: ObservableObject {
 
         recording.isCloudSyncDisabled = disabled
         recording.lastModified = Date()
+        var effects = DeferredDeletionEffects()
+        if disabled {
+            effects.stageLocalOnlyRemoval(recordingId: recordingId)
+        } else {
+            try PendingCloudMutationStore.remove(
+                kind: .localOnlyRemoval,
+                targetId: recordingId,
+                from: context
+            )
+        }
 
         do {
-            try context.save()
+            try save(committing: effects)
             AppLog.shared.coreData("Updated iCloud exclusion for recording ID: \(recordingId)")
         } catch {
             AppLog.shared.coreData("Failed to save iCloud exclusion update: \(error)", level: .error)

--- a/BisonNotes AI/BisonNotes AI/Models/DataMigrationManager.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/DataMigrationManager.swift
@@ -501,9 +501,25 @@ class DataMigrationManager: ObservableObject {
     // MARK: - Utility Methods
 
     func clearAllCoreData() async {
-        let recordings = (try? context.fetch(RecordingEntry.fetchRequest())) ?? []
-        let transcripts = (try? context.fetch(TranscriptEntry.fetchRequest())) ?? []
-        let summaries = (try? context.fetch(SummaryEntry.fetchRequest())) ?? []
+        // Every entity is read before anything is staged, and a failure on any one
+        // of them abandons the whole clear. `try?` turned a transient fetch failure
+        // into an empty collection, so a clear could delete transcripts and
+        // summaries, tombstone them for every other device, leave the recordings
+        // behind, and still log success.
+        let recordings: [RecordingEntry]
+        let transcripts: [TranscriptEntry]
+        let summaries: [SummaryEntry]
+        do {
+            recordings = try context.fetch(RecordingEntry.fetchRequest())
+            transcripts = try context.fetch(TranscriptEntry.fetchRequest())
+            summaries = try context.fetch(SummaryEntry.fetchRequest())
+        } catch {
+            AppLog.shared.dataMigration(
+                "Could not read every entity to clear; nothing was deleted so the clear can be retried: \(error)",
+                level: .error
+            )
+            return
+        }
         let deletionDate = Date()
         var effects = DeferredDeletionEffects()
 

--- a/BisonNotes AI/BisonNotes AI/Models/DataMigrationManager.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/DataMigrationManager.swift
@@ -114,48 +114,12 @@ class DataMigrationManager: ObservableObject {
         }
     }
 
-    private var cloudDeletionManager: iCloudStorageManager {
-        configurediCloudStorageManager ?? iCloudStorageManager.shared
-    }
-
-    // MARK: - Deletion Markers
+    // MARK: - Deletion markers
     //
-    // A deletion marker is durable and says the *user* deleted something, so it
-    // travels to every device and outlives the row it describes. Only
-    // clearAllCoreData raises one from this file: the user asked for the store to
-    // be emptied, and without markers the next reconcile would restore it.
-    //
-    // Repair and de-duplication deliberately do not. A local file this device
-    // cannot see is not a deletion, an orphaned row is a local inconsistency, and
-    // CLAUDE.md is explicit that superseded duplicates are pruned "never with a
-    // tombstone, because every device derives the same winner from the same
-    // data". Publishing one from any of those would delete a healthy copy from
-    // every other device over a problem local to this one.
-
-    private func enqueueTranscriptDeletion(_ transcript: TranscriptEntry) {
-        guard let transcriptId = transcript.id else { return }
-        cloudDeletionManager.enqueueTranscriptRemovalFromiCloud(
-            transcriptId: transcriptId,
-            recordingId: transcript.recordingId ?? transcript.recording?.id
-        )
-    }
-
-    private func enqueueSummaryDeletion(_ summary: SummaryEntry) {
-        guard let summaryId = summary.id else { return }
-        cloudDeletionManager.enqueueSummaryRemovalFromiCloud(
-            summaryId: summaryId,
-            recordingId: summary.recordingId ?? summary.recording?.id
-        )
-    }
-
-    private func enqueueRecordingDeletion(_ recording: RecordingEntry, includingChildren: Bool = true) {
-        guard let recordingId = recording.id else { return }
-        cloudDeletionManager.enqueueRecordingDeletionForiCloud(
-            recordingId: recordingId,
-            transcriptIds: includingChildren ? [recording.transcriptId ?? recording.transcript?.id].compactMap { $0 } : [],
-            summaryIds: includingChildren ? [recording.summaryId ?? recording.summary?.id].compactMap { $0 } : []
-        )
-    }
+    // User-requested clearing uses the same transactional outbox as the normal
+    // deletion paths. Repair and de-duplication deliberately do not raise cloud
+    // markers: a local inconsistency is not evidence that another device's copy
+    // should be deleted.
 
     func performDataMigration() async {
         AppLog.shared.dataMigration("Starting data migration")
@@ -540,50 +504,39 @@ class DataMigrationManager: ObservableObject {
         let recordings = (try? context.fetch(RecordingEntry.fetchRequest())) ?? []
         let transcripts = (try? context.fetch(TranscriptEntry.fetchRequest())) ?? []
         let summaries = (try? context.fetch(SummaryEntry.fetchRequest())) ?? []
+        let deletionDate = Date()
+        var effects = DeferredDeletionEffects()
 
-        // Batch deletes bypass Core Data relationship callbacks, so the tombstones
-        // are raised here rather than through the usual delete paths. They are
-        // raised only once the store is actually empty: queueing first and then
-        // failing the delete would wipe iCloud while the local rows survived.
-        let entities = ["RecordingEntry", "TranscriptEntry", "SummaryEntry"]
-        var clearedEveryEntity = true
-
-        for entityName in entities {
-            let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
-            let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
-
-            do {
-                try context.execute(deleteRequest)
-                AppLog.shared.dataMigration("Cleared all \(entityName) entries")
-            } catch {
-                clearedEveryEntity = false
-                AppLog.shared.dataMigration("Error clearing \(entityName): \(error)", level: .error)
-            }
+        for recording in recordings {
+            effects.stage(recording: recording, requestedAt: deletionDate)
         }
+        for transcript in transcripts {
+            effects.stage(transcript: transcript, requestedAt: deletionDate)
+        }
+        for summary in summaries {
+            effects.stage(summary: summary, requestedAt: deletionDate)
+        }
+
+        // Regular context deletes keep the local rows and their outbox intents in
+        // the same SQLite transaction. A batch delete executes independently of
+        // the context save and would reopen the crash window this outbox closes.
+        transcripts.forEach { context.delete($0) }
+        summaries.forEach { context.delete($0) }
+        recordings.forEach { context.delete($0) }
 
         do {
-            try context.save()
-            AppLog.shared.dataMigration("Core Data cleared successfully")
-        } catch {
-            AppLog.shared.dataMigration("Error saving after clearing Core Data: \(error)", level: .error)
-            context.rollback()
-            return
-        }
-
-        guard clearedEveryEntity else {
+            let coreDataManager = CoreDataManager(persistenceController: persistenceController)
+            try coreDataManager.save(committing: effects)
             AppLog.shared.dataMigration(
-                "Store only partly cleared; withholding iCloud tombstones so a retry is still possible",
-                level: .error
+                "Cleared all Core Data entries and staged \(recordings.count) recording deletion marker(s)"
             )
+        } catch {
+            AppLog.shared.dataMigration("Error clearing Core Data and staging cloud removals: \(error)", level: .error)
             return
         }
 
-        recordings.forEach { enqueueRecordingDeletion($0) }
-        transcripts.forEach { enqueueTranscriptDeletion($0) }
-        summaries.forEach { enqueueSummaryDeletion($0) }
-
-        // The batch delete bypassed relationship callbacks, so every attachment
-        // folder is now unreachable.
+        // Every attachment folder is now unreachable; this also covers any
+        // duplicate rows that were not represented by the recording relationship.
         SummaryAttachmentStore.shared.pruneOrphans(against: context)
     }
 

--- a/BisonNotes AI/BisonNotes AI/Models/RecordingWorkflowManager.swift
+++ b/BisonNotes AI/BisonNotes AI/Models/RecordingWorkflowManager.swift
@@ -316,18 +316,19 @@ class RecordingWorkflowManager: ObservableObject {
                 // deletes the user's cloud copy — and their notes — for a summary
                 // that is still on the device.
                 let migratedSummaryId = existingSummaries.first?.id
-                var supersededSummaryIds: [UUID] = []
-                var attachmentFoldersToRemove: [UUID] = []
+                var effects = DeferredDeletionEffects()
                 var deletedCount = 0
 
                 for oldSummary in existingSummaries {
                     let oldId = oldSummary.id?.uuidString ?? "nil"
                     if let oldSummaryId = oldSummary.id {
-                        supersededSummaryIds.append(oldSummaryId)
-                        // Supplemental folders that were not migrated onto the new summary.
-                        if oldSummaryId != migratedSummaryId {
-                            attachmentFoldersToRemove.append(oldSummaryId)
-                        }
+                        // Keep the primary folder because its supplemental data was
+                        // migrated to the new summary. Other folders are removed only
+                        // after the row deletion and its outbox intent commit.
+                        effects.stage(
+                            summary: oldSummary,
+                            deleteAttachments: oldSummaryId != migratedSummaryId
+                        )
                     }
                     context.delete(oldSummary)
                     deletedCount += 1
@@ -336,28 +337,14 @@ class RecordingWorkflowManager: ObservableObject {
 
                 if deletedCount > 0 {
                     do {
-                        try context.save()
-
-                        // Committed: replacing a summary is still a deletion from the
-                        // sync graph, so raise durable tombstones now that the rows
-                        // are really gone and another device cannot restore them.
-                        let iCloudManager = SummaryManager.shared.getiCloudManager()
-                        for summaryId in supersededSummaryIds {
-                            iCloudManager.enqueueSummaryRemovalFromiCloud(
-                                summaryId: summaryId,
-                                recordingId: recordingId
-                            )
-                        }
-                        for summaryId in attachmentFoldersToRemove {
-                            try? SummaryAttachmentStore.shared.deleteAll(for: summaryId)
-                        }
+                        let coreDataManager = appCoordinator?.coreDataManager
+                            ?? CoreDataManager(persistenceController: persistenceController)
+                        try coreDataManager.save(committing: effects)
 
                         AppLog.shared.backgroundProcessing("Cleaned up \(deletedCount) old summary(ies) for recording \(recordingId)", level: .debug)
                     } catch {
-                        // The old rows are still here. Discard the pending deletions so
-                        // a later unrelated save cannot commit them without tombstones,
-                        // and leave the cloud copies alone so the two stay in step.
-                        context.rollback()
+                        // The old rows and their outbox intents roll back together,
+                        // leaving the cloud copies and local rows in step.
                         AppLog.shared.backgroundProcessing(
                             "Failed to clean up \(deletedCount) old summary(ies) for recording \(recordingId); " +
                             "keeping them locally and in iCloud: \(error)",

--- a/BisonNotes AI/BisonNotes AI/Persistence.swift
+++ b/BisonNotes AI/BisonNotes AI/Persistence.swift
@@ -7,6 +7,436 @@
 
 import CoreData
 
+// MARK: - Durable Cloud Mutation Outbox
+
+/// The five kinds of cloud removal work that used to live in separate
+/// UserDefaults arrays. They deliberately stay distinct at the sync boundary,
+/// while sharing one Core Data entity so local content deletion and its durable
+/// cloud intent can commit in one SQLite transaction.
+enum PendingCloudMutationKind: String, CaseIterable {
+    case recordingDeletion
+    case localOnlyRemoval
+    case summaryRemoval
+    case transcriptRemoval
+    case importedAudioRemoval
+}
+
+struct PendingCloudMutation: Equatable {
+    let kind: PendingCloudMutationKind
+    let targetId: UUID
+    var recordingId: UUID?
+    var transcriptIds: [UUID]
+    var summaryIds: [UUID]
+    var requestedAt: Date
+
+    init(
+        kind: PendingCloudMutationKind,
+        targetId: UUID,
+        recordingId: UUID? = nil,
+        transcriptIds: [UUID] = [],
+        summaryIds: [UUID] = [],
+        requestedAt: Date
+    ) {
+        self.kind = kind
+        self.targetId = targetId
+        self.recordingId = recordingId
+        self.transcriptIds = Array(Set(transcriptIds)).sorted { $0.uuidString < $1.uuidString }
+        self.summaryIds = Array(Set(summaryIds)).sorted { $0.uuidString < $1.uuidString }
+        self.requestedAt = requestedAt
+    }
+}
+
+enum PendingCloudMutationStoreError: LocalizedError {
+    case invalidRow(String)
+    case invalidPayload(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidRow(let detail):
+            return "Pending cloud mutation row is invalid: \(detail)"
+        case .invalidPayload(let detail):
+            return "Pending cloud mutation payload is invalid: \(detail)"
+        }
+    }
+}
+
+/// Persistence and migration for the durable cloud-removal outbox.
+///
+/// This type intentionally works with `NSManagedObject` rather than generated
+/// model classes. The entity is internal bookkeeping, and using KVC keeps the
+/// model version migration independent of Xcode's code-generation mode.
+enum PendingCloudMutationStore {
+    static let entityName = "PendingCloudMutation"
+    static let payloadVersion: Int32 = 1
+
+    private static let legacyDeletionMarkersKey = "iCloudPendingDeletionMarkersV1"
+    private static let legacyLocalOnlyRemovalsKey = "iCloudPendingLocalOnlyRemovalsV1"
+    private static let legacySummaryRemovalsKey = "iCloudPendingSummaryRemovalsV1"
+    private static let legacyTranscriptRemovalsKey = "iCloudPendingTranscriptRemovalsV1"
+    private static let legacyImportedAudioRemovalsKey = "iCloudPendingImportedAudioRemovalsV1"
+
+    private struct Payload: Codable, Equatable {
+        var transcriptIds: [UUID]
+        var summaryIds: [UUID]
+    }
+
+    private struct LegacyDeletionMarker: Codable {
+        let recordingId: UUID
+        var transcriptIds: [UUID]
+        var summaryIds: [UUID]
+        let requestedAt: Date
+    }
+
+    private struct LegacyLocalOnlyRemoval: Codable {
+        let recordingId: UUID
+        let requestedAt: Date
+    }
+
+    private struct LegacySummaryRemoval: Codable {
+        let summaryId: UUID
+        var recordingId: UUID?
+        let requestedAt: Date
+    }
+
+    private struct LegacyTranscriptRemoval: Codable {
+        let transcriptId: UUID
+        var recordingId: UUID?
+        let requestedAt: Date
+    }
+
+    private struct LegacyImportedAudioRemoval: Codable {
+        let recordingId: UUID
+        let requestedAt: Date
+    }
+
+    /// Merges a mutation into the row with the same kind and target identity.
+    /// The earliest request time is load-bearing for cross-device arbitration.
+    static func enqueue(_ mutation: PendingCloudMutation, in context: NSManagedObjectContext) throws {
+        let matches = try matchingObjects(for: mutation, in: context)
+        var merged = mutation
+
+        for object in matches {
+            let existing = try decode(object)
+            merged.requestedAt = min(merged.requestedAt, existing.requestedAt)
+            if merged.recordingId == nil {
+                merged.recordingId = existing.recordingId
+            }
+            merged.transcriptIds = Array(
+                Set(merged.transcriptIds + existing.transcriptIds)
+            ).sorted { $0.uuidString < $1.uuidString }
+            merged.summaryIds = Array(
+                Set(merged.summaryIds + existing.summaryIds)
+            ).sorted { $0.uuidString < $1.uuidString }
+        }
+
+        let object = matches.first
+            ?? NSEntityDescription.insertNewObject(forEntityName: entityName, into: context)
+        try write(merged, to: object)
+
+        for duplicate in matches.dropFirst() {
+            context.delete(duplicate)
+        }
+    }
+
+    static func fetchAll(in context: NSManagedObjectContext) throws -> [PendingCloudMutation] {
+        let request = NSFetchRequest<NSManagedObject>(entityName: entityName)
+        request.sortDescriptors = [NSSortDescriptor(key: "requestedAt", ascending: true)]
+        return try context.fetch(request).map(decode)
+    }
+
+    /// Removes only rows that still equal the snapshot sent to CloudKit. A
+    /// changed payload or relationship id stays queued for the next replay.
+    @discardableResult
+    static func removeIfUnchanged(
+        _ snapshot: PendingCloudMutation,
+        from context: NSManagedObjectContext
+    ) throws -> Bool {
+        let matches = try matchingObjects(for: snapshot, in: context)
+        var removed = false
+        for object in matches where try decode(object) == snapshot {
+            context.delete(object)
+            removed = true
+        }
+        return removed
+    }
+
+    static func removeAll(in context: NSManagedObjectContext) throws {
+        let request = NSFetchRequest<NSManagedObject>(entityName: entityName)
+        for object in try context.fetch(request) {
+            context.delete(object)
+        }
+        if context.hasChanges {
+            try context.save()
+        }
+    }
+
+    static func remove(
+        kind: PendingCloudMutationKind,
+        targetId: UUID,
+        from context: NSManagedObjectContext
+    ) throws {
+        let request = NSFetchRequest<NSManagedObject>(entityName: entityName)
+        request.predicate = NSPredicate(
+            format: "kind == %@ AND targetId == %@",
+            kind.rawValue,
+            targetId as CVarArg
+        )
+        for object in try context.fetch(request) {
+            context.delete(object)
+        }
+    }
+
+    static func removeAll(
+        kind: PendingCloudMutationKind,
+        from context: NSManagedObjectContext
+    ) throws {
+        let request = NSFetchRequest<NSManagedObject>(entityName: entityName)
+        request.predicate = NSPredicate(format: "kind == %@", kind.rawValue)
+        for object in try context.fetch(request) {
+            context.delete(object)
+        }
+    }
+
+    static func count(in context: NSManagedObjectContext) -> Int {
+        let request = NSFetchRequest<NSManagedObject>(entityName: entityName)
+        request.resultType = .countResultType
+        return (try? context.count(for: request)) ?? 0
+    }
+
+    /// Migrates each legacy queue independently. A malformed queue is left in
+    /// UserDefaults, while valid queues can still be moved in the same save.
+    /// The caller should invoke this before starting normal edits on a context.
+    @discardableResult
+    static func migrateLegacyQueuesIfNeeded(
+        in context: NSManagedObjectContext,
+        defaults: UserDefaults = .standard
+    ) -> Bool {
+        guard !context.hasChanges else {
+            AppLog.shared.coreData(
+                "Deferred pending iCloud mutation migration until the Core Data context is clean",
+                level: .debug
+            )
+            return false
+        }
+
+        var keysToClear: [String] = []
+        var migratedAny = false
+
+        if let data = defaults.data(forKey: legacyDeletionMarkersKey) {
+            do {
+                let entries = try JSONDecoder().decode([LegacyDeletionMarker].self, from: data)
+                for entry in entries {
+                    try enqueue(
+                        PendingCloudMutation(
+                            kind: .recordingDeletion,
+                            targetId: entry.recordingId,
+                            transcriptIds: entry.transcriptIds,
+                            summaryIds: entry.summaryIds,
+                            requestedAt: entry.requestedAt
+                        ),
+                        in: context
+                    )
+                }
+                keysToClear.append(legacyDeletionMarkersKey)
+                migratedAny = migratedAny || !entries.isEmpty
+            } catch {
+                AppLog.shared.coreData(
+                    "Could not migrate pending recording deletions; retaining the legacy queue: \(error)",
+                    level: .error
+                )
+            }
+        }
+
+        if let data = defaults.data(forKey: legacyLocalOnlyRemovalsKey) {
+            do {
+                let entries = try JSONDecoder().decode([LegacyLocalOnlyRemoval].self, from: data)
+                for entry in entries {
+                    try enqueue(
+                        PendingCloudMutation(
+                            kind: .localOnlyRemoval,
+                            targetId: entry.recordingId,
+                            requestedAt: entry.requestedAt
+                        ),
+                        in: context
+                    )
+                }
+                keysToClear.append(legacyLocalOnlyRemovalsKey)
+                migratedAny = migratedAny || !entries.isEmpty
+            } catch {
+                AppLog.shared.coreData(
+                    "Could not migrate pending local-only removals; retaining the legacy queue: \(error)",
+                    level: .error
+                )
+            }
+        }
+
+        if let data = defaults.data(forKey: legacySummaryRemovalsKey) {
+            do {
+                let entries = try JSONDecoder().decode([LegacySummaryRemoval].self, from: data)
+                for entry in entries {
+                    try enqueue(
+                        PendingCloudMutation(
+                            kind: .summaryRemoval,
+                            targetId: entry.summaryId,
+                            recordingId: entry.recordingId,
+                            requestedAt: entry.requestedAt
+                        ),
+                        in: context
+                    )
+                }
+                keysToClear.append(legacySummaryRemovalsKey)
+                migratedAny = migratedAny || !entries.isEmpty
+            } catch {
+                AppLog.shared.coreData(
+                    "Could not migrate pending summary removals; retaining the legacy queue: \(error)",
+                    level: .error
+                )
+            }
+        }
+
+        if let data = defaults.data(forKey: legacyTranscriptRemovalsKey) {
+            do {
+                let entries = try JSONDecoder().decode([LegacyTranscriptRemoval].self, from: data)
+                for entry in entries {
+                    try enqueue(
+                        PendingCloudMutation(
+                            kind: .transcriptRemoval,
+                            targetId: entry.transcriptId,
+                            recordingId: entry.recordingId,
+                            requestedAt: entry.requestedAt
+                        ),
+                        in: context
+                    )
+                }
+                keysToClear.append(legacyTranscriptRemovalsKey)
+                migratedAny = migratedAny || !entries.isEmpty
+            } catch {
+                AppLog.shared.coreData(
+                    "Could not migrate pending transcript removals; retaining the legacy queue: \(error)",
+                    level: .error
+                )
+            }
+        }
+
+        if let data = defaults.data(forKey: legacyImportedAudioRemovalsKey) {
+            do {
+                let entries = try JSONDecoder().decode([LegacyImportedAudioRemoval].self, from: data)
+                for entry in entries {
+                    try enqueue(
+                        PendingCloudMutation(
+                            kind: .importedAudioRemoval,
+                            targetId: entry.recordingId,
+                            requestedAt: entry.requestedAt
+                        ),
+                        in: context
+                    )
+                }
+                keysToClear.append(legacyImportedAudioRemovalsKey)
+                migratedAny = migratedAny || !entries.isEmpty
+            } catch {
+                AppLog.shared.coreData(
+                    "Could not migrate pending imported-audio removals; retaining the legacy queue: \(error)",
+                    level: .error
+                )
+            }
+        }
+
+        guard !keysToClear.isEmpty else { return migratedAny }
+
+        do {
+            if context.hasChanges {
+                try context.save()
+            }
+            for key in keysToClear {
+                defaults.removeObject(forKey: key)
+            }
+            return migratedAny
+        } catch {
+            context.rollback()
+            AppLog.shared.coreData(
+                "Could not commit pending iCloud mutation migration; legacy queues were retained: \(error)",
+                level: .error
+            )
+            return false
+        }
+    }
+
+    private static func matchingObjects(
+        for mutation: PendingCloudMutation,
+        in context: NSManagedObjectContext
+    ) throws -> [NSManagedObject] {
+        let request = NSFetchRequest<NSManagedObject>(entityName: entityName)
+        request.predicate = NSPredicate(
+            format: "kind == %@ AND targetId == %@",
+            mutation.kind.rawValue,
+            mutation.targetId as CVarArg
+        )
+        request.sortDescriptors = [NSSortDescriptor(key: "requestedAt", ascending: true)]
+        return try context.fetch(request)
+    }
+
+    private static func write(
+        _ mutation: PendingCloudMutation,
+        to object: NSManagedObject
+    ) throws {
+        let payload = Payload(
+            transcriptIds: mutation.transcriptIds,
+            summaryIds: mutation.summaryIds
+        )
+        let payloadData: Data
+        do {
+            payloadData = try JSONEncoder().encode(payload)
+        } catch {
+            throw PendingCloudMutationStoreError.invalidPayload(error.localizedDescription)
+        }
+
+        object.setValue(mutation.kind.rawValue, forKey: "kind")
+        object.setValue(mutation.targetId, forKey: "targetId")
+        object.setValue(mutation.recordingId, forKey: "recordingId")
+        object.setValue(mutation.requestedAt, forKey: "requestedAt")
+        object.setValue(payloadData, forKey: "payload")
+        object.setValue(payloadVersion, forKey: "version")
+    }
+
+    private static func decode(_ object: NSManagedObject) throws -> PendingCloudMutation {
+        guard let rawKind = object.value(forKey: "kind") as? String,
+              let kind = PendingCloudMutationKind(rawValue: rawKind) else {
+            throw PendingCloudMutationStoreError.invalidRow("unknown mutation kind")
+        }
+        guard let targetId = object.value(forKey: "targetId") as? UUID else {
+            throw PendingCloudMutationStoreError.invalidRow("missing target identity")
+        }
+        guard let requestedAt = object.value(forKey: "requestedAt") as? Date else {
+            throw PendingCloudMutationStoreError.invalidRow("missing requestedAt")
+        }
+
+        let version = (object.value(forKey: "version") as? NSNumber)?.int32Value ?? 0
+        guard version == payloadVersion else {
+            throw PendingCloudMutationStoreError.invalidPayload("unsupported payload version \(version)")
+        }
+
+        let payload: Payload
+        if let data = object.value(forKey: "payload") as? Data {
+            do {
+                payload = try JSONDecoder().decode(Payload.self, from: data)
+            } catch {
+                throw PendingCloudMutationStoreError.invalidPayload(error.localizedDescription)
+            }
+        } else {
+            payload = Payload(transcriptIds: [], summaryIds: [])
+        }
+
+        return PendingCloudMutation(
+            kind: kind,
+            targetId: targetId,
+            recordingId: object.value(forKey: "recordingId") as? UUID,
+            transcriptIds: payload.transcriptIds,
+            summaryIds: payload.summaryIds,
+            requestedAt: requestedAt
+        )
+    }
+}
+
 struct PersistenceController {
     /// Core Data's container and view context are confined to the main actor.
     /// The shared controller is only used to construct the main-actor data
@@ -30,9 +460,11 @@ struct PersistenceController {
 
     let container: NSPersistentContainer
 
-    init(inMemory: Bool = false) {
+    init(inMemory: Bool = false, storeURL: URL? = nil) {
         let persistentContainer = NSPersistentContainer(name: "BisonNotes_AI")
-        if inMemory {
+        if let storeURL {
+            persistentContainer.persistentStoreDescriptions.first?.url = storeURL
+        } else if inMemory {
             persistentContainer.persistentStoreDescriptions.first!.url = URL(fileURLWithPath: "/dev/null")
         }
         persistentContainer.persistentStoreDescriptions.forEach { description in

--- a/BisonNotes AI/BisonNotes AI/Persistence.swift
+++ b/BisonNotes AI/BisonNotes AI/Persistence.swift
@@ -75,6 +75,20 @@ enum PendingCloudMutationStore {
     private static let legacyTranscriptRemovalsKey = "iCloudPendingTranscriptRemovalsV1"
     private static let legacyImportedAudioRemovalsKey = "iCloudPendingImportedAudioRemovalsV1"
 
+    static let legacyQueueKeys = [
+        legacyDeletionMarkersKey,
+        legacyLocalOnlyRemovalsKey,
+        legacySummaryRemovalsKey,
+        legacyTranscriptRemovalsKey,
+        legacyImportedAudioRemovalsKey
+    ]
+
+    /// Cheap enough to sit in front of every outbox read: once the upgrade has
+    /// happened, none of these keys exist and no context is built at all.
+    static func hasLegacyQueues(in defaults: UserDefaults = .standard) -> Bool {
+        legacyQueueKeys.contains { defaults.object(forKey: $0) != nil }
+    }
+
     private struct Payload: Codable, Equatable {
         var transcriptIds: [UUID]
         var summaryIds: [UUID]
@@ -160,13 +174,12 @@ enum PendingCloudMutationStore {
         return removed
     }
 
+    /// Stages the removal without saving, like `remove` and `enqueue`, so the
+    /// caller decides which transaction it belongs to.
     static func removeAll(in context: NSManagedObjectContext) throws {
         let request = NSFetchRequest<NSManagedObject>(entityName: entityName)
         for object in try context.fetch(request) {
             context.delete(object)
-        }
-        if context.hasChanges {
-            try context.save()
         }
     }
 
@@ -203,18 +216,42 @@ enum PendingCloudMutationStore {
         return (try? context.count(for: request)) ?? 0
     }
 
+    /// A context that touches nothing but this entity, on the same store as
+    /// `context`.
+    ///
+    /// Every write here is the outbox's alone, so saving one can neither commit
+    /// an unrelated caller's staged edits nor — on failure — roll them away.
+    /// `viewContext.automaticallyMergesChangesFromParent` carries the result back
+    /// to the UI context, and reads go to the store, so rows staged transactionally
+    /// with a deletion are still seen once that deletion commits.
+    static func makeIsolatedContext(basedOn context: NSManagedObjectContext) -> NSManagedObjectContext? {
+        guard let coordinator = context.persistentStoreCoordinator else { return nil }
+        let isolated = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+        isolated.persistentStoreCoordinator = coordinator
+        // Never let a stale registered object answer for a row another context
+        // has since changed in the store.
+        isolated.stalenessInterval = 0
+        isolated.mergePolicy = NSMergePolicy(merge: .mergeByPropertyStoreTrumpMergePolicyType)
+        return isolated
+    }
+
     /// Migrates each legacy queue independently. A malformed queue is left in
     /// UserDefaults, while valid queues can still be moved in the same save.
-    /// The caller should invoke this before starting normal edits on a context.
+    ///
+    /// The work runs on an isolated context rather than the caller's. Bailing out
+    /// when the caller's context was dirty meant a migration could be skipped
+    /// silently — `fetchAll` then reported an empty outbox, and a flush walked zero
+    /// of the user's pre-upgrade tombstones while reporting success.
     @discardableResult
     static func migrateLegacyQueuesIfNeeded(
-        in context: NSManagedObjectContext,
+        in callerContext: NSManagedObjectContext,
         defaults: UserDefaults = .standard
     ) -> Bool {
-        guard !context.hasChanges else {
+        guard hasLegacyQueues(in: defaults) else { return false }
+        guard let context = makeIsolatedContext(basedOn: callerContext) else {
             AppLog.shared.coreData(
-                "Deferred pending iCloud mutation migration until the Core Data context is clean",
-                level: .debug
+                "Could not migrate pending iCloud mutations: the context has no persistent store coordinator",
+                level: .error
             )
             return false
         }

--- a/BisonNotes AI/BisonNotes AI/Services/CacheMaintenanceService.swift
+++ b/BisonNotes AI/BisonNotes AI/Services/CacheMaintenanceService.swift
@@ -211,6 +211,9 @@ struct CacheMaintenanceReport: Equatable, Sendable {
     var cloudKitAssetBytes: Int64 = 0
     var cloudKitAssetCount = 0
     var removedDirectoryCount = 0
+    /// A sync or download arrived while the sweep was in progress. The caller
+    /// should make the next scheduled opportunity eligible again.
+    var didYieldToActiveWork = false
 
     var reclaimedBytes: Int64 {
         duplicateModelBlobBytes + orphanedModelBlobBytes + cloudKitAssetBytes
@@ -250,11 +253,15 @@ final class CacheMaintenanceService {
     func pruneCachesIfDue(now: Date = Date()) {
         if let lastSweep, now.timeIntervalSince(lastSweep) < Self.sweepInterval { return }
 
-        // Reserve the shared Hub cache before leaving the main actor: no sweep may
-        // start while a download is running or still unwinding, and two sweeps may
-        // never overlap. What protects a download that starts *during* a sweep is
-        // the per-deletion re-check below, not this reservation.
-        guard MLXSwiftDownloadManager.shared.beginCacheMaintenance() else { return }
+        // Reserve both shared resources before leaving the main actor. A new
+        // CloudKit run and a new Hub download wait for this reservation to release;
+        // either one can still request a prompt cooperative yield.
+        let cloudCoordinator = SummaryManager.shared.getiCloudManager().operationCoordinator
+        guard cloudCoordinator.beginCacheMaintenance() else { return }
+        guard MLXSwiftDownloadManager.shared.beginCacheMaintenance() else {
+            cloudCoordinator.endCacheMaintenance()
+            return
+        }
         lastSweep = now
 
         Task.detached(priority: .utility) {
@@ -268,15 +275,27 @@ final class CacheMaintenanceService {
                 },
                 isCloudSyncActive: {
                     await MainActor.run {
-                        SummaryManager.shared.getiCloudManager().operationCoordinator.isRunning
+                        let coordinator = SummaryManager.shared.getiCloudManager().operationCoordinator
+                        return coordinator.isRunning
+                    }
+                },
+                shouldYield: {
+                    await MainActor.run {
+                        let coordinator = SummaryManager.shared.getiCloudManager().operationCoordinator
+                        return coordinator.shouldYieldCacheMaintenance ||
+                            MLXSwiftDownloadManager.shared.shouldYieldCacheMaintenance
                     }
                 }
             )
-            // Released on its own, before anything that can return early: a
-            // reservation left behind blocks every later sweep for the life of
-            // the process.
-            await MainActor.run { MLXSwiftDownloadManager.shared.endCacheMaintenance() }
             await MainActor.run {
+                // A reservation left behind blocks every later sweep for the life
+                // of the process. If work arrived mid-pass, retry the sweep at the
+                // next lifecycle opportunity instead of charging the full interval.
+                if report.didYieldToActiveWork {
+                    self.lastSweep = nil
+                }
+                SummaryManager.shared.getiCloudManager().operationCoordinator.endCacheMaintenance()
+                MLXSwiftDownloadManager.shared.endCacheMaintenance()
                 guard report.didReclaimAnything else { return }
                 AppLog.shared.fileManagement(
                     "Cache maintenance reclaimed \(report.formattedReclaimedBytes) — "
@@ -316,11 +335,21 @@ struct CacheMaintenanceSweep {
     ///   yet takes that recording's audio with it.
     func run(
         isDownloadInFlight: @Sendable () async -> Bool,
-        isCloudSyncActive: @Sendable () async -> Bool
+        isCloudSyncActive: @Sendable () async -> Bool,
+        shouldYield: @Sendable () async -> Bool = { false }
     ) async -> CacheMaintenanceReport {
         var report = CacheMaintenanceReport()
-        await pruneHuggingFaceBlobCache(into: &report, isDownloadInFlight: isDownloadInFlight)
-        await pruneCloudKitAssetCache(into: &report, isCloudSyncActive: isCloudSyncActive)
+        await pruneHuggingFaceBlobCache(
+            into: &report,
+            isDownloadInFlight: isDownloadInFlight,
+            shouldYield: shouldYield
+        )
+        if report.didYieldToActiveWork { return report }
+        await pruneCloudKitAssetCache(
+            into: &report,
+            isCloudSyncActive: isCloudSyncActive,
+            shouldYield: shouldYield
+        )
         return report
     }
 
@@ -348,7 +377,8 @@ struct CacheMaintenanceSweep {
 
     private func pruneHuggingFaceBlobCache(
         into report: inout CacheMaintenanceReport,
-        isDownloadInFlight: @Sendable () async -> Bool
+        isDownloadInFlight: @Sendable () async -> Bool,
+        shouldYield: @Sendable () async -> Bool
     ) async {
         guard let hubCacheRoot, let materializedModelsRoot else { return }
 
@@ -379,6 +409,10 @@ struct CacheMaintenanceSweep {
             // single reading taken before the sweep goes stale the moment it is used.
             let size = directorySize(directory)
 
+            if await shouldYield() {
+                report.didYieldToActiveWork = true
+                return
+            }
             guard let reason = CacheMaintenancePolicy.hubPruneReason(
                 directoryName: directory.lastPathComponent,
                 installedModelIDs: installed,
@@ -474,7 +508,8 @@ struct CacheMaintenanceSweep {
 
     private func pruneCloudKitAssetCache(
         into report: inout CacheMaintenanceReport,
-        isCloudSyncActive: @Sendable () async -> Bool
+        isCloudSyncActive: @Sendable () async -> Bool,
+        shouldYield: @Sendable () async -> Bool
     ) async {
         guard let cachesRoot else { return }
         let cloudKitRoot = cachesRoot.appendingPathComponent("CloudKit", isDirectory: true)
@@ -514,6 +549,10 @@ struct CacheMaintenanceSweep {
                 // nothing is removed while a sync runs either way, but a sync that
                 // finishes part way through must not cost this pass the rest of the
                 // cache — and the containers behind this one with it.
+                if await shouldYield() {
+                    report.didYieldToActiveWork = true
+                    return
+                }
                 if await isCloudSyncActive() { continue }
                 do {
                     try fileManager.removeItem(at: url)

--- a/BisonNotes AI/BisonNotes AI/Services/CloudAudioAssetStaging.swift
+++ b/BisonNotes AI/BisonNotes AI/Services/CloudAudioAssetStaging.swift
@@ -27,6 +27,10 @@ enum CloudAudioAssetDecision: Equatable {
     /// This run has staged as much as it may hold. Metadata uploads and the audio
     /// stays owed, exactly as a failed copy leaves it.
     case deferredOverStagingBudget
+    /// The volume reports that the complete staged set would exceed the space
+    /// available right now. This is distinct from the per-run policy budget so
+    /// callers can explain a real disk-space shortage and retry after recovery.
+    case deferredInsufficientSpace(requiredBytes: Int64, availableBytes: Int64)
     case upload(byteCount: Int64, signature: String)
 
     var uploads: Bool {
@@ -61,6 +65,8 @@ enum CloudAudioAssetPolicy {
     ///   - cloudSignature: signature stored on the existing cloud record.
     ///   - stagedBytesSoFar: what this run has already copied into staging.
     ///   - stagingByteBudget: the peak this run may hold, from `stagingByteBudget(availableCapacity:)`.
+    ///   - availableCapacity: current free capacity for the staging volume, when
+    ///     the platform can report it. Negative and nil values mean unknown.
     static func decide(
         includeAudioFiles: Bool,
         sourceExists: Bool,
@@ -68,12 +74,21 @@ enum CloudAudioAssetPolicy {
         cloudSignature: String?,
         byteCount: Int64,
         stagedBytesSoFar: Int64 = 0,
-        stagingByteBudget: Int64 = maximumStagingByteBudget
+        stagingByteBudget: Int64 = maximumStagingByteBudget,
+        availableCapacity: Int64? = nil
     ) -> CloudAudioAssetDecision {
         guard includeAudioFiles else { return .skippedDisabled }
         guard sourceExists, let localSignature else { return .skippedMissingSource }
         // An unchanged file is never copied, so it never spends the budget.
         guard localSignature != cloudSignature else { return .skippedUnchanged }
+        let requiredBytes = max(0, stagedBytesSoFar) &+ max(0, byteCount)
+        if let availableCapacity, availableCapacity >= 0,
+           requiredBytes > availableCapacity {
+            return .deferredInsufficientSpace(
+                requiredBytes: requiredBytes,
+                availableBytes: availableCapacity
+            )
+        }
         // The first file of a run always goes, however large. Deferring it on size
         // alone would strand a recording bigger than the budget forever, and one
         // copy is the smallest peak that makes any progress at all.

--- a/BisonNotes AI/BisonNotes AI/Services/CloudSyncOperationCoordinator.swift
+++ b/BisonNotes AI/BisonNotes AI/Services/CloudSyncOperationCoordinator.swift
@@ -140,6 +140,13 @@ final class CloudSyncOperationCoordinator {
     private var cacheMaintenanceYieldRequested = false
     private let cacheMaintenancePollNanoseconds: UInt64 = 25_000_000
 
+    /// Identifies each run so a joiner can wait for *its* run rather than for the
+    /// queue to fall idle. Runs are strictly sequential, so "run N has finished"
+    /// is `finishedRunID >= N`.
+    private var nextRunID = 0
+    private var currentRunID = -1
+    private var finishedRunID = -1
+
     var isRunning: Bool { currentTask != nil }
     var hasPendingFollowUp: Bool { !pending.isEmpty }
     /// Distinct jobs waiting. Equivalent requests collapse, independent ones do not.
@@ -208,7 +215,7 @@ final class CloudSyncOperationCoordinator {
 
         if allowJoiningRunningOperation, coalescesWithEquivalentRequests, running.subsumes(intent) {
             // If the run we are riding on fails, this request failed with it.
-            try await waitForCurrentRunToFinish(currentTask)
+            try await waitForRunToFinish(currentRunID, task: currentTask)
             return .joinedRunningOperation(running)
         }
 
@@ -256,8 +263,17 @@ final class CloudSyncOperationCoordinator {
         return ranOwnWork ? .completed : .coalescedIntoFollowUp(coalescedInto)
     }
 
-    private func waitForCurrentRunToFinish(_ task: Task<Void, any Error>) async throws {
-        while self.currentTask != nil {
+    /// Waits for one specific run, then reports its result.
+    ///
+    /// Deliberately keyed on `runID` rather than on `currentTask != nil`: follow-up
+    /// work can claim the slot in the same main-actor turn the joined run releases
+    /// it, so a poller watching the shared handle never observes the idle window
+    /// and ends up waiting for the whole queue to drain instead of for the run it
+    /// actually joined. Polling — rather than awaiting `task.value` directly — is
+    /// what lets a cancelled joiner leave while the run continues for its other
+    /// callers.
+    private func waitForRunToFinish(_ runID: Int, task: Task<Void, any Error>) async throws {
+        while finishedRunID < runID {
             try await Task.sleep(nanoseconds: cacheMaintenancePollNanoseconds)
         }
         try await task.value
@@ -321,19 +337,28 @@ final class CloudSyncOperationCoordinator {
         let task = Task { @MainActor in
             try await work()
         }
+        let runID = nextRunID
+        nextRunID += 1
+        currentRunID = runID
         currentTask = task
         runningIntent = intent
 
         do {
             try await task.value
         } catch {
-            finishRun(intent: intent, satisfying: waiters, error: error)
+            finishRun(runID, intent: intent, satisfying: waiters, error: error)
             throw error
         }
-        finishRun(intent: intent, satisfying: waiters, error: nil)
+        finishRun(runID, intent: intent, satisfying: waiters, error: nil)
     }
 
-    private func finishRun(intent: CloudSyncIntent, satisfying waiters: Set<Int>, error: (any Error)?) {
+    private func finishRun(
+        _ runID: Int,
+        intent: CloudSyncIntent,
+        satisfying waiters: Set<Int>,
+        error: (any Error)?
+    ) {
+        finishedRunID = max(finishedRunID, runID)
         currentTask = nil
         runningIntent = nil
         completedRunCount += 1

--- a/BisonNotes AI/BisonNotes AI/Services/CloudSyncOperationCoordinator.swift
+++ b/BisonNotes AI/BisonNotes AI/Services/CloudSyncOperationCoordinator.swift
@@ -136,10 +136,44 @@ final class CloudSyncOperationCoordinator {
     private var failuresByWaiter: [Int: any Error] = [:]
     private var nextWaiterID = 0
 
+    private var isCacheMaintenanceInProgress = false
+    private var cacheMaintenanceYieldRequested = false
+    private let cacheMaintenancePollNanoseconds: UInt64 = 25_000_000
+
     var isRunning: Bool { currentTask != nil }
     var hasPendingFollowUp: Bool { !pending.isEmpty }
     /// Distinct jobs waiting. Equivalent requests collapse, independent ones do not.
     var pendingFollowUpCount: Int { pending.count }
+
+    /// Reserves the CloudKit side of the cache-maintenance exclusion. The sweep
+    /// runs off the main actor, so this reservation keeps a new sync from starting
+    /// while the filesystem pass is deleting assets.
+    @discardableResult
+    func beginCacheMaintenance() -> Bool {
+        guard currentTask == nil, pending.isEmpty, !isCacheMaintenanceInProgress else {
+            return false
+        }
+        isCacheMaintenanceInProgress = true
+        cacheMaintenanceYieldRequested = false
+        return true
+    }
+
+    /// A sync or deletion request that arrives during the sweep asks it to stop
+    /// at its next per-cache-item checkpoint, then waits for the reservation to
+    /// release before starting its own CloudKit work.
+    func requestCacheMaintenanceYield() {
+        guard isCacheMaintenanceInProgress else { return }
+        cacheMaintenanceYieldRequested = true
+    }
+
+    var shouldYieldCacheMaintenance: Bool {
+        cacheMaintenanceYieldRequested
+    }
+
+    func endCacheMaintenance() {
+        isCacheMaintenanceInProgress = false
+        cacheMaintenanceYieldRequested = false
+    }
 
     /// Submits work, waiting until either it or the run that covers it has finished.
     ///
@@ -159,6 +193,14 @@ final class CloudSyncOperationCoordinator {
         coalescesWithEquivalentRequests: Bool = true,
         work: @escaping Work
     ) async throws -> CloudSyncRunOutcome {
+        try Task.checkCancellation()
+        while isCacheMaintenanceInProgress {
+            requestCacheMaintenanceYield()
+            try await Task.sleep(nanoseconds: cacheMaintenancePollNanoseconds)
+            try Task.checkCancellation()
+        }
+        try Task.checkCancellation()
+
         guard let running = runningIntent, let currentTask else {
             try await run(intent: intent, work: work)
             return .completed
@@ -166,7 +208,7 @@ final class CloudSyncOperationCoordinator {
 
         if allowJoiningRunningOperation, coalescesWithEquivalentRequests, running.subsumes(intent) {
             // If the run we are riding on fails, this request failed with it.
-            try await currentTask.value
+            try await waitForCurrentRunToFinish(currentTask)
             return .joinedRunningOperation(running)
         }
 
@@ -181,19 +223,18 @@ final class CloudSyncOperationCoordinator {
         defer {
             satisfiedWaiters.remove(waiterID)
             failuresByWaiter.removeValue(forKey: waiterID)
+            cancelWaiter(waiterID)
         }
 
         var ranOwnWork = false
         while !satisfiedWaiters.contains(waiterID) {
-            if let task = self.currentTask {
-                // Another run's failure is not this request's to report; the run
-                // covering this request delivers its error through `failuresByWaiter`.
-                _ = try? await task.value
-                // Awaiting an already-finished task can return without suspending,
-                // and the run that owns it clears `currentTask` from its own
-                // continuation. Without an explicit yield this loop can spin on the
-                // main actor and never let that continuation run.
-                await Task.yield()
+            try Task.checkCancellation()
+            if self.currentTask != nil {
+                // Do not await the running task directly here. A cancelled waiter
+                // must be able to leave while the shared CloudKit operation keeps
+                // running for its other callers; polling the actor-owned handle
+                // also avoids a cancelled waiter remaining in the queue forever.
+                try await Task.sleep(nanoseconds: cacheMaintenancePollNanoseconds)
                 continue
             }
             guard let next = takeHighestPriorityPending() else { break }
@@ -213,6 +254,13 @@ final class CloudSyncOperationCoordinator {
             throw failure
         }
         return ranOwnWork ? .completed : .coalescedIntoFollowUp(coalescedInto)
+    }
+
+    private func waitForCurrentRunToFinish(_ task: Task<Void, any Error>) async throws {
+        while self.currentTask != nil {
+            try await Task.sleep(nanoseconds: cacheMaintenancePollNanoseconds)
+        }
+        try await task.value
     }
 
     /// Adds this request to the queue, merging it into an existing entry only when
@@ -251,6 +299,18 @@ final class CloudSyncOperationCoordinator {
         guard !pending.isEmpty else { return nil }
         let index = pending.indices.max { pending[$0].intent.priority < pending[$1].intent.priority } ?? 0
         return pending.remove(at: index)
+    }
+
+    /// Removes a cancelled caller from queued work without cancelling the shared
+    /// run itself. If it was the last waiter, the work is no longer needed and can
+    /// be discarded before another submitter drains the queue.
+    private func cancelWaiter(_ waiterID: Int) {
+        for index in pending.indices.reversed() {
+            pending[index].waiters.remove(waiterID)
+            if pending[index].waiters.isEmpty {
+                pending.remove(at: index)
+            }
+        }
     }
 
     private func run(

--- a/BisonNotes AI/BisonNotes AI/Views/OnDeviceAIDownloadView.swift
+++ b/BisonNotes AI/BisonNotes AI/Views/OnDeviceAIDownloadView.swift
@@ -221,6 +221,15 @@ struct OnDeviceAIDownloadView: View {
         if !mlxReady {
             AppLog.shared.summarization("OnDeviceAIDownload: Starting MLX \(mlxModel.displayName) download...", level: .debug)
             mlxManager.startDownload()
+            // A cache sweep in flight queues the request instead of starting it.
+            // Say so rather than reporting a download that has not begun; the
+            // settings screen shows the queued state and offers a cancel button.
+            if mlxManager.isDownloadQueued {
+                AppLog.shared.summarization(
+                    "OnDeviceAIDownload: MLX download queued behind cache maintenance; it starts when the sweep releases",
+                    level: .debug
+                )
+            }
         } else {
             AppLog.shared.summarization("OnDeviceAIDownload: MLX model already downloaded", level: .debug)
         }

--- a/BisonNotes AI/BisonNotes AI/iCloudStorageManager.swift
+++ b/BisonNotes AI/BisonNotes AI/iCloudStorageManager.swift
@@ -5894,10 +5894,23 @@ extension iCloudStorageManager {
         }
     }
 
-    private func enqueuePendingCloudMutation(_ mutation: PendingCloudMutation) {
+    /// - Returns: whether the intent is now durable. Callers that reassure the
+    ///   user their deletion will reach iCloud must not do so when this is false.
+    @discardableResult
+    private func enqueuePendingCloudMutation(_ mutation: PendingCloudMutation) -> Bool {
         applyPendingCloudMutationChanges("persist pending iCloud mutation") { context in
             try PendingCloudMutationStore.enqueue(mutation, in: context)
         }
+    }
+
+    /// Says the removal was not recorded, rather than letting the caller's
+    /// success message claim work that is not queued. The local row is already
+    /// gone in these paths, so silence here reads as "handled" when in fact the
+    /// item can come back on the next reconcile.
+    private func publishOutboxFailureMessage(_ subject: String) {
+        publishMaintenanceMessage(
+            "Could not record the iCloud removal for \(subject). It may reappear from iCloud until the deletion is recorded again."
+        )
     }
 
     private func acknowledgePendingCloudMutation(_ mutation: PendingCloudMutation) {
@@ -5935,7 +5948,9 @@ extension iCloudStorageManager {
         // failure of the second left the imported-audio removal durably gone with
         // no recording deletion queued — the user's delete would never reach the
         // other devices, and the next reconcile would restore the recording.
-        applyPendingCloudMutationChanges("queue the iCloud deletion for \(recordingId.uuidString)") { context in
+        let queued = applyPendingCloudMutationChanges(
+            "queue the iCloud deletion for \(recordingId.uuidString)"
+        ) { context in
             try PendingCloudMutationStore.remove(
                 kind: .importedAudioRemoval,
                 targetId: recordingId,
@@ -5952,15 +5967,20 @@ extension iCloudStorageManager {
                 in: context
             )
         }
+        // Still drop the summaries locally either way: re-uploading rows the user
+        // deleted is worse than an unrecorded tombstone.
         let deletedSummaryIds = Set(summaryIds)
         pendingSyncQueue.removeAll { summary in
             summary.recordingId == recordingId || deletedSummaryIds.contains(summary.id)
         }
         UserDefaults.standard.removeObject(forKey: Self.backupStateSignatureKey)
+        if !queued {
+            publishOutboxFailureMessage("this recording")
+        }
     }
 
     func enqueueLocalOnlyCloudRemoval(recordingId: UUID) {
-        enqueuePendingCloudMutation(
+        let queued = enqueuePendingCloudMutation(
             PendingCloudMutation(
                 kind: .localOnlyRemoval,
                 targetId: recordingId,
@@ -5968,6 +5988,10 @@ extension iCloudStorageManager {
             )
         )
         UserDefaults.standard.removeObject(forKey: Self.backupStateSignatureKey)
+        guard queued else {
+            publishOutboxFailureMessage("this local-only recording")
+            return
+        }
         publishMaintenanceMessage("Existing iCloud copies for local-only recordings will be removed when iCloud sync is available.")
     }
 
@@ -5976,7 +6000,7 @@ extension iCloudStorageManager {
         recordingId: UUID? = nil,
         requestedAt: Date = Date()
     ) {
-        enqueuePendingCloudMutation(
+        let queued = enqueuePendingCloudMutation(
             PendingCloudMutation(
                 kind: .summaryRemoval,
                 targetId: summaryId,
@@ -5986,6 +6010,10 @@ extension iCloudStorageManager {
         )
         pendingSyncQueue.removeAll { $0.id == summaryId }
         UserDefaults.standard.removeObject(forKey: Self.backupStateSignatureKey)
+        guard queued else {
+            publishOutboxFailureMessage("a deleted summary")
+            return
+        }
         publishMaintenanceMessage("Deleted summaries will be removed from iCloud sync records when iCloud sync is available.")
     }
 
@@ -5994,7 +6022,7 @@ extension iCloudStorageManager {
         recordingId: UUID? = nil,
         requestedAt: Date = Date()
     ) {
-        enqueuePendingCloudMutation(
+        let queued = enqueuePendingCloudMutation(
             PendingCloudMutation(
                 kind: .transcriptRemoval,
                 targetId: transcriptId,
@@ -6003,6 +6031,10 @@ extension iCloudStorageManager {
             )
         )
         UserDefaults.standard.removeObject(forKey: Self.backupStateSignatureKey)
+        guard queued else {
+            publishOutboxFailureMessage("a deleted transcript")
+            return
+        }
         publishMaintenanceMessage("Deleted transcripts will be removed from iCloud sync records when iCloud sync is available.")
     }
 
@@ -6013,7 +6045,7 @@ extension iCloudStorageManager {
         recordingId: UUID,
         requestedAt: Date = Date()
     ) {
-        enqueuePendingCloudMutation(
+        let queued = enqueuePendingCloudMutation(
             PendingCloudMutation(
                 kind: .importedAudioRemoval,
                 targetId: recordingId,
@@ -6021,6 +6053,10 @@ extension iCloudStorageManager {
             )
         )
         UserDefaults.standard.removeObject(forKey: Self.backupStateSignatureKey)
+        guard queued else {
+            publishOutboxFailureMessage("deleted imported audio")
+            return
+        }
         publishMaintenanceMessage("Deleted imported audio will be removed from iCloud sync records when iCloud sync is available.")
     }
 

--- a/BisonNotes AI/BisonNotes AI/iCloudStorageManager.swift
+++ b/BisonNotes AI/BisonNotes AI/iCloudStorageManager.swift
@@ -318,6 +318,11 @@ class iCloudStorageManager: ObservableObject {
     /// before a flush begins.
     private var pendingMutationContext: NSManagedObjectContext =
         PersistenceController.shared.container.viewContext
+    /// Sibling of `pendingMutationContext` on the same store, used for every
+    /// standalone outbox read and write so queue bookkeeping never saves or rolls
+    /// back the shared view context. Rebuilt whenever the binding changes.
+    private lazy var outboxContext: NSManagedObjectContext? =
+        PendingCloudMutationStore.makeIsolatedContext(basedOn: pendingMutationContext)
     /// Prevents a single recording/signature from spamming the maintenance status
     /// when a run is repeatedly deferred until the volume has room.
     private var reportedStagingCapacityShortages: Set<String> = []
@@ -2578,24 +2583,22 @@ class iCloudStorageManager: ObservableObject {
     /// Clears the local state that describes what already exists in iCloud. Local
     /// recordings, transcripts and summaries are untouched — only sync bookkeeping.
     private func resetLocalCloudSyncBookkeeping() {
+        // The outbox goes first, and nothing else moves until it has. Clearing the
+        // in-memory state before this and then returning early on failure left the
+        // reset half applied: `activeManifestMigrationCompletedKey` still claimed
+        // the manifest migration was done for a manifest the erase had just
+        // deleted, so the next sync skipped re-seeding it.
+        let didClearDurableOutbox = applyPendingCloudMutationChanges(
+            "clear the durable iCloud mutation outbox after erase"
+        ) { context in
+            try PendingCloudMutationStore.removeAll(in: context)
+        }
+        guard didClearDurableOutbox else { return }
+
         clearSyncState()
         lastSyncDate = nil
         lastAutoBackupDate = nil
         pendingCloudReviewItems = []
-
-        var didClearDurableOutbox = false
-        do {
-            try PendingCloudMutationStore.removeAll(in: pendingMutationContext)
-            didClearDurableOutbox = true
-        } catch {
-            pendingMutationContext.rollback()
-            AppLog.shared.iCloudSync(
-                "Could not clear the durable iCloud mutation outbox after erase: \(error)",
-                level: .error
-            )
-        }
-
-        guard didClearDurableOutbox else { return }
 
         let defaults = UserDefaults.standard
         defaults.removeObject(forKey: "lastSyncDate")
@@ -3308,8 +3311,14 @@ extension iCloudStorageManager {
             appCoordinator: appCoordinator,
             options: options
         )
+        // Read once for the whole run, the way line ~724 already does for the other
+        // queues. Each read of `pendingImportedAudioRemovals` is a Core Data fetch
+        // that decodes every outbox row; evaluating it per recording inside the
+        // three loops below cost hundreds of fetches per pass for a queue that is
+        // almost always empty.
+        let pendingImportedAudioRecordingIds = Set(pendingImportedAudioRemovals.map(\.recordingId))
         if activeManifestMigrationCompleted,
-           pendingImportedAudioRemovals.isEmpty,
+           pendingImportedAudioRecordingIds.isEmpty,
            UserDefaults.standard.string(forKey: Self.backupStateSignatureKey) == currentBackupStateSignature {
             let hasCloudContentBackup = try await cloudHasAnyContentBackupRecord()
             if hasCloudContentBackup {
@@ -3386,9 +3395,7 @@ extension iCloudStorageManager {
                 recordName: makeBackupRecordName(prefix: Self.backupRecordingRecordPrefix, id: recordingId)
             )
             let existingRecord = snapshot.recordings[recordID]
-            let hasPendingImportedAudioRemoval = pendingImportedAudioRemovals.contains {
-                $0.recordingId == recordingId
-            }
+            let hasPendingImportedAudioRemoval = pendingImportedAudioRecordingIds.contains(recordingId)
 
             if let existingRecord,
                !hasPendingImportedAudioRemoval,
@@ -3548,9 +3555,8 @@ extension iCloudStorageManager {
                 )
                 continue
             }
-            let hasPendingImportedAudioRemoval = entry.recording.id.map { recordingId in
-                pendingImportedAudioRemovals.contains { $0.recordingId == recordingId }
-            } ?? false
+            let hasPendingImportedAudioRemoval = entry.recording.id
+                .map(pendingImportedAudioRecordingIds.contains) ?? false
             let record = recordingRecordsToWrite[entry.recordID]
                 ?? CKRecord(recordType: Self.backupRecordingRecordType, recordID: entry.recordID)
 
@@ -3646,7 +3652,7 @@ extension iCloudStorageManager {
                 result.audioFilesBackedUp += 1
             }
             if let recordingId = entry.recording.id,
-               pendingImportedAudioRemovals.contains(where: { $0.recordingId == recordingId }) {
+               pendingImportedAudioRecordingIds.contains(recordingId) {
                 clearAudioBackupFields(on: record, changed: &changed)
             }
             if changed {
@@ -5757,8 +5763,9 @@ extension iCloudStorageManager {
 
     private func pendingCloudMutations() -> [PendingCloudMutation] {
         _ = PendingCloudMutationStore.migrateLegacyQueuesIfNeeded(in: pendingMutationContext)
+        guard let context = outboxContext else { return [] }
         do {
-            return try PendingCloudMutationStore.fetchAll(in: pendingMutationContext)
+            return try PendingCloudMutationStore.fetchAll(in: context)
         } catch {
             AppLog.shared.iCloudSync(
                 "Could not read pending iCloud mutation outbox: \(error)",
@@ -5779,25 +5786,42 @@ extension iCloudStorageManager {
             return
         }
 
-        guard !context.hasChanges else {
+        // Two contexts over one store already share every row, so there is nothing
+        // to move — copying and then withdrawing the snapshots would delete the
+        // very rows the copy just merged into.
+        let sameStore = pendingMutationContext.persistentStoreCoordinator != nil &&
+            pendingMutationContext.persistentStoreCoordinator === context.persistentStoreCoordinator
+        guard !sameStore else {
+            pendingMutationContext = context
+            outboxContext = PendingCloudMutationStore.makeIsolatedContext(basedOn: context)
+            _ = PendingCloudMutationStore.migrateLegacyQueuesIfNeeded(in: context)
+            return
+        }
+
+        let previousOutboxContext = outboxContext
+        let previousMutations = pendingCloudMutations()
+
+        // Both sides are outbox-only contexts, so neither the copy nor its rollback
+        // can touch a caller's unsaved work — no unrelated-changes guard is needed,
+        // and a busy view context can no longer strand a durable mutation.
+        guard let destination = PendingCloudMutationStore.makeIsolatedContext(basedOn: context) else {
             AppLog.shared.iCloudSync(
-                "Could not move pending iCloud mutations into a context with unrelated unsaved changes",
+                "Could not move pending iCloud mutations: the destination has no persistent store coordinator",
                 level: .error
             )
             return
         }
 
-        let previousContext = pendingMutationContext
-        let previousContextWasClean = !previousContext.hasChanges
-        let previousMutations = pendingCloudMutations()
         if !previousMutations.isEmpty {
             do {
                 for mutation in previousMutations {
-                    try PendingCloudMutationStore.enqueue(mutation, in: context)
+                    try PendingCloudMutationStore.enqueue(mutation, in: destination)
                 }
-                try context.save()
+                if destination.hasChanges {
+                    try destination.save()
+                }
             } catch {
-                context.rollback()
+                destination.rollback()
                 AppLog.shared.iCloudSync(
                     "Could not move pending iCloud mutations to the active Core Data store: \(error)",
                     level: .error
@@ -5807,69 +5831,78 @@ extension iCloudStorageManager {
         }
 
         pendingMutationContext = context
-
-        guard !previousMutations.isEmpty, previousContextWasClean else {
-            if !previousMutations.isEmpty {
-                AppLog.shared.iCloudSync(
-                    "Retaining pending iCloud mutations on the previous context because it has unrelated unsaved changes",
-                    level: .debug
-                )
-            }
-            _ = PendingCloudMutationStore.migrateLegacyQueuesIfNeeded(in: context)
-            return
-        }
+        outboxContext = destination
 
         // The destination is now durable. Remove only the snapshots that were
-        // copied; a newer payload remains in the source context for its next
-        // binding. The source was clean before this operation, so a rollback here
-        // cannot discard unrelated user edits.
-        do {
-            for mutation in previousMutations {
-                _ = try PendingCloudMutationStore.removeIfUnchanged(
-                    mutation,
-                    from: previousContext
+        // copied; a newer payload remains in the source store for its next binding.
+        if !previousMutations.isEmpty, let previousOutboxContext {
+            do {
+                for mutation in previousMutations {
+                    _ = try PendingCloudMutationStore.removeIfUnchanged(
+                        mutation,
+                        from: previousOutboxContext
+                    )
+                }
+                if previousOutboxContext.hasChanges {
+                    try previousOutboxContext.save()
+                }
+            } catch {
+                previousOutboxContext.rollback()
+                AppLog.shared.iCloudSync(
+                    "Copied pending iCloud mutations but could not clear the previous store: \(error)",
+                    level: .error
                 )
             }
-            if previousContext.hasChanges {
-                try previousContext.save()
-            }
-        } catch {
-            previousContext.rollback()
-            AppLog.shared.iCloudSync(
-                "Copied pending iCloud mutations but could not clear the previous context: \(error)",
-                level: .error
-            )
         }
 
         _ = PendingCloudMutationStore.migrateLegacyQueuesIfNeeded(in: context)
     }
 
-    private func enqueuePendingCloudMutation(_ mutation: PendingCloudMutation) {
-        do {
-            try PendingCloudMutationStore.enqueue(mutation, in: pendingMutationContext)
-            try pendingMutationContext.save()
-        } catch {
-            pendingMutationContext.rollback()
+    /// Applies outbox edits as one transaction on a context that holds nothing
+    /// else.
+    ///
+    /// Saving `pendingMutationContext` directly meant every queue write also
+    /// committed whatever unrelated edits the shared view context happened to be
+    /// holding — and, worse, that a failure caused by one of *those* objects
+    /// rolled the user's in-flight work away. `CoreDataManager.saveContext()`
+    /// deliberately leaves a failed save's edits staged for a retry, so that was
+    /// reachable. The delete paths still stage their intent inside the content
+    /// transaction via `save(committing:)`; this is only for the standalone
+    /// enqueue/acknowledge calls the sync legs make.
+    @discardableResult
+    private func applyPendingCloudMutationChanges(
+        _ description: String,
+        _ body: (NSManagedObjectContext) throws -> Void
+    ) -> Bool {
+        guard let context = outboxContext else {
             AppLog.shared.iCloudSync(
-                "Could not persist pending iCloud mutation: \(error)",
+                "Could not \(description): the pending mutation store is unavailable",
                 level: .error
             )
+            return false
+        }
+        do {
+            try body(context)
+            if context.hasChanges {
+                try context.save()
+            }
+            return true
+        } catch {
+            context.rollback()
+            AppLog.shared.iCloudSync("Could not \(description): \(error)", level: .error)
+            return false
+        }
+    }
+
+    private func enqueuePendingCloudMutation(_ mutation: PendingCloudMutation) {
+        applyPendingCloudMutationChanges("persist pending iCloud mutation") { context in
+            try PendingCloudMutationStore.enqueue(mutation, in: context)
         }
     }
 
     private func acknowledgePendingCloudMutation(_ mutation: PendingCloudMutation) {
-        do {
-            guard try PendingCloudMutationStore.removeIfUnchanged(
-                mutation,
-                from: pendingMutationContext
-            ) else { return }
-            try pendingMutationContext.save()
-        } catch {
-            pendingMutationContext.rollback()
-            AppLog.shared.iCloudSync(
-                "Could not acknowledge pending iCloud mutation: \(error)",
-                level: .error
-            )
+        applyPendingCloudMutationChanges("acknowledge pending iCloud mutation") { context in
+            _ = try PendingCloudMutationStore.removeIfUnchanged(mutation, from: context)
         }
     }
 
@@ -5877,19 +5910,8 @@ extension iCloudStorageManager {
         kind: PendingCloudMutationKind,
         targetId: UUID
     ) {
-        do {
-            try PendingCloudMutationStore.remove(
-                kind: kind,
-                targetId: targetId,
-                from: pendingMutationContext
-            )
-            try pendingMutationContext.save()
-        } catch {
-            pendingMutationContext.rollback()
-            AppLog.shared.iCloudSync(
-                "Could not clear pending iCloud mutation: \(error)",
-                level: .error
-            )
+        applyPendingCloudMutationChanges("clear pending iCloud mutation") { context in
+            try PendingCloudMutationStore.remove(kind: kind, targetId: targetId, from: context)
         }
     }
 
@@ -5908,16 +5930,28 @@ extension iCloudStorageManager {
         summaryIds: [UUID],
         requestedAt: Date = Date()
     ) {
-        clearPendingCloudMutation(kind: .importedAudioRemoval, targetId: recordingId)
-        enqueuePendingCloudMutation(
-            PendingCloudMutation(
-                kind: .recordingDeletion,
+        // Withdrawal and enqueue in one transaction, the way
+        // `DeferredDeletionEffects.stageCloudMutations` does it. As two saves, a
+        // failure of the second left the imported-audio removal durably gone with
+        // no recording deletion queued — the user's delete would never reach the
+        // other devices, and the next reconcile would restore the recording.
+        applyPendingCloudMutationChanges("queue the iCloud deletion for \(recordingId.uuidString)") { context in
+            try PendingCloudMutationStore.remove(
+                kind: .importedAudioRemoval,
                 targetId: recordingId,
-                transcriptIds: transcriptIds,
-                summaryIds: summaryIds,
-                requestedAt: requestedAt
+                from: context
             )
-        )
+            try PendingCloudMutationStore.enqueue(
+                PendingCloudMutation(
+                    kind: .recordingDeletion,
+                    targetId: recordingId,
+                    transcriptIds: transcriptIds,
+                    summaryIds: summaryIds,
+                    requestedAt: requestedAt
+                ),
+                in: context
+            )
+        }
         let deletedSummaryIds = Set(summaryIds)
         pendingSyncQueue.removeAll { summary in
             summary.recordingId == recordingId || deletedSummaryIds.contains(summary.id)
@@ -6245,19 +6279,30 @@ extension iCloudStorageManager {
     }
 
     func clearPendingCloudMutationsForTesting() {
-        do {
-            try PendingCloudMutationStore.removeAll(in: pendingMutationContext)
-            UserDefaults.standard.removeObject(forKey: "iCloudPendingDeletionMarkersV1")
-            UserDefaults.standard.removeObject(forKey: "iCloudPendingLocalOnlyRemovalsV1")
-            UserDefaults.standard.removeObject(forKey: "iCloudPendingSummaryRemovalsV1")
-            UserDefaults.standard.removeObject(forKey: "iCloudPendingTranscriptRemovalsV1")
-            UserDefaults.standard.removeObject(forKey: "iCloudPendingImportedAudioRemovalsV1")
-        } catch {
-            pendingMutationContext.rollback()
-            AppLog.shared.iCloudSync(
-                "Could not clear pending cloud mutations for testing: \(error)",
-                level: .error
-            )
+        applyPendingCloudMutationChanges("clear pending cloud mutations for testing") { context in
+            try PendingCloudMutationStore.removeAll(in: context)
+        }
+        // A manager that has never been bound still points at the process-wide
+        // default store. Clearing only the bound store therefore did nothing for
+        // rows queued through a differently-bound manager, and the next
+        // `bindPendingMutationContext` copied them forward into the following
+        // test. Cheap to clear both; this is a DEBUG-only hook.
+        let defaultContext = PersistenceController.shared.container.viewContext
+        if defaultContext.persistentStoreCoordinator !== pendingMutationContext.persistentStoreCoordinator,
+           let defaultOutbox = PendingCloudMutationStore.makeIsolatedContext(basedOn: defaultContext) {
+            do {
+                try PendingCloudMutationStore.removeAll(in: defaultOutbox)
+                if defaultOutbox.hasChanges { try defaultOutbox.save() }
+            } catch {
+                defaultOutbox.rollback()
+                AppLog.shared.iCloudSync(
+                    "Could not clear the default store's pending cloud mutations for testing: \(error)",
+                    level: .error
+                )
+            }
+        }
+        for key in PendingCloudMutationStore.legacyQueueKeys {
+            UserDefaults.standard.removeObject(forKey: key)
         }
     }
     #endif

--- a/BisonNotes AI/BisonNotes AI/iCloudStorageManager.swift
+++ b/BisonNotes AI/BisonNotes AI/iCloudStorageManager.swift
@@ -312,6 +312,15 @@ class iCloudStorageManager: ObservableObject {
     private var syncTimer: Timer?
     private var networkMonitor: NetworkMonitor?
     private var isInitialized = false
+    /// The outbox follows the persistent store used by the current app
+    /// coordinator. Production uses the shared view context; injected test
+    /// coordinators can point a manager at their temporary SQLite/in-memory store
+    /// before a flush begins.
+    private var pendingMutationContext: NSManagedObjectContext =
+        PersistenceController.shared.container.viewContext
+    /// Prevents a single recording/signature from spamming the maintenance status
+    /// when a run is repeatedly deferred until the volume has room.
+    private var reportedStagingCapacityShortages: Set<String> = []
     private let performanceOptimizer = PerformanceOptimizer.shared
 
     // Configuration
@@ -387,6 +396,14 @@ class iCloudStorageManager: ObservableObject {
     private var assetStagingFactory: @MainActor (String) -> any CloudAssetStaging
 
     #if DEBUG
+    private var restoredAudioFileManagerForTesting: FileManager?
+
+    func setRestoredAudioFileManagerForTesting(_ fileManager: FileManager?) {
+        restoredAudioFileManagerForTesting = fileManager
+    }
+    #endif
+
+    #if DEBUG
     func setAssetStagingFactoryForTesting(_ factory: @escaping @MainActor (String) -> any CloudAssetStaging) {
         assetStagingFactory = factory
     }
@@ -434,6 +451,8 @@ class iCloudStorageManager: ObservableObject {
         if let lastSyncTimestamp = UserDefaults.standard.object(forKey: "lastSyncDate") as? Date {
             self.lastSyncDate = lastSyncTimestamp
         }
+
+        _ = PendingCloudMutationStore.migrateLegacyQueuesIfNeeded(in: pendingMutationContext)
 
         // Check if we're in a preview environment
         let isPreview = ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1" ||
@@ -2564,6 +2583,20 @@ class iCloudStorageManager: ObservableObject {
         lastAutoBackupDate = nil
         pendingCloudReviewItems = []
 
+        var didClearDurableOutbox = false
+        do {
+            try PendingCloudMutationStore.removeAll(in: pendingMutationContext)
+            didClearDurableOutbox = true
+        } catch {
+            pendingMutationContext.rollback()
+            AppLog.shared.iCloudSync(
+                "Could not clear the durable iCloud mutation outbox after erase: \(error)",
+                level: .error
+            )
+        }
+
+        guard didClearDurableOutbox else { return }
+
         let defaults = UserDefaults.standard
         defaults.removeObject(forKey: "lastSyncDate")
         defaults.removeObject(forKey: Self.backupStateSignatureKey)
@@ -2574,6 +2607,7 @@ class iCloudStorageManager: ObservableObject {
         defaults.removeObject(forKey: Self.pendingLocalOnlyRemovalsKey)
         defaults.removeObject(forKey: Self.pendingSummaryRemovalsKey)
         defaults.removeObject(forKey: Self.pendingTranscriptRemovalsKey)
+        defaults.removeObject(forKey: Self.pendingImportedAudioRemovalsKey)
     }
 
     // MARK: - Private Methods
@@ -2604,6 +2638,9 @@ struct CloudBackupResult {
     /// Audio this run meant to upload and could not stage a copy of. The run is
     /// otherwise complete, but it must not be recorded as one.
     var audioFilesPendingRetry: Int = 0
+    /// Subset of pending audio retries whose required staged bytes exceeded the
+    /// capacity reported by the staging volume.
+    var audioFilesDeferredForInsufficientSpace: Int = 0
     var settingsBackedUp: Bool = false
     var includedSensitiveSettings: Bool = false
     var wasSkippedNoChanges: Bool = false
@@ -3484,8 +3521,9 @@ extension iCloudStorageManager {
         // Every staged copy is held until this run's `defer`, so the peak is the
         // whole changed set unless something bounds it. Past the budget the
         // remaining recordings upload metadata and leave the audio owed.
+        let availableStagingCapacity = availableStagingCapacity()
         let stagingByteBudget = CloudAudioAssetPolicy.stagingByteBudget(
-            availableCapacity: availableStagingCapacity()
+            availableCapacity: availableStagingCapacity
         )
         var stagedAudioBytes: Int64 = 0
 
@@ -3567,6 +3605,7 @@ extension iCloudStorageManager {
                     includeAudioFiles: options.includeAudioFiles,
                     recorder: recorder,
                     stagingByteBudget: stagingByteBudget,
+                    availableStagingCapacity: availableStagingCapacity,
                     stagedBytes: &stagedAudioBytes,
                     result: &result,
                     changed: &changed
@@ -3599,6 +3638,7 @@ extension iCloudStorageManager {
                 includeAudioFiles: options.includeAudioFiles,
                 recorder: recorder,
                 stagingByteBudget: stagingByteBudget,
+                availableStagingCapacity: availableStagingCapacity,
                 stagedBytes: &stagedAudioBytes,
                 result: &result,
                 changed: &changed
@@ -3692,7 +3732,13 @@ extension iCloudStorageManager {
             )
             guard let settledRecord = settledRecordsByID[recordID],
                   !hasAudioBackupFields(settledRecord) else { continue }
-            clearPendingImportedAudioRemoval(recordingId: pendingRemoval.recordingId)
+            acknowledgePendingCloudMutation(
+                PendingCloudMutation(
+                    kind: .importedAudioRemoval,
+                    targetId: pendingRemoval.recordingId,
+                    requestedAt: pendingRemoval.requestedAt
+                )
+            )
         }
 
         // The settled manifest, not this run's arithmetic on a snapshot that may
@@ -4498,7 +4544,11 @@ extension iCloudStorageManager {
         do {
             var result = CloudRestoreResult()
             let context = appCoordinator.coreDataManager.managedObjectContext
+            #if DEBUG
+            let fileManager = restoredAudioFileManagerForTesting ?? FileManager.default
+            #else
             let fileManager = FileManager.default
+            #endif
             let deletionTargets = preflight.deletionTargets
 
             let restoreSnapshot: BackupCloudSnapshot
@@ -5491,7 +5541,15 @@ extension iCloudStorageManager {
             summaryIds: summaryIds
         )
         UserDefaults.standard.removeObject(forKey: Self.backupStateSignatureKey)
-        clearPendingRecordingDeletion(recordingId: recordingId)
+        acknowledgePendingCloudMutation(
+            PendingCloudMutation(
+                kind: .recordingDeletion,
+                targetId: recordingId,
+                transcriptIds: transcriptIds,
+                summaryIds: summaryIds,
+                requestedAt: deletedAt
+            )
+        )
         await MainActor.run {
             self.lastMaintenanceMessage = "Deleted item removed from iCloud sync records."
         }
@@ -5523,7 +5581,14 @@ extension iCloudStorageManager {
             transcriptId: transcriptId
         )
         UserDefaults.standard.removeObject(forKey: Self.backupStateSignatureKey)
-        clearPendingTranscriptRemoval(transcriptId: transcriptId)
+        acknowledgePendingCloudMutation(
+            PendingCloudMutation(
+                kind: .transcriptRemoval,
+                targetId: transcriptId,
+                recordingId: recordingId,
+                requestedAt: deletedAt
+            )
+        )
         await MainActor.run {
             self.lastMaintenanceMessage = "Deleted transcript removed from iCloud sync records."
         }
@@ -5558,7 +5623,14 @@ extension iCloudStorageManager {
             summaryIds: [summaryId]
         )
         UserDefaults.standard.removeObject(forKey: Self.backupStateSignatureKey)
-        clearPendingSummaryRemoval(summaryId: summaryId)
+        acknowledgePendingCloudMutation(
+            PendingCloudMutation(
+                kind: .summaryRemoval,
+                targetId: summaryId,
+                recordingId: recordingId,
+                requestedAt: deletedAt
+            )
+        )
         await MainActor.run {
             self.lastMaintenanceMessage = "Deleted summary removed from iCloud sync records."
         }
@@ -5590,6 +5662,9 @@ extension iCloudStorageManager {
             ($0.recordingId ?? $0.recording?.id) == recordingId
         }
 
+        let pendingMutation = pendingCloudMutations().first {
+            $0.kind == .localOnlyRemoval && $0.targetId == recordingId
+        }
         let deletedCloudRecords = try await deleteCloudContentRecords(
             recordingId: recordingId,
             transcriptIds: transcripts.compactMap(\.id),
@@ -5597,7 +5672,13 @@ extension iCloudStorageManager {
         )
 
         UserDefaults.standard.removeObject(forKey: Self.backupStateSignatureKey)
-        clearPendingLocalOnlyCloudRemoval(recordingId: recordingId)
+        acknowledgePendingCloudMutation(
+            pendingMutation ?? PendingCloudMutation(
+                kind: .localOnlyRemoval,
+                targetId: recordingId,
+                requestedAt: Date()
+            )
+        )
         AppLog.shared.iCloudSync("Removed \(deletedCloudRecords) iCloud records for local-only recording \(recordingId.uuidString)", level: .debug)
     }
 
@@ -5621,44 +5702,194 @@ extension iCloudStorageManager {
     }
 
     private var pendingCloudDeletionMarkers: [PendingCloudDeletionMarker] {
-        get { Self.decodePendingCloudMutations(PendingCloudDeletionMarker.self, key: Self.pendingDeletionMarkersKey) }
-        set { Self.storePendingCloudMutations(newValue, key: Self.pendingDeletionMarkersKey) }
+        pendingCloudMutations().compactMap { mutation in
+            guard mutation.kind == .recordingDeletion else { return nil }
+            return PendingCloudDeletionMarker(
+                recordingId: mutation.targetId,
+                transcriptIds: mutation.transcriptIds,
+                summaryIds: mutation.summaryIds,
+                requestedAt: mutation.requestedAt
+            )
+        }
     }
 
     private var pendingLocalOnlyCloudRemovals: [PendingLocalOnlyCloudRemoval] {
-        get { Self.decodePendingCloudMutations(PendingLocalOnlyCloudRemoval.self, key: Self.pendingLocalOnlyRemovalsKey) }
-        set { Self.storePendingCloudMutations(newValue, key: Self.pendingLocalOnlyRemovalsKey) }
+        pendingCloudMutations().compactMap { mutation in
+            guard mutation.kind == .localOnlyRemoval else { return nil }
+            return PendingLocalOnlyCloudRemoval(
+                recordingId: mutation.targetId,
+                requestedAt: mutation.requestedAt
+            )
+        }
     }
 
     private var pendingSummaryCloudRemovals: [PendingSummaryCloudRemoval] {
-        get { Self.decodePendingCloudMutations(PendingSummaryCloudRemoval.self, key: Self.pendingSummaryRemovalsKey) }
-        set { Self.storePendingCloudMutations(newValue, key: Self.pendingSummaryRemovalsKey) }
+        pendingCloudMutations().compactMap { mutation in
+            guard mutation.kind == .summaryRemoval else { return nil }
+            return PendingSummaryCloudRemoval(
+                summaryId: mutation.targetId,
+                recordingId: mutation.recordingId,
+                requestedAt: mutation.requestedAt
+            )
+        }
     }
 
     private var pendingTranscriptCloudRemovals: [PendingTranscriptCloudRemoval] {
-        get { Self.decodePendingCloudMutations(PendingTranscriptCloudRemoval.self, key: Self.pendingTranscriptRemovalsKey) }
-        set { Self.storePendingCloudMutations(newValue, key: Self.pendingTranscriptRemovalsKey) }
+        pendingCloudMutations().compactMap { mutation in
+            guard mutation.kind == .transcriptRemoval else { return nil }
+            return PendingTranscriptCloudRemoval(
+                transcriptId: mutation.targetId,
+                recordingId: mutation.recordingId,
+                requestedAt: mutation.requestedAt
+            )
+        }
     }
 
     private var pendingImportedAudioRemovals: [PendingImportedAudioRemoval] {
-        get { Self.decodePendingCloudMutations(PendingImportedAudioRemoval.self, key: Self.pendingImportedAudioRemovalsKey) }
-        set { Self.storePendingCloudMutations(newValue, key: Self.pendingImportedAudioRemovalsKey) }
+        pendingCloudMutations().compactMap { mutation in
+            guard mutation.kind == .importedAudioRemoval else { return nil }
+            return PendingImportedAudioRemoval(
+                recordingId: mutation.targetId,
+                requestedAt: mutation.requestedAt
+            )
+        }
     }
 
-    private static func decodePendingCloudMutations<T: Decodable>(_ type: T.Type, key: String) -> [T] {
-        guard let data = UserDefaults.standard.data(forKey: key) else {
+    private func pendingCloudMutations() -> [PendingCloudMutation] {
+        _ = PendingCloudMutationStore.migrateLegacyQueuesIfNeeded(in: pendingMutationContext)
+        do {
+            return try PendingCloudMutationStore.fetchAll(in: pendingMutationContext)
+        } catch {
+            AppLog.shared.iCloudSync(
+                "Could not read pending iCloud mutation outbox: \(error)",
+                level: .error
+            )
             return []
         }
-        return (try? JSONDecoder().decode([T].self, from: data)) ?? []
     }
 
-    private static func storePendingCloudMutations<T: Encodable>(_ mutations: [T], key: String) {
-        guard !mutations.isEmpty else {
-            UserDefaults.standard.removeObject(forKey: key)
+    /// Binds queue inspection to the coordinator's store before a sync run. The
+    /// production coordinator normally shares this view context, while tests and
+    /// previews deliberately use an isolated in-memory store. Any rows queued on
+    /// the manager's previous context are copied first so changing the binding
+    /// cannot strand an already-durable mutation.
+    func bindPendingMutationContext(to context: NSManagedObjectContext) {
+        guard pendingMutationContext !== context else {
+            _ = PendingCloudMutationStore.migrateLegacyQueuesIfNeeded(in: context)
             return
         }
-        if let data = try? JSONEncoder().encode(mutations) {
-            UserDefaults.standard.set(data, forKey: key)
+
+        guard !context.hasChanges else {
+            AppLog.shared.iCloudSync(
+                "Could not move pending iCloud mutations into a context with unrelated unsaved changes",
+                level: .error
+            )
+            return
+        }
+
+        let previousContext = pendingMutationContext
+        let previousContextWasClean = !previousContext.hasChanges
+        let previousMutations = pendingCloudMutations()
+        if !previousMutations.isEmpty {
+            do {
+                for mutation in previousMutations {
+                    try PendingCloudMutationStore.enqueue(mutation, in: context)
+                }
+                try context.save()
+            } catch {
+                context.rollback()
+                AppLog.shared.iCloudSync(
+                    "Could not move pending iCloud mutations to the active Core Data store: \(error)",
+                    level: .error
+                )
+                return
+            }
+        }
+
+        pendingMutationContext = context
+
+        guard !previousMutations.isEmpty, previousContextWasClean else {
+            if !previousMutations.isEmpty {
+                AppLog.shared.iCloudSync(
+                    "Retaining pending iCloud mutations on the previous context because it has unrelated unsaved changes",
+                    level: .debug
+                )
+            }
+            _ = PendingCloudMutationStore.migrateLegacyQueuesIfNeeded(in: context)
+            return
+        }
+
+        // The destination is now durable. Remove only the snapshots that were
+        // copied; a newer payload remains in the source context for its next
+        // binding. The source was clean before this operation, so a rollback here
+        // cannot discard unrelated user edits.
+        do {
+            for mutation in previousMutations {
+                _ = try PendingCloudMutationStore.removeIfUnchanged(
+                    mutation,
+                    from: previousContext
+                )
+            }
+            if previousContext.hasChanges {
+                try previousContext.save()
+            }
+        } catch {
+            previousContext.rollback()
+            AppLog.shared.iCloudSync(
+                "Copied pending iCloud mutations but could not clear the previous context: \(error)",
+                level: .error
+            )
+        }
+
+        _ = PendingCloudMutationStore.migrateLegacyQueuesIfNeeded(in: context)
+    }
+
+    private func enqueuePendingCloudMutation(_ mutation: PendingCloudMutation) {
+        do {
+            try PendingCloudMutationStore.enqueue(mutation, in: pendingMutationContext)
+            try pendingMutationContext.save()
+        } catch {
+            pendingMutationContext.rollback()
+            AppLog.shared.iCloudSync(
+                "Could not persist pending iCloud mutation: \(error)",
+                level: .error
+            )
+        }
+    }
+
+    private func acknowledgePendingCloudMutation(_ mutation: PendingCloudMutation) {
+        do {
+            guard try PendingCloudMutationStore.removeIfUnchanged(
+                mutation,
+                from: pendingMutationContext
+            ) else { return }
+            try pendingMutationContext.save()
+        } catch {
+            pendingMutationContext.rollback()
+            AppLog.shared.iCloudSync(
+                "Could not acknowledge pending iCloud mutation: \(error)",
+                level: .error
+            )
+        }
+    }
+
+    private func clearPendingCloudMutation(
+        kind: PendingCloudMutationKind,
+        targetId: UUID
+    ) {
+        do {
+            try PendingCloudMutationStore.remove(
+                kind: kind,
+                targetId: targetId,
+                from: pendingMutationContext
+            )
+            try pendingMutationContext.save()
+        } catch {
+            pendingMutationContext.rollback()
+            AppLog.shared.iCloudSync(
+                "Could not clear pending iCloud mutation: \(error)",
+                level: .error
+            )
         }
     }
 
@@ -5677,20 +5908,16 @@ extension iCloudStorageManager {
         summaryIds: [UUID],
         requestedAt: Date = Date()
     ) {
-        var queue = pendingCloudDeletionMarkers
-        if let index = queue.firstIndex(where: { $0.recordingId == recordingId }) {
-            queue[index].transcriptIds = Self.mergedUUIDs(queue[index].transcriptIds, transcriptIds)
-            queue[index].summaryIds = Self.mergedUUIDs(queue[index].summaryIds, summaryIds)
-        } else {
-            queue.append(PendingCloudDeletionMarker(
-                recordingId: recordingId,
+        clearPendingCloudMutation(kind: .importedAudioRemoval, targetId: recordingId)
+        enqueuePendingCloudMutation(
+            PendingCloudMutation(
+                kind: .recordingDeletion,
+                targetId: recordingId,
                 transcriptIds: transcriptIds,
                 summaryIds: summaryIds,
                 requestedAt: requestedAt
-            ))
-        }
-        pendingCloudDeletionMarkers = queue
-        pendingImportedAudioRemovals.removeAll { $0.recordingId == recordingId }
+            )
+        )
         let deletedSummaryIds = Set(summaryIds)
         pendingSyncQueue.removeAll { summary in
             summary.recordingId == recordingId || deletedSummaryIds.contains(summary.id)
@@ -5699,11 +5926,13 @@ extension iCloudStorageManager {
     }
 
     func enqueueLocalOnlyCloudRemoval(recordingId: UUID) {
-        var queue = pendingLocalOnlyCloudRemovals
-        if !queue.contains(where: { $0.recordingId == recordingId }) {
-            queue.append(PendingLocalOnlyCloudRemoval(recordingId: recordingId, requestedAt: Date()))
-            pendingLocalOnlyCloudRemovals = queue
-        }
+        enqueuePendingCloudMutation(
+            PendingCloudMutation(
+                kind: .localOnlyRemoval,
+                targetId: recordingId,
+                requestedAt: Date()
+            )
+        )
         UserDefaults.standard.removeObject(forKey: Self.backupStateSignatureKey)
         publishMaintenanceMessage("Existing iCloud copies for local-only recordings will be removed when iCloud sync is available.")
     }
@@ -5713,19 +5942,14 @@ extension iCloudStorageManager {
         recordingId: UUID? = nil,
         requestedAt: Date = Date()
     ) {
-        var queue = pendingSummaryCloudRemovals
-        if let index = queue.firstIndex(where: { $0.summaryId == summaryId }) {
-            if queue[index].recordingId == nil {
-                queue[index].recordingId = recordingId
-            }
-        } else {
-            queue.append(PendingSummaryCloudRemoval(
-                summaryId: summaryId,
+        enqueuePendingCloudMutation(
+            PendingCloudMutation(
+                kind: .summaryRemoval,
+                targetId: summaryId,
                 recordingId: recordingId,
                 requestedAt: requestedAt
-            ))
-        }
-        pendingSummaryCloudRemovals = queue
+            )
+        )
         pendingSyncQueue.removeAll { $0.id == summaryId }
         UserDefaults.standard.removeObject(forKey: Self.backupStateSignatureKey)
         publishMaintenanceMessage("Deleted summaries will be removed from iCloud sync records when iCloud sync is available.")
@@ -5736,19 +5960,14 @@ extension iCloudStorageManager {
         recordingId: UUID? = nil,
         requestedAt: Date = Date()
     ) {
-        var queue = pendingTranscriptCloudRemovals
-        if let index = queue.firstIndex(where: { $0.transcriptId == transcriptId }) {
-            if queue[index].recordingId == nil {
-                queue[index].recordingId = recordingId
-            }
-        } else {
-            queue.append(PendingTranscriptCloudRemoval(
-                transcriptId: transcriptId,
+        enqueuePendingCloudMutation(
+            PendingCloudMutation(
+                kind: .transcriptRemoval,
+                targetId: transcriptId,
                 recordingId: recordingId,
                 requestedAt: requestedAt
-            ))
-        }
-        pendingTranscriptCloudRemovals = queue
+            )
+        )
         UserDefaults.standard.removeObject(forKey: Self.backupStateSignatureKey)
         publishMaintenanceMessage("Deleted transcripts will be removed from iCloud sync records when iCloud sync is available.")
     }
@@ -5760,33 +5979,35 @@ extension iCloudStorageManager {
         recordingId: UUID,
         requestedAt: Date = Date()
     ) {
-        var queue = pendingImportedAudioRemovals
-        if !queue.contains(where: { $0.recordingId == recordingId }) {
-            queue.append(PendingImportedAudioRemoval(recordingId: recordingId, requestedAt: requestedAt))
-            pendingImportedAudioRemovals = queue
-        }
+        enqueuePendingCloudMutation(
+            PendingCloudMutation(
+                kind: .importedAudioRemoval,
+                targetId: recordingId,
+                requestedAt: requestedAt
+            )
+        )
         UserDefaults.standard.removeObject(forKey: Self.backupStateSignatureKey)
         publishMaintenanceMessage("Deleted imported audio will be removed from iCloud sync records when iCloud sync is available.")
     }
 
     func clearPendingLocalOnlyCloudRemoval(recordingId: UUID) {
-        pendingLocalOnlyCloudRemovals.removeAll { $0.recordingId == recordingId }
+        clearPendingCloudMutation(kind: .localOnlyRemoval, targetId: recordingId)
     }
 
     func clearPendingSummaryRemoval(summaryId: UUID) {
-        pendingSummaryCloudRemovals.removeAll { $0.summaryId == summaryId }
+        clearPendingCloudMutation(kind: .summaryRemoval, targetId: summaryId)
     }
 
     func clearPendingTranscriptRemoval(transcriptId: UUID) {
-        pendingTranscriptCloudRemovals.removeAll { $0.transcriptId == transcriptId }
+        clearPendingCloudMutation(kind: .transcriptRemoval, targetId: transcriptId)
     }
 
     func clearPendingImportedAudioRemoval(recordingId: UUID) {
-        pendingImportedAudioRemovals.removeAll { $0.recordingId == recordingId }
+        clearPendingCloudMutation(kind: .importedAudioRemoval, targetId: recordingId)
     }
 
     func clearPendingRecordingDeletion(recordingId: UUID) {
-        pendingCloudDeletionMarkers.removeAll { $0.recordingId == recordingId }
+        clearPendingCloudMutation(kind: .recordingDeletion, targetId: recordingId)
     }
 
     /// Removes the cloud audio and placeholder relationships for an imported item
@@ -5797,6 +6018,11 @@ extension iCloudStorageManager {
     private func markImportedAudioRemovedInCloud(
         _ pendingRemoval: PendingImportedAudioRemoval
     ) async throws {
+        let mutation = PendingCloudMutation(
+            kind: .importedAudioRemoval,
+            targetId: pendingRemoval.recordingId,
+            requestedAt: pendingRemoval.requestedAt
+        )
         let recordID = CKRecord.ID(
             recordName: makeBackupRecordName(
                 prefix: Self.backupRecordingRecordPrefix,
@@ -5810,7 +6036,7 @@ extension iCloudStorageManager {
         guard let record = fetchOutcome.records[recordID] else {
             // The recording was already removed from CloudKit. There is no asset
             // left for this intent to clear, so the durable work is complete.
-            clearPendingImportedAudioRemoval(recordingId: pendingRemoval.recordingId)
+            acknowledgePendingCloudMutation(mutation)
             return
         }
 
@@ -5855,7 +6081,7 @@ extension iCloudStorageManager {
         markBackupRecordActive(record, changed: &changed)
 
         guard changed else {
-            clearPendingImportedAudioRemoval(recordingId: pendingRemoval.recordingId)
+            acknowledgePendingCloudMutation(mutation)
             return
         }
 
@@ -5867,15 +6093,11 @@ extension iCloudStorageManager {
             throw CloudSyncUnsettledRecordsError(recordCount: 1)
         }
 
-        clearPendingImportedAudioRemoval(recordingId: pendingRemoval.recordingId)
+        acknowledgePendingCloudMutation(mutation)
         AppLog.shared.iCloudSync(
             "Recorded imported audio removal for \(pendingRemoval.recordingId.uuidString)",
             level: .debug
         )
-    }
-
-    private static func mergedUUIDs(_ lhs: [UUID], _ rhs: [UUID]) -> [UUID] {
-        Array(Set(lhs + rhs)).sorted { $0.uuidString < $1.uuidString }
     }
 
     /// Entry point for a deletion the user just made.
@@ -5904,6 +6126,7 @@ extension iCloudStorageManager {
 
     @discardableResult
     func flushPendingiCloudMutations(appCoordinator: AppDataCoordinator) async throws -> (deletions: Int, localOnlyRemovals: Int, summaryRemovals: Int) {
+        bindPendingMutationContext(to: appCoordinator.coreDataManager.managedObjectContext)
         guard isEnabled else {
             return (0, 0, 0)
         }
@@ -5914,54 +6137,60 @@ extension iCloudStorageManager {
         var flushedTranscriptRemovals = 0
         var flushedImportedAudioRemovals = 0
 
-        for pendingDeletion in pendingCloudDeletionMarkers {
-            try await markRecordingDeletedIniCloud(
-                recordingId: pendingDeletion.recordingId,
-                transcriptIds: pendingDeletion.transcriptIds,
-                summaryIds: pendingDeletion.summaryIds,
-                deletedAt: pendingDeletion.requestedAt
-            )
-            flushedDeletions += 1
-        }
+        // Snapshot once. Each operation acknowledges the exact payload it sent;
+        // a later enqueue for the same target therefore remains for the next run.
+        for mutation in pendingCloudMutations() {
+            switch mutation.kind {
+            case .recordingDeletion:
+                try await markRecordingDeletedIniCloud(
+                    recordingId: mutation.targetId,
+                    transcriptIds: mutation.transcriptIds,
+                    summaryIds: mutation.summaryIds,
+                    deletedAt: mutation.requestedAt
+                )
+                flushedDeletions += 1
 
-        for pendingTranscriptRemoval in pendingTranscriptCloudRemovals {
-            try await markTranscriptDeletedIniCloud(
-                transcriptId: pendingTranscriptRemoval.transcriptId,
-                recordingId: pendingTranscriptRemoval.recordingId,
-                deletedAt: pendingTranscriptRemoval.requestedAt
-            )
-            flushedTranscriptRemovals += 1
-        }
+            case .transcriptRemoval:
+                try await markTranscriptDeletedIniCloud(
+                    transcriptId: mutation.targetId,
+                    recordingId: mutation.recordingId,
+                    deletedAt: mutation.requestedAt
+                )
+                flushedTranscriptRemovals += 1
 
-        for pendingSummaryRemoval in pendingSummaryCloudRemovals {
-            try await markSummaryDeletedIniCloud(
-                summaryId: pendingSummaryRemoval.summaryId,
-                recordingId: pendingSummaryRemoval.recordingId,
-                deletedAt: pendingSummaryRemoval.requestedAt
-            )
-            flushedSummaryRemovals += 1
-        }
+            case .summaryRemoval:
+                try await markSummaryDeletedIniCloud(
+                    summaryId: mutation.targetId,
+                    recordingId: mutation.recordingId,
+                    deletedAt: mutation.requestedAt
+                )
+                flushedSummaryRemovals += 1
 
-        for pendingRemoval in pendingLocalOnlyCloudRemovals {
-            guard let recording = appCoordinator.coreDataManager.getRecording(id: pendingRemoval.recordingId) else {
-                clearPendingLocalOnlyCloudRemoval(recordingId: pendingRemoval.recordingId)
-                continue
+            case .localOnlyRemoval:
+                guard let recording = appCoordinator.coreDataManager.getRecording(id: mutation.targetId) else {
+                    acknowledgePendingCloudMutation(mutation)
+                    continue
+                }
+                guard recording.isCloudSyncDisabled else {
+                    acknowledgePendingCloudMutation(mutation)
+                    continue
+                }
+
+                try await removeContentFromiCloud(
+                    recordingId: mutation.targetId,
+                    appCoordinator: appCoordinator
+                )
+                flushedLocalOnlyRemovals += 1
+
+            case .importedAudioRemoval:
+                try await markImportedAudioRemovedInCloud(
+                    PendingImportedAudioRemoval(
+                        recordingId: mutation.targetId,
+                        requestedAt: mutation.requestedAt
+                    )
+                )
+                flushedImportedAudioRemovals += 1
             }
-            guard recording.isCloudSyncDisabled else {
-                clearPendingLocalOnlyCloudRemoval(recordingId: pendingRemoval.recordingId)
-                continue
-            }
-
-            try await removeContentFromiCloud(
-                recordingId: pendingRemoval.recordingId,
-                appCoordinator: appCoordinator
-            )
-            flushedLocalOnlyRemovals += 1
-        }
-
-        for pendingRemoval in pendingImportedAudioRemovals {
-            try await markImportedAudioRemovedInCloud(pendingRemoval)
-            flushedImportedAudioRemovals += 1
         }
 
         if flushedDeletions > 0 || flushedLocalOnlyRemovals > 0 ||
@@ -6016,11 +6245,20 @@ extension iCloudStorageManager {
     }
 
     func clearPendingCloudMutationsForTesting() {
-        pendingCloudDeletionMarkers = []
-        pendingLocalOnlyCloudRemovals = []
-        pendingSummaryCloudRemovals = []
-        pendingTranscriptCloudRemovals = []
-        pendingImportedAudioRemovals = []
+        do {
+            try PendingCloudMutationStore.removeAll(in: pendingMutationContext)
+            UserDefaults.standard.removeObject(forKey: "iCloudPendingDeletionMarkersV1")
+            UserDefaults.standard.removeObject(forKey: "iCloudPendingLocalOnlyRemovalsV1")
+            UserDefaults.standard.removeObject(forKey: "iCloudPendingSummaryRemovalsV1")
+            UserDefaults.standard.removeObject(forKey: "iCloudPendingTranscriptRemovalsV1")
+            UserDefaults.standard.removeObject(forKey: "iCloudPendingImportedAudioRemovalsV1")
+        } catch {
+            pendingMutationContext.rollback()
+            AppLog.shared.iCloudSync(
+                "Could not clear pending cloud mutations for testing: \(error)",
+                level: .error
+            )
+        }
     }
     #endif
 
@@ -7637,6 +7875,7 @@ extension iCloudStorageManager {
         includeAudioFiles: Bool,
         recorder: CloudSyncRunRecorder?,
         stagingByteBudget: Int64,
+        availableStagingCapacity: Int64?,
         stagedBytes: inout Int64,
         result: inout CloudBackupResult,
         changed: inout Bool
@@ -7662,7 +7901,8 @@ extension iCloudStorageManager {
             cloudSignature: record[Self.fieldAudioSignature] as? String,
             byteCount: byteCount,
             stagedBytesSoFar: stagedBytes,
-            stagingByteBudget: stagingByteBudget
+            stagingByteBudget: stagingByteBudget,
+            availableCapacity: availableStagingCapacity
         )
 
         switch decision {
@@ -7676,6 +7916,16 @@ extension iCloudStorageManager {
             // next run offers this file again rather than taking the
             // nothing-changed shortcut past it.
             result.audioFilesPendingRetry += 1
+            return false
+        case .deferredInsufficientSpace(let requiredBytes, let availableBytes):
+            result.audioFilesPendingRetry += 1
+            result.audioFilesDeferredForInsufficientSpace += 1
+            reportStagingCapacityShortage(
+                for: recording,
+                signature: signature,
+                requiredBytes: requiredBytes,
+                availableBytes: availableBytes
+            )
             return false
         case .upload(let uploadByteCount, let uploadSignature):
             guard let localURL, let stagedURL = await staging.stage(localURL) else {
@@ -7698,6 +7948,23 @@ extension iCloudStorageManager {
             recorder?.addAudio(fileCount: 1, byteCount: uploadByteCount, seconds: durationSeconds)
             return true
         }
+    }
+
+    private func reportStagingCapacityShortage(
+        for recording: RecordingEntry,
+        signature: String?,
+        requiredBytes: Int64,
+        availableBytes: Int64
+    ) {
+        guard let signature else { return }
+        let identity = recording.id?.uuidString ?? recording.recordingName ?? "recording"
+        let key = "\(identity):\(signature)"
+        guard reportedStagingCapacityShortages.insert(key).inserted else { return }
+
+        publishMaintenanceMessage(
+            "Audio backup for \(recording.recordingName ?? "this recording") is waiting for disk space " +
+                "(needs \(requiredBytes) bytes; \(availableBytes) available)."
+        )
     }
 
     /// Brings the audio assets down for records that are about to be written to

--- a/BisonNotes AI/BisonNotes AITests/CacheMaintenanceTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/CacheMaintenanceTests.swift
@@ -494,6 +494,31 @@ final class CacheMaintenanceTests: XCTestCase {
         XCTAssertEqual(whenIdle.cloudKitAssetCount, 1)
     }
 
+    func testSweepYieldsBeforeDeletingWhenNewWorkArrives() async throws {
+        let root = try makeCachesRoot(hubRepos: [], installedModels: [])
+        let assets = root
+            .appendingPathComponent("CloudKit", isDirectory: true)
+            .appendingPathComponent("container", isDirectory: true)
+            .appendingPathComponent("Assets", isDirectory: true)
+        try FileManager.default.createDirectory(at: assets, withIntermediateDirectories: true)
+        let asset = assets.appendingPathComponent("asset0")
+        try Data(repeating: 0x65, count: 4_096).write(to: asset)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSinceNow: -60 * 60 * 48)],
+            ofItemAtPath: asset.path
+        )
+
+        let report = await CacheMaintenanceSweep(cachesRoot: root).run(
+            isDownloadInFlight: { false },
+            isCloudSyncActive: { false },
+            shouldYield: { true }
+        )
+
+        XCTAssertTrue(report.didYieldToActiveWork)
+        XCTAssertEqual(report.cloudKitAssetCount, 0)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: asset.path))
+    }
+
     /// The sync gate skips what the sweep is looking at; it must not abandon the
     /// pass. This sweep is scheduled from launch and activation — the same moments
     /// that start a sync — so returning on the first busy check meant a device that

--- a/BisonNotes AI/BisonNotes AITests/CloudAudioAssetPolicyTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/CloudAudioAssetPolicyTests.swift
@@ -156,6 +156,87 @@ final class CloudAudioAssetPolicyTests: XCTestCase {
         XCTAssertEqual(decision, .skippedUnchanged)
     }
 
+    func testAFileThatExceedsReportedCapacityReturnsATypedRetry() {
+        let decision = CloudAudioAssetPolicy.decide(
+            includeAudioFiles: true,
+            sourceExists: true,
+            localSignature: "new",
+            cloudSignature: "old",
+            byteCount: 900,
+            stagedBytesSoFar: 200,
+            stagingByteBudget: 10_000,
+            availableCapacity: 1_000
+        )
+
+        XCTAssertEqual(
+            decision,
+            .deferredInsufficientSpace(requiredBytes: 1_100, availableBytes: 1_000)
+        )
+        XCTAssertFalse(decision.uploads)
+    }
+
+    func testReportedCapacityShortageWinsOverThePerRunBudget() {
+        let decision = CloudAudioAssetPolicy.decide(
+            includeAudioFiles: true,
+            sourceExists: true,
+            localSignature: "new",
+            cloudSignature: "old",
+            byteCount: 900,
+            stagedBytesSoFar: 200,
+            stagingByteBudget: 500,
+            availableCapacity: 10_000
+        )
+
+        XCTAssertEqual(decision, .deferredOverStagingBudget)
+    }
+
+    func testUnknownCapacityDoesNotStrandAnAudioUpload() {
+        let nilCapacity = CloudAudioAssetPolicy.decide(
+            includeAudioFiles: true,
+            sourceExists: true,
+            localSignature: "new",
+            cloudSignature: "old",
+            byteCount: 900,
+            availableCapacity: nil
+        )
+        let negativeCapacity = CloudAudioAssetPolicy.decide(
+            includeAudioFiles: true,
+            sourceExists: true,
+            localSignature: "new",
+            cloudSignature: "old",
+            byteCount: 900,
+            availableCapacity: -1
+        )
+
+        XCTAssertTrue(nilCapacity.uploads)
+        XCTAssertTrue(negativeCapacity.uploads)
+    }
+
+    func testARecoveredCapacityAllowsTheSameAudioToUpload() {
+        let blocked = CloudAudioAssetPolicy.decide(
+            includeAudioFiles: true,
+            sourceExists: true,
+            localSignature: "new",
+            cloudSignature: "old",
+            byteCount: 900,
+            availableCapacity: 100
+        )
+        let recovered = CloudAudioAssetPolicy.decide(
+            includeAudioFiles: true,
+            sourceExists: true,
+            localSignature: "new",
+            cloudSignature: "old",
+            byteCount: 900,
+            availableCapacity: 1_000
+        )
+
+        XCTAssertEqual(
+            blocked,
+            .deferredInsufficientSpace(requiredBytes: 900, availableBytes: 100)
+        )
+        XCTAssertEqual(recovered, .upload(byteCount: 900, signature: "new"))
+    }
+
     func testTheBudgetIsNeverMoreThanHalfOfWhatIsFree() {
         XCTAssertEqual(CloudAudioAssetPolicy.stagingByteBudget(availableCapacity: 1_000), 500)
     }

--- a/BisonNotes AI/BisonNotes AITests/ICloudBackupRegressionTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/ICloudBackupRegressionTests.swift
@@ -4,6 +4,7 @@
 //
 
 import CloudKit
+import CoreData
 import XCTest
 @testable import BisonNotes_AI
 
@@ -12,6 +13,47 @@ final class ICloudBackupRegressionTests: XCTestCase {
     private var persistenceController: PersistenceController!
     private var appCoordinator: AppDataCoordinator!
     private var tempDirectory: URL!
+
+    private static let legacyMutationKeys = [
+        "iCloudPendingDeletionMarkersV1",
+        "iCloudPendingLocalOnlyRemovalsV1",
+        "iCloudPendingSummaryRemovalsV1",
+        "iCloudPendingTranscriptRemovalsV1",
+        "iCloudPendingImportedAudioRemovalsV1"
+    ]
+
+    private struct LegacyDeletionMarkerFixture: Codable {
+        let recordingId: UUID
+        let transcriptIds: [UUID]
+        let summaryIds: [UUID]
+        let requestedAt: Date
+    }
+
+    private struct LegacyLocalOnlyRemovalFixture: Codable {
+        let recordingId: UUID
+        let requestedAt: Date
+    }
+
+    private struct LegacySummaryRemovalFixture: Codable {
+        let summaryId: UUID
+        let recordingId: UUID?
+        let requestedAt: Date
+    }
+
+    private struct LegacyTranscriptRemovalFixture: Codable {
+        let transcriptId: UUID
+        let recordingId: UUID?
+        let requestedAt: Date
+    }
+
+    private struct LegacyImportedAudioRemovalFixture: Codable {
+        let recordingId: UUID
+        let requestedAt: Date
+    }
+
+    private final class PersistentStoreLoadBox: @unchecked Sendable {
+        var error: Error?
+    }
 
     override func setUpWithError() throws {
         UserDefaults.standard.set(false, forKey: "iCloudSyncEnabled")
@@ -1183,6 +1225,275 @@ final class ICloudBackupRegressionTests: XCTestCase {
         XCTAssertEqual(manifest, [], "The manifest must not keep claiming a record that was deleted")
     }
 
+    // MARK: Durable outbox persistence and migration
+
+    func testSQLiteMigrationFromShippingModelPreservesContentAndAddsDurableOutbox() throws {
+        let storeURL = tempDirectory.appendingPathComponent("shipping-migration.sqlite")
+        let shippingContainer = try makeShippingModelContainer(at: storeURL)
+        let recordingId = UUID()
+        let shippingContext = shippingContainer.viewContext
+        let shippingRecording = NSEntityDescription.insertNewObject(
+            forEntityName: "RecordingEntry",
+            into: shippingContext
+        )
+        shippingRecording.setValue(recordingId, forKey: "id")
+        shippingRecording.setValue("Before durable outbox", forKey: "recordingName")
+        shippingRecording.setValue(Date(), forKey: "recordingDate")
+        shippingRecording.setValue(42.0, forKey: "duration")
+        shippingRecording.setValue(Int64(1024), forKey: "fileSize")
+        shippingRecording.setValue(Date(), forKey: "lastModified")
+        try shippingContext.save()
+        try closePersistentStores(of: shippingContainer)
+
+        let migrated = PersistenceController(storeURL: storeURL)
+        defer { try? closePersistentStores(of: migrated) }
+        let context = migrated.container.viewContext
+        let request = NSFetchRequest<NSManagedObject>(entityName: "RecordingEntry")
+        request.predicate = NSPredicate(format: "id == %@", recordingId as CVarArg)
+        let restored = try XCTUnwrap(try context.fetch(request).first)
+
+        XCTAssertEqual(restored.value(forKey: "recordingName") as? String, "Before durable outbox")
+        XCTAssertNotNil(
+            NSEntityDescription.entity(forEntityName: PendingCloudMutationStore.entityName, in: context),
+            "The current model must add the outbox entity while migrating the shipping store"
+        )
+
+        let requestedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        try PendingCloudMutationStore.enqueue(
+            PendingCloudMutation(
+                kind: .recordingDeletion,
+                targetId: recordingId,
+                requestedAt: requestedAt
+            ),
+            in: context
+        )
+        try context.save()
+
+        XCTAssertEqual(
+            try PendingCloudMutationStore.fetchAll(in: context),
+            [PendingCloudMutation(kind: .recordingDeletion, targetId: recordingId, requestedAt: requestedAt)]
+        )
+    }
+
+    func testSQLiteDeletionAndOutboxSurviveReopenTogether() throws {
+        let storeURL = tempDirectory.appendingPathComponent("delete-outbox.sqlite")
+        let recordingId = UUID()
+        let firstController = PersistenceController(storeURL: storeURL)
+        let firstManager = CoreDataManager(persistenceController: firstController)
+        let recording = RecordingEntry(context: firstManager.managedObjectContext)
+        recording.id = recordingId
+        recording.recordingName = "Durably deleted"
+        recording.recordingDate = Date()
+        recording.duration = 30
+        recording.fileSize = 1024
+        recording.lastModified = Date()
+        try firstManager.saveContext()
+
+        try firstManager.deleteRecording(id: recordingId)
+        XCTAssertNil(firstManager.getRecording(id: recordingId))
+        XCTAssertEqual(PendingCloudMutationStore.count(in: firstManager.managedObjectContext), 1)
+        try closePersistentStores(of: firstController)
+
+        let reopened = PersistenceController(storeURL: storeURL)
+        defer { try? closePersistentStores(of: reopened) }
+        let context = reopened.container.viewContext
+        let recordings = try context.fetch(NSFetchRequest<NSManagedObject>(entityName: "RecordingEntry"))
+        let mutations = try PendingCloudMutationStore.fetchAll(in: context)
+
+        XCTAssertTrue(recordings.isEmpty)
+        XCTAssertEqual(mutations.count, 1)
+        XCTAssertEqual(mutations.first?.kind, .recordingDeletion)
+        XCTAssertEqual(mutations.first?.targetId, recordingId)
+    }
+
+    func testSQLiteSaveFailureRollsBackTheDeletionAndItsOutboxTogether() throws {
+        let storeURL = tempDirectory.appendingPathComponent("delete-outbox-rollback.sqlite")
+        let controller = PersistenceController(storeURL: storeURL)
+        defer { try? closePersistentStores(of: controller) }
+        let manager = CoreDataManager(persistenceController: controller)
+        let context = manager.managedObjectContext
+        let recordingId = UUID()
+        let recording = RecordingEntry(context: context)
+        recording.id = recordingId
+        recording.recordingName = "Must survive failed save"
+        recording.recordingDate = Date()
+        recording.duration = 30
+        recording.fileSize = 1024
+        recording.lastModified = Date()
+        try manager.saveContext()
+
+        // Force the same save to contain an invalid required outbox value. The
+        // deletion and the valid outbox row must both roll back as one transaction.
+        let invalidOutbox = NSEntityDescription.insertNewObject(
+            forEntityName: PendingCloudMutationStore.entityName,
+            into: context
+        )
+        invalidOutbox.setValue(nil, forKey: "kind")
+        invalidOutbox.setValue(nil, forKey: "targetId")
+
+        XCTAssertThrowsError(try manager.deleteRecording(id: recordingId))
+        XCTAssertNotNil(manager.getRecording(id: recordingId))
+        XCTAssertEqual(PendingCloudMutationStore.count(in: context), 0)
+    }
+
+    func testClearAllCoreDataCommitsItsCloudRemovalsWithTheLocalRows() async throws {
+        _ = try createCompleteRecording(named: "Clear all transaction")
+        let migrationManager = DataMigrationManager(persistenceController: persistenceController)
+
+        await migrationManager.clearAllCoreData()
+
+        XCTAssertTrue(appCoordinator.coreDataManager.getAllRecordings().isEmpty)
+        XCTAssertTrue(appCoordinator.coreDataManager.getAllTranscripts().isEmpty)
+        XCTAssertTrue(appCoordinator.coreDataManager.getAllSummaries().isEmpty)
+
+        let mutations = try PendingCloudMutationStore.fetchAll(
+            in: persistenceController.container.viewContext
+        )
+        XCTAssertEqual(mutations.count, 3)
+        XCTAssertEqual(
+            Set(mutations.map(\.kind)),
+            Set([
+                .recordingDeletion,
+                .transcriptRemoval,
+                .summaryRemoval
+            ])
+        )
+    }
+
+    func testLegacyMutationQueuesMigrateLosslesslyAndRerunWithoutDuplicates() throws {
+        let defaults = UserDefaults.standard
+        let keys = Self.legacyMutationKeys
+        let oldValues = keys.map { ($0, defaults.object(forKey: $0)) }
+        defer {
+            for (key, value) in oldValues {
+                if let value { defaults.set(value, forKey: key) } else { defaults.removeObject(forKey: key) }
+            }
+        }
+        keys.forEach { defaults.removeObject(forKey: $0) }
+
+        let recordingId = UUID()
+        let transcriptId = UUID()
+        let summaryId = UUID()
+        let requestedAt = Date(timeIntervalSince1970: 1_700_000_001)
+        let encoder = JSONEncoder()
+        defaults.set(
+            try encoder.encode([
+                LegacyDeletionMarkerFixture(
+                    recordingId: recordingId,
+                    transcriptIds: [transcriptId],
+                    summaryIds: [summaryId],
+                    requestedAt: requestedAt
+                )
+            ]),
+            forKey: "iCloudPendingDeletionMarkersV1"
+        )
+        defaults.set(
+            try encoder.encode([
+                LegacyLocalOnlyRemovalFixture(recordingId: recordingId, requestedAt: requestedAt)
+            ]),
+            forKey: "iCloudPendingLocalOnlyRemovalsV1"
+        )
+        defaults.set(
+            try encoder.encode([
+                LegacySummaryRemovalFixture(
+                    summaryId: summaryId,
+                    recordingId: recordingId,
+                    requestedAt: requestedAt
+                )
+            ]),
+            forKey: "iCloudPendingSummaryRemovalsV1"
+        )
+        defaults.set(
+            try encoder.encode([
+                LegacyTranscriptRemovalFixture(
+                    transcriptId: transcriptId,
+                    recordingId: recordingId,
+                    requestedAt: requestedAt
+                )
+            ]),
+            forKey: "iCloudPendingTranscriptRemovalsV1"
+        )
+        defaults.set(
+            try encoder.encode([
+                LegacyImportedAudioRemovalFixture(recordingId: recordingId, requestedAt: requestedAt)
+            ]),
+            forKey: "iCloudPendingImportedAudioRemovalsV1"
+        )
+
+        let controller = PersistenceController(inMemory: true)
+        defer { try? closePersistentStores(of: controller) }
+        let context = controller.container.viewContext
+
+        XCTAssertTrue(PendingCloudMutationStore.migrateLegacyQueuesIfNeeded(in: context))
+        let firstPass = try PendingCloudMutationStore.fetchAll(in: context)
+        XCTAssertEqual(firstPass.count, 5)
+        XCTAssertTrue(keys.allSatisfy { defaults.object(forKey: $0) == nil })
+        XCTAssertFalse(PendingCloudMutationStore.migrateLegacyQueuesIfNeeded(in: context))
+        XCTAssertEqual(try PendingCloudMutationStore.fetchAll(in: context).count, firstPass.count)
+        XCTAssertEqual(
+            Set(firstPass.map(\.kind)),
+            Set(PendingCloudMutationKind.allCases)
+        )
+        XCTAssertEqual(
+            firstPass.first(where: { $0.kind == .recordingDeletion })?.transcriptIds,
+            [transcriptId]
+        )
+        XCTAssertEqual(
+            firstPass.first(where: { $0.kind == .recordingDeletion })?.summaryIds,
+            [summaryId]
+        )
+    }
+
+    func testFailedLegacyMigrationRetainsRecoverableUserDefaultsData() throws {
+        let defaults = UserDefaults.standard
+        let key = "iCloudPendingDeletionMarkersV1"
+        let oldValue = defaults.object(forKey: key)
+        defer {
+            if let oldValue { defaults.set(oldValue, forKey: key) } else { defaults.removeObject(forKey: key) }
+        }
+        let malformed = Data("not-json".utf8)
+        defaults.set(malformed, forKey: key)
+
+        let controller = PersistenceController(inMemory: true)
+        defer { try? closePersistentStores(of: controller) }
+        XCTAssertFalse(PendingCloudMutationStore.migrateLegacyQueuesIfNeeded(in: controller.container.viewContext))
+        XCTAssertEqual(defaults.data(forKey: key), malformed)
+        XCTAssertTrue(try PendingCloudMutationStore.fetchAll(in: controller.container.viewContext).isEmpty)
+    }
+
+    func testPendingMutationAcknowledgementRetainsAConcurrentNewerPayload() throws {
+        let controller = PersistenceController(inMemory: true)
+        defer { try? closePersistentStores(of: controller) }
+        let context = controller.container.viewContext
+        let targetId = UUID()
+        let firstTranscript = UUID()
+        let newerTranscript = UUID()
+        let first = PendingCloudMutation(
+            kind: .recordingDeletion,
+            targetId: targetId,
+            transcriptIds: [firstTranscript],
+            requestedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        try PendingCloudMutationStore.enqueue(first, in: context)
+        try context.save()
+        let snapshot = try XCTUnwrap(PendingCloudMutationStore.fetchAll(in: context).first)
+
+        try PendingCloudMutationStore.enqueue(
+            PendingCloudMutation(
+                kind: .recordingDeletion,
+                targetId: targetId,
+                transcriptIds: [newerTranscript],
+                requestedAt: Date(timeIntervalSince1970: 1_700_000_100)
+            ),
+            in: context
+        )
+        try context.save()
+
+        XCTAssertFalse(try PendingCloudMutationStore.removeIfUnchanged(snapshot, from: context))
+        let retained = try XCTUnwrap(PendingCloudMutationStore.fetchAll(in: context).first)
+        XCTAssertEqual(Set(retained.transcriptIds), Set([firstTranscript, newerTranscript]))
+    }
+
     // MARK: Arbitration through the real legs
 
     func testNewerCloudRecordWinsThroughBatchedExecution() async throws {
@@ -1348,5 +1659,47 @@ final class ICloudBackupRegressionTests: XCTestCase {
             ProcessingStatus.completed.rawValue,
             "An accepted summary must repair a stale recording status"
         )
+    }
+
+    private func makeShippingModelContainer(at storeURL: URL) throws -> NSPersistentContainer {
+        let sourceRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let modelURL = sourceRoot
+            .appendingPathComponent("BisonNotes_AI.xcdatamodeld")
+            .appendingPathComponent("BisonNotes_AI.xcdatamodel")
+        guard let model = NSManagedObjectModel(contentsOf: modelURL) else {
+            throw NSError(
+                domain: "ICloudBackupRegressionTests",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Could not load the shipping Core Data model at \(modelURL.path)"]
+            )
+        }
+
+        let container = NSPersistentContainer(name: "BisonNotes_AI_Shipping", managedObjectModel: model)
+        let description = container.persistentStoreDescriptions[0]
+        description.url = storeURL
+        description.setOption(true as NSNumber, forKey: NSMigratePersistentStoresAutomaticallyOption)
+        description.setOption(true as NSNumber, forKey: NSInferMappingModelAutomaticallyOption)
+        let loadBox = PersistentStoreLoadBox()
+        container.loadPersistentStores { _, error in
+            loadBox.error = error
+        }
+        if let loadError = loadBox.error { throw loadError }
+        return container
+    }
+
+    private func closePersistentStores(of controller: PersistenceController) throws {
+        let coordinator = controller.container.persistentStoreCoordinator
+        for store in coordinator.persistentStores {
+            try coordinator.remove(store)
+        }
+    }
+
+    private func closePersistentStores(of container: NSPersistentContainer) throws {
+        let coordinator = container.persistentStoreCoordinator
+        for store in coordinator.persistentStores {
+            try coordinator.remove(store)
+        }
     }
 }

--- a/BisonNotes AI/BisonNotes AITests/ICloudBackupRegressionTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/ICloudBackupRegressionTests.swift
@@ -1661,13 +1661,35 @@ final class ICloudBackupRegressionTests: XCTestCase {
         )
     }
 
+    /// The compiled `.momd` that ships in the bundle, which holds every model
+    /// version as its own `.mom`.
+    ///
+    /// Deliberately not the source `.xcdatamodel`: `NSManagedObjectModel` loads
+    /// compiled `.mom`/`.momd` only, so reading the source tree could never have
+    /// produced a model no matter what path it was given.
+    private static func compiledModelDirectoryURL() -> URL? {
+        var searched: [Bundle] = [Bundle(for: ICloudBackupRegressionTests.self), Bundle.main]
+        searched.append(contentsOf: Bundle.allBundles)
+        for bundle in searched {
+            if let url = bundle.url(forResource: "BisonNotes_AI", withExtension: "momd") {
+                return url
+            }
+        }
+        return nil
+    }
+
     private func makeShippingModelContainer(at storeURL: URL) throws -> NSPersistentContainer {
-        let sourceRoot = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        let modelURL = sourceRoot
-            .appendingPathComponent("BisonNotes_AI.xcdatamodeld")
-            .appendingPathComponent("BisonNotes_AI.xcdatamodel")
+        guard let modelDirectoryURL = Self.compiledModelDirectoryURL() else {
+            throw NSError(
+                domain: "ICloudBackupRegressionTests",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Could not find BisonNotes_AI.momd in any loaded bundle"]
+            )
+        }
+        // `BisonNotes_AI.mom` is the v1 entry — the model as shipped, before
+        // `PendingCloudMutation` was added. Opening the `.momd` directory instead
+        // would load the current version and test nothing.
+        let modelURL = modelDirectoryURL.appendingPathComponent("BisonNotes_AI.mom")
         guard let model = NSManagedObjectModel(contentsOf: modelURL) else {
             throw NSError(
                 domain: "ICloudBackupRegressionTests",
@@ -1675,6 +1697,10 @@ final class ICloudBackupRegressionTests: XCTestCase {
                 userInfo: [NSLocalizedDescriptionKey: "Could not load the shipping Core Data model at \(modelURL.path)"]
             )
         }
+        XCTAssertNil(
+            model.entitiesByName[PendingCloudMutationStore.entityName],
+            "The shipping model must not already contain the outbox, or this migration proves nothing"
+        )
 
         let container = NSPersistentContainer(name: "BisonNotes_AI_Shipping", managedObjectModel: model)
         let description = container.persistentStoreDescriptions[0]

--- a/BisonNotes AI/BisonNotes AITests/ICloudSyncOrchestrationTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/ICloudSyncOrchestrationTests.swift
@@ -62,10 +62,19 @@ final class ICloudSyncOrchestrationTests: XCTestCase {
             metricsSink: metrics
         )
         manager.networkStatus = .available
+        // The outbox is a Core Data table now, not a UserDefaults blob, so clearing
+        // it only reaches the store this manager is bound to. Bind it to the test
+        // store first: deletions made through `appCoordinator` queue their intent
+        // there via the shared manager, and clearing the default on-disk store
+        // instead left those rows behind for `bindPendingMutationContext` to copy
+        // into the next test's store, where the flush leg then wrote them out.
+        manager.bindPendingMutationContext(to: appCoordinator.coreDataManager.managedObjectContext)
         manager.clearPendingCloudMutationsForTesting()
     }
 
     override func tearDown() async throws {
+        // Bound to the test store in `setUp`, so this really does empty it rather
+        // than the process-wide default store.
         manager?.clearPendingCloudMutationsForTesting()
         // A retry armed by a deferred run holds the coordinator until it fires.
         manager?.cancelDeferredSyncRetry()

--- a/BisonNotes AI/BisonNotes AITests/ICloudSyncOrchestrationTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/ICloudSyncOrchestrationTests.swift
@@ -962,6 +962,61 @@ final class ICloudSyncOrchestrationTests: XCTestCase {
         }
     }
 
+    func testCloudSyncWaitsForCacheMaintenanceAndRequestsAYield() async throws {
+        let coordinator = CloudSyncOperationCoordinator()
+        XCTAssertTrue(coordinator.beginCacheMaintenance())
+        var ran = false
+
+        let sync = Task { @MainActor in
+            try await coordinator.submit(intent: .routineSnapshot) {
+                ran = true
+            }
+        }
+        await Task.yield()
+
+        XCTAssertFalse(ran)
+        XCTAssertTrue(coordinator.shouldYieldCacheMaintenance)
+
+        coordinator.endCacheMaintenance()
+        _ = try await sync.value
+        XCTAssertTrue(ran)
+    }
+
+    func testCancelledCloudSyncWaiterIsRemovedFromTheFollowUpQueue() async throws {
+        let coordinator = CloudSyncOperationCoordinator()
+        let gate = AsyncGate()
+        let first = Task { @MainActor in
+            try await coordinator.submit(intent: .routineSnapshot) {
+                await gate.wait()
+            }
+        }
+        await waitUntil("the first sync to start") { coordinator.isRunning }
+
+        var secondWorkRan = false
+        let second = Task { @MainActor in
+            try await coordinator.submit(
+                intent: .seedFromThisDevice,
+                allowJoiningRunningOperation: false
+            ) {
+                secondWorkRan = true
+            }
+        }
+        await waitUntil("the second sync to queue") { coordinator.pendingFollowUpCount == 1 }
+
+        second.cancel()
+        do {
+            _ = try await second.value
+            XCTFail("A cancelled queued waiter must throw")
+        } catch is CancellationError {
+            // Expected.
+        }
+        XCTAssertEqual(coordinator.pendingFollowUpCount, 0)
+        XCTAssertFalse(secondWorkRan)
+
+        gate.open()
+        _ = try await first.value
+    }
+
     func testAThrottledQueryDoesNotEscalateIntoAZoneScan() async throws {
         try createCompleteRecording(named: "Throttled query")
         // The deletion-marker scan is the first query a run makes.
@@ -1883,6 +1938,86 @@ final class ICloudSyncOrchestrationTests: XCTestCase {
         XCTAssertEqual(fullReadCount, 2, "The refetch this covers has to have happened")
     }
 
+    /// A failed restore copy is a transient local-cache/filesystem condition, not
+    /// evidence that the cloud asset is gone. The next routine pass must fetch the
+    /// asset again and install it without requiring a manual restore.
+    func testARecordingAudioRestoreIsRetriedByALaterRoutineReconcile() async throws {
+        let recordingId = UUID()
+        let now = Date()
+        let context = appCoordinator.coreDataManager.managedObjectContext
+        let recording = RecordingEntry(context: context)
+        recording.id = recordingId
+        recording.recordingName = "Restore retry"
+        recording.recordingDate = now
+        recording.createdAt = now
+        recording.lastModified = now
+        recording.recordingURL = nil
+        recording.duration = 12
+        recording.fileSize = 11
+        recording.audioQuality = AudioQuality.whisperOptimized.rawValue
+        recording.transcriptionStatus = ProcessingStatus.notStarted.rawValue
+        recording.summaryStatus = ProcessingStatus.notStarted.rawValue
+        try context.save()
+
+        let cloudAudioURL = tempDirectory.appendingPathComponent("restore-retry.m4a")
+        try Data("cloud audio that becomes available to the next pass".utf8).write(to: cloudAudioURL)
+        let recordName = "backup_recording_\(recordingId.uuidString)"
+        transport.seed([
+            CloudKitTestRecords.record(
+                type: "CD_BackupRecording",
+                name: recordName,
+                fields: [
+                    "recordingName": "Restore retry",
+                    "recordingDate": now,
+                    "createdAt": now,
+                    "lastModified": now,
+                    "recordingURL": "restore-retry.m4a",
+                    "duration": 12.0,
+                    "fileSize": 11,
+                    "audioQuality": AudioQuality.whisperOptimized.rawValue,
+                    "audioAsset": CKAsset(fileURL: cloudAudioURL),
+                    "audioFileName": "restore-retry.m4a",
+                    "audioByteCount": Int64("cloud audio that becomes available to the next pass".utf8.count),
+                    "audioSignature": "restore-retry-signature",
+                    "syncLifecycle": "active",
+                    "syncSchemaVersion": 2
+                ]
+            )
+        ])
+        seedTrustedManifest()
+
+        let previousAudioSetting = UserDefaults.standard.object(forKey: "iCloudBackupIncludeAudioFiles")
+        UserDefaults.standard.set(true, forKey: "iCloudBackupIncludeAudioFiles")
+        defer {
+            manager.setRestoredAudioFileManagerForTesting(nil)
+            if let previousAudioSetting {
+                UserDefaults.standard.set(previousAudioSetting, forKey: "iCloudBackupIncludeAudioFiles")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "iCloudBackupIncludeAudioFiles")
+            }
+        }
+
+        manager.setRestoredAudioFileManagerForTesting(FailingReconcileRestoreCopyFileManager())
+        let failed = try await runReconcile()
+
+        XCTAssertEqual(failed.restoreResult.audioFilesFailedToRestore, 1)
+        XCTAssertEqual(failed.restoreResult.audioFilesRestored, 0)
+        XCTAssertNil(
+            appCoordinator.getRecording(id: recordingId)?.recordingURL,
+            "A failed copy must leave the existing local URL untouched"
+        )
+
+        manager.setRestoredAudioFileManagerForTesting(nil)
+        let retried = try await runReconcile(reason: .appBecameActive)
+
+        XCTAssertEqual(retried.restoreResult.audioFilesFailedToRestore, 0)
+        XCTAssertEqual(retried.restoreResult.audioFilesRestored, 1)
+        let restoredRecording = try XCTUnwrap(appCoordinator.getRecording(id: recordingId))
+        let restoredURL = try XCTUnwrap(appCoordinator.coreDataManager.getAbsoluteURL(for: restoredRecording))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: restoredURL.path))
+        XCTAssertEqual(try Data(contentsOf: restoredURL), Data("cloud audio that becomes available to the next pass".utf8))
+    }
+
     /// A marker is the only record other devices have of a delete they did not
     /// see. Retiring it in the same non-atomic batch as the records it authorises
     /// means CloudKit can take the marker, permanently refuse one content record,
@@ -2023,5 +2158,12 @@ final class ICloudSyncOrchestrationTests: XCTestCase {
             appCoordinator.coreDataManager.getAllRecordings().contains { $0.id == recordingId },
             "The bootstrap scan must actually restore what it finds"
         )
+    }
+}
+
+private final class FailingReconcileRestoreCopyFileManager: FileManager, @unchecked Sendable {
+    override func copyItem(at source: URL, to destination: URL) throws {
+        try Data("partial restore".utf8).write(to: destination)
+        throw POSIXError(.ENOSPC)
     }
 }

--- a/BisonNotes AI/BisonNotes AITests/MLXDownloadGenerationTests.swift
+++ b/BisonNotes AI/BisonNotes AITests/MLXDownloadGenerationTests.swift
@@ -4,6 +4,73 @@ import XCTest
 
 final class MLXDownloadGenerationTests: XCTestCase {
     @MainActor
+    func testDownloadWaitsForCacheMaintenanceAndStartsAfterItReleases() async {
+        let defaults = UserDefaults.standard
+        let modelKey = MLXSwiftSettingsKeys.modelId
+        let markerKey = MLXSwiftSettingsKeys.inFlightDownloadModelID
+        let oldModel = defaults.object(forKey: modelKey)
+        let oldMarker = defaults.object(forKey: markerKey)
+        defer {
+            defaults.set(oldModel, forKey: modelKey)
+            defaults.set(oldMarker, forKey: markerKey)
+        }
+
+        defaults.set("tests/maintenance-queue-\(UUID())", forKey: modelKey)
+        let downloads = ControlledMLXDownloads()
+        let manager = MLXSwiftDownloadManager(
+            downloadOperation: { _ in try await downloads.run() },
+            blobCleanup: { _ in }
+        )
+
+        XCTAssertTrue(manager.beginCacheMaintenance())
+        manager.startDownload()
+        XCTAssertTrue(manager.isDownloadQueued)
+        XCTAssertFalse(manager.isDownloading)
+        XCTAssertTrue(downloads.pending.isEmpty)
+
+        manager.endCacheMaintenance()
+        await waitUntil { downloads.pending.count == 1 }
+        XCTAssertTrue(manager.isDownloading)
+        XCTAssertFalse(manager.isDownloadQueued)
+
+        downloads.finish(0)
+        await waitUntil { !manager.isDownloading }
+    }
+
+    @MainActor
+    func testCancelledQueuedDownloadDoesNotStartAfterMaintenance() async {
+        let defaults = UserDefaults.standard
+        let modelKey = MLXSwiftSettingsKeys.modelId
+        let markerKey = MLXSwiftSettingsKeys.inFlightDownloadModelID
+        let oldModel = defaults.object(forKey: modelKey)
+        let oldMarker = defaults.object(forKey: markerKey)
+        defer {
+            defaults.set(oldModel, forKey: modelKey)
+            defaults.set(oldMarker, forKey: markerKey)
+        }
+
+        defaults.set("tests/maintenance-cancel-\(UUID())", forKey: modelKey)
+        let downloads = ControlledMLXDownloads()
+        let manager = MLXSwiftDownloadManager(
+            downloadOperation: { _ in try await downloads.run() },
+            blobCleanup: { _ in }
+        )
+
+        XCTAssertTrue(manager.beginCacheMaintenance())
+        manager.startDownload()
+        XCTAssertTrue(manager.isDownloadQueued)
+
+        manager.cancelDownload()
+        XCTAssertFalse(manager.isDownloadQueued)
+        XCTAssertFalse(manager.isDownloading)
+
+        manager.endCacheMaintenance()
+        await Task.yield()
+        XCTAssertTrue(downloads.pending.isEmpty)
+        XCTAssertFalse(manager.isDownloading)
+    }
+
+    @MainActor
     func testCancelledCompletionCannotCleanUpReplacementDownload() async {
         await exerciseRestart(staleFails: false, replacementFinishesFirst: false)
     }

--- a/docs/for-v2.5.md
+++ b/docs/for-v2.5.md
@@ -16,10 +16,38 @@ Ordered by value, not by effort.
 
 ---
 
+## Follow-up execution status — 2026-09-06
+
+The correctness work from [v2.5-follow-up-agent-plan.md](v2.5-follow-up-agent-plan.md)
+is implemented on `codex/v2.5-follow-up-agent-plan`, based on `v2.5`. The
+remaining release gates are recorded here rather than implied by source-level
+tests:
+
+- Atomic deletion intent now lives in a versioned `PendingCloudMutation` entity
+  in the same Core Data store and transaction as local changes, including the
+  clear-all local-data path. Legacy queues migrate losslessly and retain
+  malformed data for recovery.
+- Failed restore audio is retried by a later ordinary reconcile; no separate
+  retry queue was needed.
+- CloudKit and Hub cache maintenance use reservations, cooperative yield, and
+  cancellation-safe queued work. Typed staging-capacity deferral preserves
+  metadata progress and retries audio after space is available.
+- The native macOS Debug build passed. The iOS test target could not complete in
+  this checkout because the existing Watch Widget source uses `accessoryCorner`,
+  which Xcode 26.6 reports unavailable for the iOS build configuration. Signed
+  device, two-device CloudKit, low-storage, and real download/sync validation
+  remain outstanding.
+
+The `iCloudStorageManager` extraction and Textual fork work remain out of scope;
+the detailed design notes below are retained for a later, separately scoped
+change.
+
 ## 1. Atomic deletion outbox
 
-**Status:** planned, not started. Raised by Codex on PR #124 against
-`RecordingWorkflowManager.swift:339`; declined there and left open on the thread.
+**Status:** implemented on the follow-up branch; full iOS test execution remains
+blocked by the existing Watch Widget build error described above. Raised by
+Codex on PR #124 against `RecordingWorkflowManager.swift:339`; declined there
+and left open on the thread.
 
 ### The defect
 
@@ -143,32 +171,27 @@ ordering is correct and must survive this refactor.
 
 ## 2. Reserve the CloudKit asset cache for the duration of a sync
 
-**Status:** partially fixed in v2.4 (`6f71e6ae`); a residual window remains.
+**Status:** implemented on the follow-up branch; the residual check-to-delete
+window is replaced by resource reservations and cooperative yield.
 
 `CacheMaintenanceSweep.pruneCloudKitAssetCache` now takes `isCloudSyncActive` and
-re-reads it immediately before every asset deletion, so a sync that starts
-mid-sweep protects the assets it has not copied out yet. That is the same shape
-as the `isDownloadInFlight` gate on the blob sweep.
+re-reads it immediately before every asset deletion. The follow-up now also gives
+`CloudSyncOperationCoordinator` a resource-scoped `beginCacheMaintenance()` /
+`endCacheMaintenance()` reservation: new CloudKit work waits and requests a
+cooperative yield, while the sweep holds the reservation through off-main deletion.
+`MLXSwiftDownloadManager` uses the same lifecycle for Hub downloads and explicit
+model deletion, including cancellation-safe queued startup.
 
-It is still a check, not a reservation. A sync that starts in the window between
-the check and `removeItem` is not seen. The blob sweep does not have this problem
-because `MLXSwiftDownloadManager.beginCacheMaintenance()` *reserves* the cache
-before the sweep leaves the main actor, so the download side can refuse to start.
-
-**The fix:** give `CloudSyncOperationCoordinator` the same pair —
-`beginCacheMaintenance()` / `endCacheMaintenance()`, refusing to hand out a
-maintenance reservation while an operation is running and refusing to start an
-operation while one is held. Then the sweep reserves once instead of polling.
-
-**Priority: low.** The residual window is microseconds, and the v2.4 restore-side
-fix (below) already means the consequence is one skipped audio file rather than a
-failed run. Worth doing when the coordinator is next touched, not on its own.
+The per-item activity checks remain as a defensive guard for existing direct cache
+access, but they are no longer the primary exclusion mechanism.
 
 ---
 
 ## 3. Retry audio that a restore could not copy
 
-**Status:** open question, verify before building.
+**Status:** verified on the follow-up branch. A failed copy leaves the existing
+local URL unchanged, and a later ordinary reconcile retries and installs the
+same cloud asset; no durable retry state was added.
 
 `performRestore` now counts `audioFilesFailedToRestore` and continues rather than
 throwing out of the whole run (`6f71e6ae`). Nothing explicitly schedules another
@@ -191,8 +214,9 @@ same spirit as `audioFilesPendingRetry` clearing the backup signature.
 
 ## 4. A recording larger than half the free disk still cannot stage
 
-**Status:** known limitation of the v2.4 staging budget (`876bd1f3`). Raised by
-Cursor's review of PR #124.
+**Status:** typed capacity deferral implemented on the follow-up branch. The
+per-run budget remains separate from measured free capacity, metadata continues
+to upload, and the user-facing shortage message is deduplicated.
 
 `CloudAudioAssetPolicy.stagingByteBudget` caps a run's staging at half of
 available capacity. The "first file of a run always stages, however large" rule

--- a/docs/v2.5-follow-up-agent-plan.md
+++ b/docs/v2.5-follow-up-agent-plan.md
@@ -1,0 +1,323 @@
+# v2.5 follow-up execution plan for AI agents
+
+## Objective and starting evidence
+
+Complete the correctness follow-ups described in [for-v2.5.md](for-v2.5.md),
+then report optional maintenance work separately. This plan can be executed by
+one agent or a lead with delegated workers. Writing this plan does not execute
+its implementation steps or authorize additional commits, pushes, or merges.
+
+Evidence snapshot: September 6, 2026, commit
+`2f7bd993294e6d24f41b61305f2dcc5e8f79cac5`, on
+`codex/v2.5-recording-restore-download-fixes`.
+[PR #125](https://github.com/bisonbet/BisonNotes-AI/pull/125) targets `v2.5` and
+contains the live callback, atomic audio installation, and download-generation
+fixes. Its final validation passed 508 app unit tests and the native macOS Debug
+build. This is historical evidence, not validation of future changes.
+
+Two corrections to the older follow-up document govern this plan:
+
+- Do not move `DeferredDeletionEffects.commit()` wholesale before a database
+  save. It publishes cloud intents **and deletes attachment folders**. Only
+  transactional outbox insertion moves before save; irreversible filesystem
+  cleanup remains after a successful save.
+- The Hub cache currently has no symmetric exclusion between maintenance and a
+  newly starting download. `startDownload()` deliberately permits startup during
+  a sweep. Both Hub and CloudKit cleanup need examination; polling activity is
+  not a reservation that lasts through deletion.
+
+## Execution rules
+
+1. Read current `AGENTS.md`, this plan, `docs/for-v2.5.md`, and
+   `docs/testing-regimen.md`. User instructions override these documents.
+2. Preserve unrelated work. Do not stash, reset, discard, force-push, or merge a
+   PR merely to make the starting tree convenient. Keep PR #125's behavior.
+3. Execute required phases 0–5 in order in single-agent mode. Phase 6 is optional
+   refactoring; phase 7 belongs to another repository. Do not automatically fold
+   either into the correctness work.
+4. Use injected transports, temporary files, isolated preferences, and temporary
+   persistent stores. Do not use customer recordings, a real CloudKit account,
+   production databases, real model downloads, or destructive cache sweeps as
+   ordinary regression fixtures.
+5. Inspect source and tests before changing behavior. References below identify
+   symbols and files; old line numbers and reference counts are not authoritative.
+6. Keep work reviewable by phase. Only commit/push/create PRs when the execution
+   request authorizes delivery. Use `codex/` feature branches and target `v2.5`
+   unless the user specifies otherwise. Never merge automatically.
+7. At every gate, report what actually ran. Compilation, unit tests, simulator
+   execution, signed-device tests, and two-device CloudKit tests are distinct.
+
+## Phase 0 — establish provenance and a baseline
+
+1. Record branch, HEAD, status, worktrees, remotes, and comparison base:
+
+   ```bash
+   git status --short
+   git branch --show-current
+   git rev-parse HEAD
+   git worktree list
+   git remote -v
+   git log -8 --oneline
+   ```
+
+2. Verify PR #125's current state and whether its fixes are in the intended base.
+   Account for a squash merge by checking behavior, not only ancestry. If it is
+   still unmerged, use a clearly identified stacked branch from its head or wait
+   for integration as directed by the user. Do not duplicate the fixes or silently
+   implement on an older `v2.5` checkout.
+3. Inventory the five UserDefaults queues, enqueue callers, queue consumers,
+   Core Data model/configurations, erase paths, and test seams. Inspect
+   `DeferredDeletionEffects`, `save(committing:)`, and `createSummary`.
+4. Inventory cache access: sync operations, direct restore entry points, download
+   start/cancel/unwind, explicit model deletion, startup cleanup, and maintenance.
+   Every participant that accesses a protected resource must be accounted for.
+5. Check Xcode/runtime availability with `xcodebuild -version` and
+   `xcrun simctl list devices available`. On Linux, report platform limits and
+   retain macOS validation as an uncompleted gate.
+6. Record baseline test/lint results or verified recent results for the exact
+   starting tree. Assign file ownership before delegation.
+
+**Exit gate:** a short inventory with exact provenance, protected behavior,
+available test infrastructure, and the chosen integration base. Resolve ambiguous
+ownership or incompatible user work before editing those files.
+
+## Phase 1 — prove whether failed restore audio already retries
+
+Primary files: `iCloudStorageManager.swift`,
+`BisonNotes AITests/ICloudSyncOrchestrationTests.swift`, and the existing fake
+CloudKit transport. All app paths below are under `BisonNotes AI/BisonNotes AI/`.
+
+1. Trace the complete routine path: `performReconcile` → `performBackup` →
+   `performRestore` → `recordingRecordsWithAudioAssets` → `shouldApplyCloudVersion`.
+   Include the matching-backup-signature path that returns a nil snapshot.
+2. Add a deterministic orchestration test with unchanged cloud timestamps and a
+   known audio payload. Fail the first copy by providing an unavailable asset or
+   a narrowly injected installer failure, then provide a readable asset next run.
+3. Verify the first pass commits metadata, increments `audioFilesFailedToRestore`,
+   and preserves any previously valid local audio and its URL. Verify the next
+   **routine reconcile**, not just a manual restore, installs the cloud audio.
+4. Cover a new metadata-only local row and an existing recording. Preserve UUIDs,
+   exclusion/tombstone rules, and absence of duplicate recordings. Include the
+   unchanged-signature case; a forced full scan must not mask a retry defect.
+5. If those tests pass, close the retry-mechanism question and retain the tests.
+   Do not build a queue merely because the older document suggested one.
+6. If they fail, identify the exact selection/scheduling condition. Implement the
+   smallest correction. If durable retry state is necessary, define its identity,
+   completion/removal, bounded retry policy, deletion/exclusion handling, and
+   interaction with metadata timestamps before adding it. Do not overwrite newer
+   metadata merely to retrieve audio or cause an unbounded retry loop.
+
+**Exit gate:** a passing test for failed-copy → later automatic reconcile, with
+the chosen outcome documented as “existing behavior verified” or “fixed.”
+
+## Phase 2 — make deletion and cloud-removal intent atomic
+
+Primary files: `Models/CoreDataManager.swift`,
+`Models/RecordingWorkflowManager.swift`, `iCloudStorageManager.swift`,
+`BisonNotes_AI.xcdatamodeld`, and persistence/backup regression tests.
+
+1. Write the transaction contract first: a successful local deletion and its
+   outbox intent commit together; a failed save commits neither; no attachment
+   deletion or cloud publication happens before that transaction succeeds.
+2. Design one versioned `PendingCloudMutation` entity in the **same persistent
+   store and save transaction** as the deleted content. Derive its fields from
+   all five real payload types; do not assume every target has the same shape.
+   Preserve kind, identity, relationship IDs, original `requestedAt`, and any
+   kind-specific payload. Define idempotent identity and earliest-claim merging.
+3. Add a new Core Data model version and test migration from the shipping model.
+   Preserve old model versions. Verify outbox rows are not uploaded as ordinary
+   content or swept by unrelated cleanup. A separate store would defeat atomicity.
+4. Introduce a small outbox persistence abstraction. Keep existing enqueue APIs
+   where possible, but make persistence failure observable to transaction owners.
+   Do not replace durable intents with an in-memory fallback after a failed write.
+5. Split deferred effects into transactional intent insertion and post-commit
+   filesystem effects. In `save(committing:)`, stage outbox rows, save once, then
+   perform filesystem effects. On failure, roll back both database changes.
+   Preserve `localOnly` paths: they must not publish cloud removals.
+6. Route superseded-summary cleanup in `createSummary` through that transaction
+   contract. Preserve supplemental-data migration and remove old attachment
+   folders only after deletion commits. Expose a suitable transaction API rather
+   than bypassing `CoreDataManager`'s private helper.
+7. Migrate these queues losslessly and idempotently:
+   - `iCloudPendingDeletionMarkersV1`
+   - `iCloudPendingLocalOnlyRemovalsV1`
+   - `iCloudPendingSummaryRemovalsV1`
+   - `iCloudPendingTranscriptRemovalsV1`
+   - `iCloudPendingImportedAudioRemovalsV1`
+
+   Insert and save before clearing a legacy key. A crash after the save but before
+   key removal must merge safely on restart. Failed or undecodable entries must
+   remain recoverable; do not interpret decode failure as an empty queue.
+8. Update `flushPendingiCloudMutations`, all queue accessors, and erase handling.
+   Remove only acknowledged mutations; partial cloud failures retain the rest.
+   Preserve in-flight/newer intents when acknowledging an older batch. Coordinate
+   migration and erase so legacy queues cannot repopulate after a completed erase.
+9. Add temporary SQLite-store tests, not only in-memory-context tests:
+   - save/reopen: row deletion and intent both survive;
+   - injected save failure: neither deletion nor intent persists;
+   - interruption immediately after database commit: the intent survives even
+     when post-commit filesystem work did not run;
+   - migration rerun after commit-before-key-clear is duplicate-safe;
+   - failed migration preserves legacy data;
+   - original deletion times and earliest claims survive migration/replay;
+   - partial acknowledgement retains failures and concurrent newer intent;
+   - local-only deletion and cloud erase preserve their existing local-data rules.
+
+**Exit gate:** transaction, migration, replay, and erase tests pass after reopening
+the persistent store. Never present a context rollback test alone as crash proof.
+
+## Phase 3 — reserve caches through destructive maintenance
+
+Primary files: `Services/CacheMaintenanceService.swift`,
+`Services/CloudSyncOperationCoordinator.swift`, `MLXSwiftEngine.swift`, and
+`CacheMaintenanceTests`, `MLXDownloadGenerationTests`, and orchestration tests.
+
+1. Specify mutual exclusion for each resource: maintenance may delete only while
+   it owns that resource; a sync/download may read or write only under its own
+   valid ownership. A Boolean sampled before a filesystem call is insufficient.
+2. Choose resource-scoped leases or another equivalent ownership primitive.
+   Keep sizing/enumeration outside exclusive deletion windows where practical.
+   Model repository leases separately from CloudKit cache leases. Define order
+   if any operation needs more than one lease; avoid deadlocks.
+3. Ensure the coordinator reserves before work starts and releases on success,
+   failure, and cancellation. Ensure maintenance holds its lease until the actual
+   off-main deletion finishes. Releasing after dispatch is too early.
+4. Preserve responsive user startup. If a removal is already in progress, expose
+   and bound the wait or yield maintenance; do not silently ignore Download/Sync
+   or block it behind a whole multi-gigabyte sweep. Do not block MainActor while
+   waiting on asynchronous work.
+5. Count cancelled tasks until the underlying operation actually stops. Generation
+   fencing protects state publication; it does not prove that a writer has stopped.
+   Preserve PR #125's cleanup and delayed-progress safeguards.
+6. Cover explicit model deletion and direct sync entry points discovered in phase
+   0. Document exclusions with evidence instead of assuming all callers funnel
+   through the same coordinator.
+7. Add barrier-controlled tests for operation-first and maintenance-first starts,
+   including a pause between admission and deletion. Also cover cancel/restart,
+   a cancelled task unwinding during an existing sweep, failure release, waiter
+   cancellation, repeated release, and eventual progress for queued user work.
+   Use fake deletion closures and temporary directories; avoid timing-only tests.
+
+**Exit gate:** no overlap between protected filesystem access and maintenance,
+no leaked reservation, and no lost or indefinitely blocked user request.
+
+## Phase 4 — handle audio that cannot fit in staging
+
+Primary files: `Services/CloudAudioAssetStaging.swift`,
+`iCloudStorageManager.swift`, `CloudAudioAssetPolicyTests.swift`, and sync tests.
+
+1. Separate the per-run staging budget from actual usable capacity. Preserve the
+   rule allowing the first recording to exceed the budget when it physically fits.
+2. Add a typed “insufficient space” decision when a reliable capacity measurement
+   says the copy cannot fit. Define behavior for nil, zero, negative, and stale
+   capacity; unknown capacity must not permanently strand audio.
+3. Keep metadata upload successful and audio pending. Avoid attempting a known
+   impossible copy. Capacity can change after preflight, so retain safe cleanup
+   and retry handling for a real `ENOSPC` during copying.
+4. Surface a useful, deduplicated status describing the shortage and what the user
+   can do. Do not emit a new notification or identical warning on every sync.
+5. Reevaluate on later user/reconcile triggers after capacity changes. Do not add
+   a busy retry loop. Verify no success signature falsely marks audio complete.
+6. Test above-budget-but-fits, cannot-fit, unknown-capacity, space-recovered, and
+   partial-copy-failure cases. Confirm metadata progress and staged-file cleanup.
+7. Keep separate metadata/audio completeness signatures as a follow-up unless
+   measurements show that repeated full metadata passes justify that extra state.
+
+**Exit gate:** impossible copies are explained and skipped safely, and audio
+uploads resume after space becomes available without metadata loss.
+
+## Phase 5 — integrate, validate, and report
+
+1. Freeze edits while builds/tests run. Verify new-file target membership and
+   inspect modified code for dead declarations, duplicate helpers, stale comments,
+   placeholder behavior, and secrets. Remove code only after call-site checks.
+2. Run the affected suites during each phase and the complete app unit target
+   after integration. Include the previously added live-transcription, restore
+   installer, and MLX generation regressions. For example, after verifying the
+   destination and package cache exist:
+
+   ```bash
+   task_dd=$(mktemp -d /private/tmp/bisonnotes-v25-followups.XXXXXX)
+   xcodebuild test \
+     -project 'BisonNotes AI/BisonNotes AI.xcodeproj' \
+     -scheme 'BisonNotes AI' \
+     -destination 'platform=iOS Simulator,name=iPad Pro 13-inch (M5)' \
+     -derivedDataPath "$task_dd" \
+     -clonedSourcePackagesDirPath /private/tmp/bisonnotes-test-derived/SourcePackages \
+     -disableAutomaticPackageResolution \
+     -only-testing:'BisonNotes AITests' \
+     -resultBundlePath "$task_dd/app-unit.xcresult"
+   ```
+
+   Use a unique result path for reruns. Reuse a verified package cache, not another
+   agent's active DerivedData/build database. Do not run Xcode builds concurrently.
+3. Build native macOS. Run the full pre-merge regimen from
+   `docs/testing-regimen.md` before merge, including relevant Watch and UI gates.
+   If those gates fail, identify exact failures and distinguish infrastructure,
+   existing issues, and regressions. Do not call a partial run fully green.
+4. Run `git diff --check` and focused/full SwiftLint with the committed config.
+   Report actual counts; do not regenerate the baseline to conceal violations.
+5. Record outstanding signed-device checks: migration from v2.4 with real local
+   data, two-device deletion/replay, failed-then-retried audio restore, cache
+   maintenance during a real download/sync, and low-storage recovery. Automated
+   fixtures do not replace these checks or authorize production testing.
+6. Update `docs/for-v2.5.md` with verified status and corrected design notes.
+   Mark an item complete only when its stated gate passed; retain hardware gaps.
+7. Deliver a concise report: exact branch/HEAD/base, phase status, modified files,
+   test counts/result paths, lint counts, limitations, and remaining work. If
+   delivery was authorized, use phase-sized commits with the Codex co-author
+   trailer, open PRs against the agreed base, and verify remote SHA and clean
+   status. Never claim an open PR is merged.
+
+## Phase 6 — optional incremental manager extraction
+
+After correctness changes settle, choose one boundary per change: restore,
+backup, or deletion preflight. Capture behavior with the existing test suites,
+extract dependencies explicitly, and preserve public behavior. Do not combine
+schema migration with a large structural rewrite. Build and test each extraction
+before the next one. This phase is not necessary to close a correctness defect.
+
+## Phase 7 — separate Textual repository follow-up
+
+Report the pinned `bisonbet/textual` revision and the Catalyst-only differences.
+Do not modify another checkout under authorization limited to BisonNotes-AI.
+When that repository is explicitly in scope, inspect its own instructions and
+branch state, rebase/remove obsolete guards there, then separately validate any
+dependency-pin update in this app on iOS and native macOS.
+
+## Optional multi-agent assignment
+
+Default: one agent executes the phases in order. For a group, use one lead and at
+most three workers. Delegate bounded subtasks within this execution; do not create
+new user-visible tasks unless requested. No model override is required.
+
+| Role | Exclusive ownership | When it may run |
+| --- | --- | --- |
+| Lead/integrator | `iCloudStorageManager.swift`, shared orchestration tests, project/model integration, docs, Git delivery, all builds | Throughout |
+| Persistence worker | Outbox implementation, Core Data model, `CoreDataManager`, `RecordingWorkflowManager`, dedicated outbox tests | After phase 1 and agreement on the transaction API |
+| Cache worker | Cache/coordinator services, MLX manager, dedicated reservation/generation tests | Read-only design during phase 1; implementation after interface/ownership agreement |
+| Validation reviewer | Read-only adversarial review; new fixture/test files only when explicitly assigned | Alongside implementation; tests run through the lead |
+
+The lead may delegate model-file ownership to the persistence worker, but must
+record that transfer first. Shared files always have one writer. Disk-capacity
+work starts after outbox/cache integration; manager refactoring starts last.
+With fewer workers, combine roles and execute sequentially.
+
+Each worker handoff must include: starting HEAD, exact files changed, behavioral
+contract, tests added/run with results, assumptions, integration instructions,
+and unresolved risks. A worker must not stage another worker's changes, run a
+competing build, or expand into a shared file without transferring ownership.
+
+## Copy-ready execution prompt
+
+> Execute required phases 0–5 of `docs/v2.5-follow-up-agent-plan.md`. Begin with
+> provenance and verify the PR #125 fixes are in the chosen base. Preserve all
+> unrelated work. Use a single agent or bounded delegated workers with the file
+> ownership and build rules in the plan. Prove automatic restore retry before
+> adding new retry state; make deletion/outbox persistence atomic without moving
+> attachment deletion before commit; add real cache exclusion; and handle
+> insufficient staging capacity. Keep optional extraction and the separate
+> Textual repository out of this implementation. Run the required validation,
+> update follow-up status only with evidence, and report remaining hardware gates.
+> Unless separately authorized in this task, leave changes uncommitted and
+> unpushed and do not merge any PR.


### PR DESCRIPTION
## Summary

- Add a durable Core Data `PendingCloudMutation` outbox with legacy migration and transactional deletion, clear-all, erase, and sync-toggle handling.
- Retry failed audio restoration through later ordinary reconciliation.
- Add cache/MLX resource leases, cooperative yielding, and cancellation-safe queues.
- Add typed insufficient-staging-capacity handling so metadata can proceed while audio remains pending.
- Add regression coverage and update the v2.5 execution documentation.

## Validation

- Native macOS Debug build: passed.
- `swiftc -parse` for modified Swift sources: passed.
- `git diff --check`: passed.
- SwiftLint: 2,044 baseline/environment violations reported; the committed baseline was not regenerated.
- iOS test-target build: blocked before XCTest execution by the existing Watch Widget `accessoryCorner` availability error under Xcode 26.6.
- Signed-app, physical-device, CloudKit two-device, low-storage, and real MLX download/sync validation remain pending.